### PR TITLE
Added APPSMITH_OAUTH2_ALLOWED_DOMAINS parameter to Google OAuth login page

### DIFF
--- a/third-party-services/google-login.md
+++ b/third-party-services/google-login.md
@@ -36,8 +36,13 @@ To enable Google Sign in, login to your [google cloud console](https://console.c
 # ******** Google OAuth ********
 APPSMITH_OAUTH2_GOOGLE_CLIENT_ID=YOUR_CLIENT_ID
 APPSMITH_OAUTH2_GOOGLE_CLIENT_SECRET=YOUR_CLIENT_SECRET
+APPSMITH_OAUTH2_ALLOWED_DOMAINS=YOUR_DOMAIN_NAME
 # ******************************
 ```
+
+* replace `YOUR_CLIENT_ID` and `YOUR_CLIENT_SECRET` with the client ID and client secret generated in the step above
+* replace `YOUR_DOMAIN_NAME` with a second-level domain name **`(ex: abc.com)`**, to only allow users with an email address from that domain name to log in **`(ex: john@abc.com)`**
+    * **Note**: you can provide several domain names using a comma-separated list
 
 **6. Restart docker & nginx**
 


### PR DESCRIPTION
Added APPSMITH_OAUTH2_ALLOWED_DOMAINS parameter to the docker.env section of the Google OAuth login page. Fixes appsmithorg/appsmith#1148