### PR TITLE
Updating mongorestore command to fix mongodump-mongorestore flow for migrating appsmith instance

### DIFF
--- a/how-to-guides/backup-restore.md
+++ b/how-to-guides/backup-restore.md
@@ -13,10 +13,13 @@ On Appsmith, you can migrate all Appsmith data from one instance to another or j
 3. Open the file `encryption.env` and note the values in this file. The values here are important for Appsmith to be able to read sensitive information in the new installation.
 
 ## **Restore the backup on the new VM:** 
+{% hint style="warning" %}
+The restore would end up deleting all the existing data in the mongo database of the newly installed appsmith instance
+{% endhint %}
 
 1. Install Appsmith via the install.sh script. 
 
-2. Restore the dump on the newly created mongo container via the command: `mongorestore /tmp/appsmith-mongo-dump -d appsmith --uri=mongodb://<rootUsername>:<rootPassword>@localhost/appsmith` 
+2. Restore the dump on the newly created mongo container via the command: `mongorestore --drop /tmp/appsmith-mongo-dump -d appsmith --uri=mongodb://<rootUsername>:<rootPassword>@localhost/appsmith` 
 
 3. Open the file `encryption.env` and change the variables `APPSMITH_ENCRYPTION_PASSWORD` & `APPSMITH_ENCRYPTION_SALT` to the same ones as the old VM. This is important because sensitive data in Mongo is encrypted using these credentials. Without this, you risk corrupting any passwords you've saved. 
 


### PR DESCRIPTION
Adding --drop argument to mongorestore to ensure that existing collections created when the server comes up for the first time are dropped and only then does a collection get restored. This is important for data sanity of the restored dump

Fixes : [https://github.com/appsmithorg/appsmith/issues/5643](https://github.com/appsmithorg/appsmith/issues/5643)