### PR TITLE
Sort widgets alphabetically in widget-reference section

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -30,19 +30,19 @@
 
 ## Widget Reference
 
-* [Table](widget-reference/table.md)
-* [Form](widget-reference/form.md)
-* [Input](widget-reference/input.md)
-* [Dropdown](widget-reference/dropdown.md)
-* [Datepicker](widget-reference/datepicker.md)
-* [Filepicker](widget-reference/filepicker.md)
-* [Radio](widget-reference/radio.md)
-* [Checkbox](widget-reference/checkbox.md)
 * [Button](widget-reference/button.md)
 * [Chart](widget-reference/chart.md)
-* [Text](widget-reference/text.md)
-* [Image](widget-reference/image.md)
+* [Checkbox](widget-reference/checkbox.md)
 * [Container](widget-reference/container.md)
+* [Datepicker](widget-reference/datepicker.md)
+* [Dropdown](widget-reference/dropdown.md)
+* [Filepicker](widget-reference/filepicker.md)
+* [Form](widget-reference/form.md)
+* [Image](widget-reference/image.md)
+* [Input](widget-reference/input.md)
+* [Radio](widget-reference/radio.md)
+* [Table](widget-reference/table.md)
+* [Text](widget-reference/text.md)
 * [Video](widget-reference/video.md)
 
 ## Function Reference


### PR DESCRIPTION
Fixes [#939](https://github.com/appsmithorg/appsmith/issues/939) by @Nikhil-Nandagopal 

This pr fixes the order of widgets in the widget reference section in SUMMARY.md and arranges them alphabetically.

![Screenshot from 2020-10-09 21-56-49](https://user-images.githubusercontent.com/58393531/95608245-7b8c1d00-0a7a-11eb-9cec-3d520b33ece7.png)
