### PR TITLE
fix formatting for amazon s3 doc - add space before enumeration and images.

### DIFF
--- a/datasource-reference/querying-amazon-s3.md
+++ b/datasource-reference/querying-amazon-s3.md
@@ -1,19 +1,23 @@
 # Querying Amazon S3 [Coming Soon]
 The Amazon S3 plugin can connect to an Amazon S3 instance and execute a set of [actions](#supported-actions) 
 supported by Appsmith. In order to do so, you need to
+
 1. Create an Amazon S3 datasource to connect to your Amazon S3 instance.
 2. Create a query on the Amazon S3 datasource.
 
 ## Create an Amazon S3 datasource
 In order to connect to an Amazon S3 instance, you need to fill out the following datasource configuration form:
+
 ![Click to expand](../.gitbook/assets/amazon_s3_create_datasource.png)
 
 There are three mandatory fields that are required to be filled: 
+
 1. Amazon Access Key
 2. Amazon Secret Key
 3. Region
 
 All the above three details can be fetched from your Amazon account:
+
 1. [How to get Amazon access key ?](https://Amazon.amazon.com/premiumsupport/knowledge-center/create-access-key/)
 2. [How to get Amazon secret key ?](https://Amazon.amazon.com/blogs/security/wheres-my-secret-access-key/#:~:text=Secret%20access%20keys%20are%E2%80%94as,key%20after%20its%20initial%20creation.)
 3. [Amazon S3 regions/endpoints](https://docs.Amazon.amazon.com/general/latest/gr/rande.html)
@@ -21,12 +25,14 @@ All the above three details can be fetched from your Amazon account:
 ## Query Form and Supported Actions
 In order to execute an action on an Amazon S3 instance, you need to create a query on an [Amazon S3 datasource](#create-an-s3-datasource). 
 Query form has four fields:
+
 1. **Action** - action that you want to execute
 2. **Bucket Name** - bucket name on which to run the action. 
 3. **File Path** - file path in case the action is to create a file or read a file.
 4. **Content**  - file content in case the action is to create a file.
 
 Appsmith supports the following actions on any Amazon S3 instance:
+
 1. List all files in a bucket.
 2. Create a new file.
 3. Upload file.   
@@ -37,6 +43,7 @@ Appsmith supports the following actions on any Amazon S3 instance:
 ### List all files in a bucket
 1. Set the 'Action' field to 'List all files in a bucket'
 2. Set the 'Bucket Name' field to the name of the bucket whose files you want to list.
+
 ![Click to expand](../.gitbook/assets/amazon_s3_list_query.png)
 
 ### Create a new file
@@ -44,6 +51,7 @@ Appsmith supports the following actions on any Amazon S3 instance:
 2. Set the 'Bucket Name' field to the name of the bucket where you want to add the new file.
 3. Set the 'File Path' field to the path of the new file relative to the bucket.
 4. Set the 'Content' field to the content that you want to write into the file.
+
 ![Click to expand](../.gitbook/assets/amazon_s3_create_query.png)
    
 ### Upload file
@@ -54,12 +62,14 @@ Appsmith supports the following actions on any Amazon S3 instance:
    context.
 5. Use [mustache expression](#taking-inputs-from-widgets) inside the 'Content' field to get the contents of the file 
    uploaded via the [Filepicker widget](https://docs.appsmith.com/widget-reference/filepicker)
+   
 ![Click to expand](../.gitbook/assets/amazon_s3_upload_query_using_filepicker.png) 
    
 ### Read file
 1. Set the 'Action' field to 'Read file'.
 2. Set the 'Bucket Name' field to the name of the bucket where the file is located.
 3. Set the 'File Path' field to the path of the file relative to the bucket name.
+
 ![Click to expand](../.gitbook/assets/amazon_s3_read_query.png)
    
 ### Download file
@@ -69,12 +79,14 @@ Appsmith supports the following actions on any Amazon S3 instance:
 4. Create a [Button widget](https://docs.appsmith.com/widget-reference/button) and configure its property pane as follows:
    - Set 'onClick' action to [Download](https://docs.appsmith.com/framework-reference/download)
    - Set 'Data to download' to use data from your desired query using [mustache syntax](#displaying-query-data)
+   
 ![Click to expand](../.gitbook/assets/amazon_s3_download_using_button.png)
 
 ### Delete file
 1. Set the 'Action' field to 'Delete file'.
 2. Set the 'Bucket Name' field to the name of the bucket where the file is located.
 3. Set the 'File Path' field to the path of the file relative to the bucket name.
+
 ![Click to expand](../.gitbook/assets/amazon_s3_delete_query.png)
 
 ## Taking Inputs from Widgets


### PR DESCRIPTION
1. Amazon s3 documentation page is not able to parse enumeration and images are not expanding on click. Adding space before enumerations and images to see if it helps.