### PR TITLE
Fix outdated link in Ports Unavailable section

### DIFF
--- a/troubleshooting-guide/deployment-errors.md
+++ b/troubleshooting-guide/deployment-errors.md
@@ -6,7 +6,7 @@
 
 If you encounter the error that port 80 & 443 are not open, we recommend that you kill all processes on these ports and start again. If the processes on these ports cannot be stopped, you can run appsmith on another port.
 
-1. Comment out the line: [https://github.com/appsmithorg/appsmith/blob/master/deploy/install.sh\#L469](https://github.com/appsmithorg/appsmith/blob/master/deploy/install.sh#L469) from the install.sh script and run it. This will ensure that the script does not check for port availability of **80/443**.
+1. Comment out the line: [https://github.com/appsmithorg/appsmith/blob/0051c3f78fe8a22a48afd17d0785cda0dbe855eb/deploy/install.sh#L475](https://github.com/appsmithorg/appsmith/blob/0051c3f78fe8a22a48afd17d0785cda0dbe855eb/deploy/install.sh#L475) from the install.sh script and run it. This will ensure that the script does not check for port availability of **80/443**.
 2. Once the docker-compose file is installed, the script will try to start the containers and fail because of port conflicts.
 3. In the file `docker-compose.yml` , change the ports for the Nginx container to a custom port
 4. Run `docker-compose up -d`


### PR DESCRIPTION
Edited the docs to point to an updated line number.
Also, Instead of linking to a line number, replaced it with a canonical URL.

Fixes #123 