### PR TITLE
Changed cases for Appsmith and fixed typo

### DIFF
--- a/core-concepts/apis/running-apis-on-page-load.md
+++ b/core-concepts/apis/running-apis-on-page-load.md
@@ -6,7 +6,7 @@ description: >-
 
 # Running APIs on Page Load
 
-If we connect an API response to a widget, appsmith automatically runs that API on page load without any additional configuration being required.
+If we connect an API response to a widget, Appsmith automatically runs that API on page load without any additional configuration being required.
 
 To fetch a list of users to be displayed in a table, we only need to connect the getUsers API data to the Table widget 
 

--- a/core-concepts/connecting-to-databases/README.md
+++ b/core-concepts/connecting-to-databases/README.md
@@ -8,7 +8,7 @@ description: >-
 
 ## Database Connections
 
-Connections to databases can be created in the datasource pane. Contact your database admin for the connection credentials and configure them in the data source section. If you are hosting appsmith, you must whitelist the ip address of the appsmith deployment
+Connections to databases can be created in the datasource pane. Contact your database admin for the connection credentials and configure them in the data source section. If you are hosting Appsmith, you must whitelist the ip address of the Appsmith deployment
 
 {% hint style="success" %}Whitelist 18.223.74.85 to connect to your database from our cloud hosted version. A step-by-step guide to do this on AWS is available [here](aws-whitelist.md) {% endhint %}
 

--- a/core-concepts/connecting-ui-and-logic/working-with-js-libraries.md
+++ b/core-concepts/connecting-ui-and-logic/working-with-js-libraries.md
@@ -17,7 +17,7 @@ The following JS libraries are supported in the Appsmith platform.
 
 ## Using JS libraries
 
-The utility functions provided by the included libraies can be used when transforming data.
+The utility functions provided by the included libraries can be used when transforming data.
 
 ### Example: lodash
 

