### PR TITLE
docs: Fixed the properties list

### DIFF
--- a/widget-reference/filepicker.md
+++ b/widget-reference/filepicker.md
@@ -36,7 +36,7 @@ See our guides on
 | **Allowed File Types** | Enables you to set constraints on the type of file a user can upload. Accepts an _array_ of wildcards`image/*`, exact mime types `image/jpeg`, or file extensions `.jpg`:`['image/*', '.jpg', '.jpeg', '.png', '.gif']` |
 | **Required** | When turned on, it makes a user input required and disables any form submission until an input is made. |
 | **Visible** | Controls widget's visibility on the page. When turned off, the widget will not be visible when the app is published |
+
 | Action | Description |
 | :--- | :--- |
 | **onFilesSelected** | Sets the action to be run when the user selects files to be uploaded. See a list of [supported actions](../core-concepts/writing-code/appsmith-framework.md). You can immediately call an API or the S3 plugin to upload the base64 of the file to your cloud storage |
-


### PR DESCRIPTION
Forgot the line break which displayed the markdown instead of the intended appearence.