### PR TITLE
docs: Add list of invalid names for queries and widgets

### DIFF
--- a/core-concepts/connecting-to-data-sources/querying-a-database/README.md
+++ b/core-concepts/connecting-to-data-sources/querying-a-database/README.md
@@ -31,6 +31,10 @@ A query and its results can be accessed from only the page that it is a part of.
 
 A query must have a unique name that acts as an identifier. It is used to access the query results. In that sense, a name is like a variable in a programming language. You can access the various properties of the query and it's data using the query name.
 
+{% hint style="warning" %}
+Note that [JavaScript keywords](https://www.w3schools.com/js/js_reserved.asp) and [the window object methods and properties](https://www.w3schools.com/jsref/obj_window.asp) are not valid as query names.
+{% endhint %}
+
 ### **Running a Query**
 
 Click on the Run button or hit `cmd + enter` to execute a query. If the query execution succeeds, a success message will pop up on the screen in the top right corner along with the results below the query.

--- a/core-concepts/displaying-data-read/README.md
+++ b/core-concepts/displaying-data-read/README.md
@@ -32,7 +32,13 @@ Widgets can be dragged from the widget pane, positioned on the canvas, and resiz
 
 ### Naming a Widget
 
-A widget must have a unique name that acts as an identifier on the page. It is used to access the properties of the widget everywhere in the application. In that sense, a name is like a variable in a programming language. You can access the various properties of the widget using the widget's name.
+A widget must have a unique name that acts as an identifier on the page. It is used to access the properties of the widget everywhere in the application. In that sense, a name is like a variable in a programming language. 
+
+{% hint style="warning" %}
+Note that [JavaScript keywords](https://www.w3schools.com/js/js_reserved.asp) and [the window object methods and properties](https://www.w3schools.com/jsref/obj_window.asp) are not valid as widget names.
+{% endhint %}
+
+You can access the various properties of the widget using the widget's name.
 
 ```javascript
 {{ Table1.selectedRow.id }}

--- a/troubleshooting-guide/application-errors.md
+++ b/troubleshooting-guide/application-errors.md
@@ -20,7 +20,7 @@ Entity name: <name> is already being used
 
 This error indicates that the name being assigned to the entity has been used before.
 
-This error can be fixed by assigning a new unique name to the entity.
+This error can be fixed by assigning a new unique name to the entity. [JavaScript keywords](https://www.w3schools.com/js/js_reserved.asp) and [the window object methods and properties](https://www.w3schools.com/jsref/obj_window.asp) are not valid as entity names.
 
 ## Login / Signup Errors
 


### PR DESCRIPTION
Using [JavaScript keywords](https://www.w3schools.com/js/js_reserved.asp) and [the window object methods and properties](https://www.w3schools.com/jsref/obj_window.asp) as entity names can lead to bugs on Appsmith. 
These names aren't valid as entity names.