--- a/enabling-3p-services.md
+++ b/enabling-3p-services.md
@@ -12,7 +12,7 @@ All third party services are enabled by default in our [cloud hosted](https://ap
 
 ## Enabling Services for Self Hosting
 
-Our self-hosted version allows you to configure your own keys to enable third party services such as Google OAuth. To enable a service, simply open the folder of your appsmith installation and edit the **docker.env** file.
+Our self-hosted version allows you to configure your own keys to enable third party services such as Google OAuth. To enable a service, simply open the folder of your Appsmith installation and edit the **docker.env** file.
 
 You may need root access to modify the docker.env file.
 

--- a/function-reference/navigateto.md
+++ b/function-reference/navigateto.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  With navigateTo, we can navigate in between the internal pages of appsmith. It
+  With navigateTo, we can navigate in between the internal pages of Appsmith. It
   could be triggered on any widget action like Button onClick, Dropdown
   onOptionChange etc. Create a new Page with a valid
 ---

--- a/quick-start.md
+++ b/quick-start.md
@@ -4,21 +4,21 @@ description: Appsmith stands for speed and getting started with Appsmith is just
 
 # Getting started
 
-You can begin using appsmith via our cloud instance or by deploying appsmith yourself
+You can begin using Appsmith via our cloud instance or by deploying Appsmith yourself
 
 * [Using Appsmith Cloud](quick-start.md#appsmith-cloud) **\(recommended\):** Create a new application with just one click
 * [Using Docker](quick-start.md#docker): Deploy anywhere using docker
 
 ## Appsmith Cloud
 
-The fastest way to get started with appsmith is using our cloud-hosted version. It's as easy as
+The fastest way to get started with Appsmith is using our cloud-hosted version. It's as easy as
 
 1. [Create an Account](https://app.appsmith.com/user/signup)
 2. [Start Building](core-concepts/building-the-ui/)
 
 ## Docker
 
-Appsmith can be deployed locally or on your private instance using docker. To simplify installation, appsmith comes with an installation script that will download all of the necessary dependencies and help you configure Appsmith.
+Appsmith can be deployed locally or on your private instance using docker. To simplify installation, Appsmith comes with an installation script that will download all of the necessary dependencies and help you configure Appsmith.
 
 **Supported Operating Systems**
 
@@ -29,7 +29,7 @@ Appsmith can be deployed locally or on your private instance using docker. To si
 For Mac, [Docker Desktop](https://docs.docker.com/docker-for-mac/install/) is required. For other operating systems, Docker will be installed automatically by the script.
 {% endhint %}
 
-1. Fetch the **install.sh** script on the system you want to deploy appsmith
+1. Fetch the **install.sh** script on the system you want to deploy Appsmith
 
 ```bash
 # Downloads install.sh

--- a/third-party-services/email/README.md
+++ b/third-party-services/email/README.md
@@ -1,20 +1,20 @@
 ---
 description: >-
   Configure an email provider of your choice to send and receive email
-  notifications in appsmith
+  notifications in Appsmith
 ---
 
 # Email
 
-Email is used to communicate with users on your installation of appsmith. Emails are sent out to
+Email is used to communicate with users on your installation of Appsmith. Emails are sent out to
 
 * Verify new user signups
-* Invite users to your organisation in appsmith
+* Invite users to your organisation in Appsmith
 * Notify admins of important events & approvals requests
 
 ## Enabling Email
 
-1. To enable email, open the docker.env file of your appsmith installation and uncomment the following block
+1. To enable email, open the docker.env file of your Appsmith installation and uncomment the following block
 
 ```text
 # ***** Email **********

--- a/third-party-services/email/amazon-ses.md
+++ b/third-party-services/email/amazon-ses.md
@@ -1,5 +1,5 @@
 ---
-description: Configure Amazon SES to invite users to your appsmith installation
+description: Configure Amazon SES to invite users to your Appsmith installation
 ---
 
 # Amazon SES
@@ -22,11 +22,11 @@ To configure Amazon SES as your SMTP server, [create an account](https://aws.ama
 
 ![Click to expand](../../.gitbook/assets/aws-smtp-creds.png)
 
-**5. Verify the email address via which appsmith should send and receive emails**
+**5. Verify the email address via which Appsmith should send and receive emails**
 
 ![](../../.gitbook/assets/aws-verify-email.png)
 
-**6. Update the docker.env file in your appsmith deployment folder**
+**6. Update the docker.env file in your Appsmith deployment folder**
 
 {% hint style="danger" %}
 Do not use **port** **465** listed on the SES page because it is TLS enabled by default

--- a/third-party-services/email/sendgrid.md
+++ b/third-party-services/email/sendgrid.md
@@ -1,5 +1,5 @@
 ---
-description: Configure Sendgrid to invite users to your appsmith installation
+description: Configure Sendgrid to invite users to your Appsmith installation
 ---
 
 # Sendgrid
@@ -26,7 +26,7 @@ To configure Sendgrid as your SMTP server, [create an account](https://signup.se
 
 ![Click to expand](../../.gitbook/assets/sendgrid-create-sender.png)
 
-**6. Update the docker.env file in your appsmith deployment folder**
+**6. Update the docker.env file in your Appsmith deployment folder**
 
 ```text
 # ***** Email **********

--- a/third-party-services/github-login.md
+++ b/third-party-services/github-login.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Configure Github OAuth to enable Login via Github for the appsmith
+  Configure Github OAuth to enable Login via Github for the Appsmith
   installation
 ---
 
@@ -25,13 +25,13 @@ To enable Github Sign in, login to your [Github Account](https://github.com)
 
 **4. Configure the OAuth Credentials for a web application**
 
-**Homepage URL:** The domain on which you are hosting appsmith with https **`(ex: https://app.appsmith.com)`**
+**Homepage URL:** The domain on which you are hosting Appsmith with https **`(ex: https://app.appsmith.com)`**
 
 **Authorization Callback URL:** Append **/login/oauth2/code/github** to the Homepage URL **`(ex: https://app.appsmith.com/login/oauth2/code/github)`**
 
 ![Click to expand](../.gitbook/assets/github-app-config.png)
 
-**5. Update the docker.env file in your appsmith deployment folder**
+**5. Update the docker.env file in your Appsmith deployment folder**
 
 ```text
 # ********* Github OAUth **********
@@ -46,5 +46,5 @@ APPSMITH_OAUTH2_GITHUB_CLIENT_SECRET=YOUR_GITHUB_CLIENT_SECRET                  
 sudo docker-compose rm -fsv appsmith-internal-server nginx && sudo docker-compose up -d 
 ```
 
-Github Login should now be enabled for your appsmith installation
+Github Login should now be enabled for your Appsmith installation
 

--- a/third-party-services/google-login.md
+++ b/third-party-services/google-login.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Configure Google OAuth to enable login via Google for the appsmith
+  Configure Google OAuth to enable login via Google for the Appsmith
   installation
 ---
 
@@ -14,7 +14,7 @@ To enable Google Sign in, login to your [google cloud console](https://console.c
 
 ![Click to expand](../.gitbook/assets/google-oauth-consent-1.png)
 
-**2. Configure the consent screen with the domain on which you want to host appsmith**
+**2. Configure the consent screen with the domain on which you want to host Appsmith**
 
 ![Click to expand](../.gitbook/assets/google-oauth-consent.png)
 
@@ -24,13 +24,13 @@ To enable Google Sign in, login to your [google cloud console](https://console.c
 
 **4. Configure the OAuth Credentials for a web application**
 
-**Javascript Origins:** The domain on which you are hosting appsmith with https **`(ex: https://app.appsmith.com)`**
+**Javascript Origins:** The domain on which you are hosting Appsmith with https **`(ex: https://app.appsmith.com)`**
 
 **Redirect URIs:** Append **/login/oauth2/code/google** to your Javascript origins **`(ex: https://app.appsmith.com/login/oauth2/code/google)`**
 
 ![Click to expand](../.gitbook/assets/google-oauth-creds-2.png)
 
-**5. Update the docker.env file in your appsmith deployment folder**
+**5. Update the docker.env file in your Appsmith deployment folder**
 
 ```text
 # ******** Google OAuth ********
@@ -50,5 +50,5 @@ APPSMITH_OAUTH2_ALLOWED_DOMAINS=YOUR_DOMAIN_NAME
 sudo docker-compose rm -fsv appsmith-internal-server nginx && sudo docker-compose up -d 
 ```
 
-Google Login should now be enabled for your appsmith installation
+Google Login should now be enabled for your Appsmith installation
 

--- a/third-party-services/google-maps.md
+++ b/third-party-services/google-maps.md
@@ -29,7 +29,7 @@ To enable the maps widget, login to your [google cloud console](https://console.
 
 ![Click to expand](../.gitbook/assets/maps-apis.png)
 
-**5. Update the docker.env file in your appsmith deployment folder**
+**5. Update the docker.env file in your Appsmith deployment folder**
 
 ```text
 # ******** Google Maps ***********


### PR DESCRIPTION
Changed cases for references of "Appsmith" in documentation pages. Also fixed typo in JS libraries documentation page.

Fixes appsmithorg/appsmith#1321