### PR TITLE
[Docs]Fixed docker section steps number to correct numbers

### DIFF
--- a/quick-start.md
+++ b/quick-start.md
@@ -36,19 +36,19 @@ For Mac, [Docker Desktop](https://docs.docker.com/docker-for-mac/install/) is re
 curl -O https://raw.githubusercontent.com/appsmithorg/appsmith/master/deploy/install.sh
 ```
 
-    2. Make the script executable
+2. Make the script executable
 
 ```bash
 chmod +x install.sh
 ```
 
-    3. Run the script. **Make sure no other processes are running on ports 80 & 443**.
+3. Run the script. **Make sure no other processes are running on ports 80 & 443**.
 
 ```bash
 ./install.sh
 ```
 
-    4. Check if all the containers are running correctly.
+4. Check if all the containers are running correctly.
 
 ```bash
 docker ps


### PR DESCRIPTION
The steps mentioned in docker section shows step number as 1 for all steps mentioned in this section.
I have changed the number of the step to 1,2,3 and 4 .

Fixes appsmithorg/appsmith#904