### PR TITLE
chore: Renames actions to events on relevant doc pages

### DIFF
--- a/core-concepts/building-the-ui/README.md
+++ b/core-concepts/building-the-ui/README.md
@@ -37,7 +37,7 @@ Widget names are important while adding logic, so name your widgets well!
 
 ## Editing widget properties
 
-Widget properties can be edited via the property pane which is opened using top-right icon \(Edit Widget Properties\). Widget properties can affect the widget data, styling and actions.
+Widget properties can be edited via the property pane which is opened using top-right icon \(Edit Widget Properties\). Widget properties can affect the widget data, styling and events.
 
 ![](../../.gitbook/assets/input-property-pane.png)
 

--- a/core-concepts/building-the-ui/calling-apis-from-widgets.md
+++ b/core-concepts/building-the-ui/calling-apis-from-widgets.md
@@ -6,9 +6,9 @@ description: >-
 
 # Triggering APIs / Queries from Widgets
 
-## Configuring the action
+## Configuring the Event
 
-The property pane has an action section where all the interactions that a user can perform with a widget are listed. We can configure the action to be taken when the interaction takes place in this section.
+The property pane has an Events section where all the interactions that a user can perform with a widget are listed. We can configure an action to be taken when the interaction takes place in this section.
 
 To configure the API / Query we want to call when a button is clicked, we can select the action in the onClick dropdown.
 
@@ -16,7 +16,7 @@ To configure the API / Query we want to call when a button is clicked, we can se
 
 ## Handling Success / Error
 
-The action section also allows us to configure the action to take once an API  / Query returns with a success or an error. Success / Error is determined by the HTTP status code or the query response status returned by the API  / Query. We can decide to display a success or an error message by using the **Show Alert action**.
+The events section also allows us to configure the action to take once an API  / Query returns with a success or an error. Success / Error is determined by the HTTP status code or the query response status returned by the API  / Query. We can decide to display a success or an error message by using the **Show Alert action**.
 
 ![](../../.gitbook/assets/success.gif)
 

--- a/core-concepts/capturing-data-write/README.md
+++ b/core-concepts/capturing-data-write/README.md
@@ -41,7 +41,7 @@ In the examples above, **`text`** is the internal property of the **`nameInput`*
 
 Since write operations are more expensive, the Query should be triggered once all the user data is captured. To do this, we can make use of a [Button](../../widget-reference/button/) widget and configure the Query to run in the onClick of the button.
 
-The property pane has an action section where all the interactions that a user can perform with a widget are listed. We can configure the action to be taken when the interaction takes place in this section.
+The property pane has an events section where all the interactions that a user can perform with a widget are listed. We can configure an action to be taken when the interaction takes place in this section.
 
 To configure the Query we want to call when a button is clicked, we can select the action in the onClick dropdown.
 

--- a/core-concepts/connecting-ui-and-logic/sharing-data-across-pages.md
+++ b/core-concepts/connecting-ui-and-logic/sharing-data-across-pages.md
@@ -8,7 +8,7 @@ description: >-
 
 ## Sharing data via query params
 
-Query params can be passed by adding the query params object to [NavigateTo action](../../function-reference/navigateto.md). To do this click on the JS mode for Action and update it as follows.
+Query params can be passed by adding the query params object to [NavigateTo action](../../function-reference/navigateto.md). To do this click on the JS mode for the Event and update it as follows.
 
 ```text
 {{navigateTo("PageName", {"param": "value"})}}

--- a/core-concepts/displaying-data-read/README.md
+++ b/core-concepts/displaying-data-read/README.md
@@ -26,7 +26,7 @@ Appsmith has a collection of widgets that can be used to build the UI.
 * [Text](../../widget-reference/text.md)
 * [Video](../../widget-reference/video.md)
 
-Widgets can be dragged from the widget pane, positioned on the canvas, and resized to fit the data they need to display. They also come with properties that can be visually edited to set their data, change their styles, and trigger actions from them.
+Widgets can be dragged from the widget pane, positioned on the canvas, and resized to fit the data they need to display. They also come with properties that can be visually edited to set their data, change their styles, and trigger actions when an event occurs i.e when clicked.
 
 ![](../../.gitbook/assets/drop-widget.gif)
 

--- a/framework-reference/navigateto.md
+++ b/framework-reference/navigateto.md
@@ -1,7 +1,7 @@
 ---
 description: >-
   With navigateTo, we can navigate in between the internal pages of Appsmith. It
-  could be triggered on any widget action like Button onClick, Dropdown
+  could be triggered on any widget event like Button onClick, Dropdown
   onOptionChange etc. Create a new Page with a valid
 ---
 

--- a/function-reference/navigateto.md
+++ b/function-reference/navigateto.md
@@ -1,7 +1,7 @@
 ---
 description: >-
   With navigateTo, we can navigate in between the internal pages of Appsmith. It
-  could be triggered on any widget action like Button onClick, Dropdown
+  could be triggered on any widget event like Button onClick, Dropdown
   onOptionChange etc. Create a new Page with a valid
 ---
 

--- a/getting-started/setting-up/aws-ami.md
+++ b/getting-started/setting-up/aws-ami.md
@@ -141,7 +141,7 @@ IMPORTANT: The application password is only available in the system log for the 
 
 * Go to your EC2 instances dashboard on AWS
 * Select the instance
-* From the “Actions” drop-down menu, select the “Get System Log” menu item.
+* From the “Events” drop-down menu, select the “Get System Log” menu item.
 
 ![Select System Log](../../.gitbook/assets/aws-select-system-log.png)
 

--- a/getting-started/tutorial-1/part-2-using-forms/submitting-the-form.md
+++ b/getting-started/tutorial-1/part-2-using-forms/submitting-the-form.md
@@ -32,12 +32,12 @@ The only difference is that you’re using the mustache template to write JavaSc
 
 What you did here is that you accessed the widgets' state in your query. This is the inverse of what you did in part 1 where you accessed **ProductsQuery**'s results in the **Products\_Table** widget. To reiterate, widgets, APIs, and DB Queries belonging to the same parent page can access each other's state/data by calling the appropriate method on their respective names.
 
-## Triggering action on UI events
+## Triggering actions on UI events
 
 Your query **AddProductQuery** is now set up to insert dynamic user input from the form. Let's bind the Submit button of the form to invoke **AddProductQuery**:
 
 1. Open the properties of **SubmitButton**
-2. Go to **Action → onClick**
+2. Go to **Events → onClick**
 3. Choose **Execute DB Query → AddProductQuery**
 
 Try creating a new product using the form. You’ll notice that you don't have a way to tell whether the product got added after submitting, or not. It's because you haven't set up a success or an error message. Let's do that:
@@ -88,7 +88,7 @@ You've created a new page **AddProductPage** with a form that allows users to ad
 2. Drag-drop the [button widget ](https://docs.appsmith.com/widget-reference/button)at the bottom right of the table
 3. Rename widget to **AddProductButton**
 4. Change button label to **Add New Product**
-5. Go to **Action → onClick → Navigate To** 
+5. Go to **Events → onClick → Navigate To** 
 6. Type **AddProductPage** in **Page Name** field
 
 Your **ProductListPage** now looks like: 

--- a/getting-started/tutorial-1/part-3-creating-interactive-views/adding-edit-button.md
+++ b/getting-started/tutorial-1/part-3-creating-interactive-views/adding-edit-button.md
@@ -3,14 +3,14 @@
 You've built a page to view all products, and another page to add a new product. We now move on to the third functionality of enabling a user to edit a product. Let's add an **Edit** button in each row of the table. On clicking the **Edit** button, a form modal will open which will allow users to edit the product in the corresponding row.
 
 1. Open **Products\_Table**’s properties
-2. Click on **New** **Button** under **Actions → Row Button**
+2. Click on **New** **Button** under **Events → Row Button**
 3. Rename the button to **Edit**
 
 You'll see an Edit button in the last column of each row. A Row Button adds a button action for each row. Let's configure the Edit button.
 
 1. Open **Products\_Table**’s properties
-2. Go to **Actions → Row Button → Edit**
-3. Choose the action **Open Modal** from the **Actions** dropdown
+2. Go to **Events → Row Button → Edit**
+3. Choose the action **Open Modal** from the **Events** dropdown
 4. Choose **New Modal**
 5. Rename the new modal to **EditProductModal** using its properties 
 6. Choose **Modal Type** as **Form Modal**

--- a/getting-started/tutorial-1/part-3-creating-interactive-views/running-multiple-actions-on-submit.md
+++ b/getting-started/tutorial-1/part-3-creating-interactive-views/running-multiple-actions-on-submit.md
@@ -4,7 +4,7 @@ The API to update a product is ready. In this section, you'll bind the **Confirm
 
 1. Open **EditProductForm**'s properties
 2. Rename **label** to **Update**
-3. Go to **Actions → Call an API**
+3. Go to **Event → Call an API**
 4. Choose **UpdateProductApi**
 5. Go to **onSuccess**
 6. Choose **Execute DB Query → ProductQuery**

--- a/how-to-guides/how-to-upload-to-s3.md
+++ b/how-to-guides/how-to-upload-to-s3.md
@@ -45,7 +45,7 @@ To download a file
 
 1. To download the file selected in the table
 
-   * Click on the `JS` button next to `onRowSelected` Action and write the 
+   * Click on the `JS` button next to `onRowSelected` Event and write the 
 
      following javascript query:
 

--- a/how-to-guides/sharing-data-across-pages.md
+++ b/how-to-guides/sharing-data-across-pages.md
@@ -8,7 +8,7 @@ description: >-
 
 ## Sharing data via query params
 
-Query params can be passed by adding the query params object to [NavigateTo action](../framework-reference/navigateto.md). To do this click on the JS mode for Action and update it as follows.
+Query params can be passed by adding the query params object to [NavigateTo action](../framework-reference/navigateto.md). To do this click on the JS mode for the event and update it as follows.
 
 ```javascript
 {{navigateTo("PageName", {"param": "value"})}}

--- a/how-to-guides/writing-javascript-in-appsmith.md
+++ b/how-to-guides/writing-javascript-in-appsmith.md
@@ -56,9 +56,9 @@ First, drag and drop the required text widgets. Now inside the text widget prope
 
 Now, when you click on the random row’s in the table, you can see the text automatically changes its state to the product name. In this way, you can access and manipulate the state inside the widgets. Similarly, you can also, add images and many more for your applications.
 
-## **Performing Actions**
+## **Handling Events**
 
-Appsmith loves JavaScript! Whenever you want to write custom logic for certain action calls or API calls, you can customise with simple JS. For example, say, you want to show an alert whenever you’re searching through tables. You can select the row and can add logic to the **`onSeachTextChanged`** property.
+Appsmith loves JavaScript! Whenever you want to write custom logic for certain events, you can do that by writing JavaScript. For example, say, you want to show an alert whenever you’re searching through tables. You can select the row and can add logic to the **`onSeachTextChanged`** event.
 
 ```javascript
 {{ showAlert(Table1.searchText) }}
@@ -66,19 +66,19 @@ Appsmith loves JavaScript! Whenever you want to write custom logic for certain a
 
 With this, whenever you’re searching for anything on the tables, you’ll see an alert with the value you’ve entered in the search input.
 
-![Configuring Actions on Appsmith](https://lh5.googleusercontent.com/PB37xpaK7u6063ANpW8tnyTQyM16w9XugIt_PSQy2O_Hoy-A-FyP4Dhaq1HR8NUfyCvoVF0CKpx2Q3FMNO3JMifebaORF0MSfXIm3HSsVmyXQ2OWEaa5bGgKVDhpWNB27MNwF4j8)
+![Configuring Events on Appsmith](https://lh5.googleusercontent.com/PB37xpaK7u6063ANpW8tnyTQyM16w9XugIt_PSQy2O_Hoy-A-FyP4Dhaq1HR8NUfyCvoVF0CKpx2Q3FMNO3JMifebaORF0MSfXIm3HSsVmyXQ2OWEaa5bGgKVDhpWNB27MNwF4j8)
 
 ## **Manually triggering APIs/Query**
 
-You might often want to invoke your API Queries on certain actions. For example, say you’re APIs or DB Queries are updating from time to time and wanted to add a refresh button, you can simply do it with JS in Appsmith.
+You might often want to invoke your API Queries when certain events occur. For example, say you’re APIs or DB Queries are updating from time to time and wanted to add a refresh button, you can simply do it with JS in Appsmith.
 
-Now, let’s quickly add a button that will execute the Query when clicked. Next, open the button’s property pane; you’ll find the onclick property under the actions section. Now add a new action and choose to execute a DB Query option; you’ll find all the already defined queries in the application. Select the `get_produts` query you’ll see JS already added to the onclick action.
+Now, let’s quickly add a button that will execute the Query when clicked. Next, open the button’s property pane; you’ll find the onclick property under the events section. Now add a new action and choose to execute a DB Query option; you’ll find all the already defined queries in the application. Select the `get_produts` query you’ll see JS already added to the onclick event.
 
 ```javascript
 {{get_products.run()}}
 ```
 
-In this way, you can customise all the actions on Appsmith for different widgets.
+In this way, you can customise all the events on Appsmith for different widgets.
 
 ## Multiline JavaScript
 

--- a/quick-start/aws-ami.md
+++ b/quick-start/aws-ami.md
@@ -141,7 +141,7 @@ IMPORTANT: The application password is only available in the system log for the 
 
 * Go to your EC2 instances dashboard on AWS
 * Select the instance
-* From the “Actions” drop-down menu, select the “Get System Log” menu item.
+* From the “Events” drop-down menu, select the “Get System Log” menu item.
 
 ![Select System Log](../.gitbook/assets/aws-select-system-log.png)
 

--- a/setting-up/aws-ami.md
+++ b/setting-up/aws-ami.md
@@ -141,7 +141,7 @@ IMPORTANT: The application password is only available in the system log for the 
 
 * Go to your EC2 instances dashboard on AWS
 * Select the instance
-* From the “Actions” drop-down menu, select the “Get System Log” menu item.
+* From the “Events” drop-down menu, select the “Get System Log” menu item.
 
 ![Select System Log](../.gitbook/assets/aws-select-system-log.png)
 

--- a/setup/aws-ami.md
+++ b/setup/aws-ami.md
@@ -71,7 +71,7 @@ IMPORTANT: The application password is only available in the system log for the 
 
 * Go to your EC2 instances dashboard on AWS
 * Select the instance
-* From the “Actions” drop-down menu, select the “Get System Log” menu item.
+* From the “Events” drop-down menu, select the “Get System Log” menu item.
 
 ![Select System Log](../.gitbook/assets/aws-select-system-log.png)
 

--- a/troubleshooting-guide/widget-errors.md
+++ b/troubleshooting-guide/widget-errors.md
@@ -171,7 +171,7 @@ Table1.isVisible -> Table1
 
 ## Debugging
 
-For debugging JS logic inside widget actions, you can use `debugger` statement.
+For debugging JS logic inside widget events, you can use `debugger` statement.
 
 ### Description
 

--- a/tutorial/part-2-creating-a-basic-form/submitting-the-form.md
+++ b/tutorial/part-2-creating-a-basic-form/submitting-the-form.md
@@ -45,7 +45,7 @@ Think of widgets as variables. Similar to variables:
 Let's bind the Submit button of the for to invoke this AddProductQuery. 
 
 1. Open the properties of **SubmitButton**
-2. Go to **Action → onClick**
+2. Go to **Events → onClick**
 3. Choose **Execute DB Query → AddProductQuery**
 
 Try creating a new product using the form. You’ll notice that you don't have a way to tell whether the product got added after submitting, or not. It's because you haven't set up a success or an error message. Let's do that:
@@ -84,7 +84,7 @@ You've created a new page **AddProductPage** with a form that allows users to ad
 2. Drag-drop the [button widget ](https://docs.appsmith.com/widget-reference/button)at the bottom right of the table
 3. Rename widget to **AddProductButton**
 4. Change button label to **Add New Product**
-5. Go to **Action → onClick → Navigate To** 
+5. Go to **Events → onClick → Navigate To** 
 6. Type **AddProductPage** in **Page Name** field
 
 Let's test this. Click on the Add New Product button on the ProductListPage. You'll see that the AddProductForm page opens up, ready for you to fill the form. 

--- a/tutorial/part-2-using-forms/submitting-the-form.md
+++ b/tutorial/part-2-using-forms/submitting-the-form.md
@@ -37,7 +37,7 @@ What you did here is that you accessed the widgets' state in your query. This is
 Your query **AddProductQuery** is now set up to insert dynamic user input from the form. Let's bind the Submit button of the form to invoke **AddProductQuery**:
 
 1. Open the properties of **SubmitButton**
-2. Go to **Action → onClick**
+2. Go to **Events → onClick**
 3. Choose **Execute DB Query → AddProductQuery**
 
 Try creating a new product using the form. You’ll notice that you don't have a way to tell whether the product got added after submitting, or not. It's because you haven't set up a success or an error message. Let's do that:
@@ -77,7 +77,7 @@ You've created a new page **AddProductPage** with a form that allows users to ad
 2. Drag-drop the [button widget ](https://docs.appsmith.com/widget-reference/button)at the bottom right of the table
 3. Rename widget to **AddProductButton**
 4. Change button label to **Add New Product**
-5. Go to **Action → onClick → Navigate To** 
+5. Go to **Events → onClick → Navigate To** 
 6. Type **AddProductPage** in **Page Name** field
 
 Your **ProductListPage** now looks like: 

--- a/tutorial/part-3-creating-interactive-views/adding-edit-button.md
+++ b/tutorial/part-3-creating-interactive-views/adding-edit-button.md
@@ -3,14 +3,14 @@
 You've built a page to view all products, and another page to add a new product. We now move on to the third functionality of enabling a user to edit a product. Let's add an **Edit** button in each row of the table. On clicking the **Edit** button, a form modal will open which will allow users to edit the product in the corresponding row.
 
 1. Open **Products\_Table**’s properties
-2. Click on **New** **Button** under **Actions → Row Button**
+2. Click on **New** **Button** under **Events → Row Button**
 3. Rename the button to **Edit**
 
 You'll see an Edit button in the last column of each row. A Row Button adds a button action for each row. Let's configure the Edit button.
 
 1. Open **Products\_Table**’s properties
-2. Go to **Actions → Row Button → Edit**
-3. Choose the action **Open Modal** from the **Actions** dropdown
+2. Go to **Events → Row Button → Edit**
+3. Choose the action **Open Modal** from the **Events** dropdown
 4. Choose **New Modal**
 5. Rename the new modal to **EditProductModal** using its properties 
 6. Choose **Modal Type** as **Form Modal**

--- a/tutorial/part-3-creating-interactive-views/running-multiple-actions-on-submit.md
+++ b/tutorial/part-3-creating-interactive-views/running-multiple-actions-on-submit.md
@@ -4,7 +4,7 @@ The API to update a product is ready. In this section, you'll bind the **Confirm
 
 1. Open **EditProductForm**'s properties
 2. Rename **label** to **Update**
-3. Go to **Actions → Call an API**
+3. Go to **Events → Call an API**
 4. Choose **UpdateProductApi**
 5. Go to **onSuccess**
 6. Choose **Execute DB Query → ProductQuery**

--- a/tutorial/part-3-widget-interaction/adding-edit-button.md
+++ b/tutorial/part-3-widget-interaction/adding-edit-button.md
@@ -3,14 +3,14 @@
 You've built a page to view all products, and another page to add a new product. We now move on to the third functionality of enabling a user to edit a product. Let's add an **Edit** button in each row of the table. On clicking the **Edit** button, a form modal will open which will allow users to edit the product in the corresponding row.
 
 1. Open **Products\_Table**’s properties
-2. Click on **New** **Button** under **Actions → Row Button**
+2. Click on **New** **Button** under **Events → Row Button**
 3. Rename the button to **Edit**
 
 You'll see an Edit button in the last column of each row. A Row Button adds a button action for each row. Let's configure the Edit button.
 
 1. Open **Products\_Table**’s properties
-2. Go to **Actions → Row Button → Edit**
-3. Choose the action **Open Modal** from the **Actions** dropdown
+2. Go to **Events → Row Button → Edit**
+3. Choose the action **Open Modal** from the **Events** dropdown
 4. Choose **New Modal**
 5. Rename the new modal to **EditProductModal** using its properties 
 6. Choose **Modal Type** as **Form Modal**

--- a/tutorial/part-3-widget-interaction/running-multiple-actions-on-submit.md
+++ b/tutorial/part-3-widget-interaction/running-multiple-actions-on-submit.md
@@ -4,7 +4,7 @@ The API to update a product is ready. In this section, you'll bind the **Confirm
 
 1. Open **EditProductForm**'s properties
 2. Rename **label** to **Update**
-3. Go to **Actions → Call an API**
+3. Go to **Events → Call an API**
 4. Choose **UpdateProductApi**
 5. Go to **onSuccess**
 6. Choose **Execute DB Query → ProductQuery**

--- a/tutorials/building-a-store-catalog-manager/part-2-using-forms.md
+++ b/tutorials/building-a-store-catalog-manager/part-2-using-forms.md
@@ -204,7 +204,7 @@ What you did here is that you accessed the widgets' property in your query. This
 Your query **AddProductQuery** is now set up to insert dynamic user input from the form. Let's bind the Submit button of the form to invoke **AddProductQuery**:
 
 1. Open the properties of **SubmitButton**
-2. Go to **Action → onClick**
+2. Go to **Events → onClick**
 3. Choose **Execute DB Query → AddProductQuery**
 
 Try creating a new product using the form. You’ll notice that you don't have a way to tell whether the product got added after submitting, or not. It's because you haven't set up a success or an error message. Let's do that:
@@ -259,7 +259,7 @@ You've created a new page **AddProductPage** with a form that allows users to ad
 2. Drag-drop the [button widget ](https://docs.appsmith.com/widget-reference/button)at the bottom right of the table
 3. Rename widget to **AddProductButton**
 4. Change button label to **Add New Product**
-5. Go to **Action → onClick → Navigate To** 
+5. Go to **Events → onClick → Navigate To** 
 6. Type **AddProductPage** in **Page Name** field
 
 Your **ProductListPage** now looks like:

--- a/tutorials/building-a-store-catalog-manager/part-3-creating-interactive-views.md
+++ b/tutorials/building-a-store-catalog-manager/part-3-creating-interactive-views.md
@@ -141,7 +141,7 @@ The API to update a product is ready. In this section, you'll bind the **Confirm
 
 1. Open **EditProductForm**'s properties
 2. Rename **label** to **Update**
-3. Go to **Actions → Call an API**
+3. Go to **Events → Call an API**
 4. Choose **UpdateProductApi**
 5. Go to **onSuccess**
 6. Choose **Execute DB Query → ProductQuery**

--- a/tutorials/review-moderator-dashboard/creating-interactive-views-using-lists-and-charts.md
+++ b/tutorials/review-moderator-dashboard/creating-interactive-views-using-lists-and-charts.md
@@ -10,7 +10,7 @@ You are now almost ready with your super cool dashboard. Next, let's add a butto
 
 1. Drag and drop a button widget under business details
 2. Open the buttons property pane and change the label to `View Reviews`
-3. Under Actions, toggle the JS button and paste the following code:
+3. Under Events, toggle the JS button and paste the following code:
 
 ```javascript
 {{

--- a/widget-reference/button/README.md
+++ b/widget-reference/button/README.md
@@ -16,7 +16,7 @@ description: >-
 | **Disabled** | Disables input to the widget. The widget will remain visible to the user but user input will not be allowed. |
 | **Google Recaptcha Key** | Adds a [Google ReCAPTCHA v3](https://www.google.com/recaptcha/) check to the button. The token will be accessible from the API pane with the `recaptchaToken` key \(see [Google reCAPTCHA](google-recaptcha.md)\). |
 
-| Action | Description |
+| Events | Description |
 | :--- | :--- |
 | **onClick** | Sets the action to be run when the user clicks a button. See a list of [supported actions](../../core-concepts/writing-code/appsmith-framework.md) |
 

--- a/widget-reference/checkbox.md
+++ b/widget-reference/checkbox.md
@@ -23,7 +23,7 @@ description: >-
 | **Visible** | Controls widget's visibility on the page. When turned off, the widget will not be visible when the app is published |
 | **Disabled** | Disables input to the widget. The widget will remain visible to the user but user input will not be allowed. |
 
-| Action | Description |
+| Events | Description |
 | :--- | :--- |
 | **onCheckChange** | Sets the action to be run when the user checks/unchecks a checkbox. See a list of [supported actions](../core-concepts/writing-code/appsmith-framework.md) |
 

--- a/widget-reference/datepicker.md
+++ b/widget-reference/datepicker.md
@@ -74,7 +74,7 @@ description: >-
   </tbody>
 </table>
 
-| Action. | Description |
+| Events | Description |
 | :--- | :--- |
 | **onDateSelected** | Sets the action to be run when the user selects a date. See a list of [supported actions](../core-concepts/writing-code/appsmith-framework.md) |
 

--- a/widget-reference/dropdown-1.md
+++ b/widget-reference/dropdown-1.md
@@ -61,7 +61,7 @@ Read more about submitting Input data to an API below.
 | **Disabled** | Disables input/selection to the widget. The widget will remain visible to the user but user input/selection will not be allowed. |
 | **Server Side Filtering** | Enables server side filtering of the  via an API / Query request. Use this property when your Select option data is being bound to an API / Query. |
 
-| Action | Description |
+| Events | Description |
 | :--- | :--- |
 | **onOptionChange** | Sets the action to be run when the user selects/unselects an option. See a list of [supported actions](../core-concepts/writing-code/appsmith-framework.md) |
 | **onFilterUpdate** | Trigger an action on change of `filterText`. See a list of [supported actions](../core-concepts/writing-code/appsmith-framework.md) |

--- a/widget-reference/dropdown.md
+++ b/widget-reference/dropdown.md
@@ -61,7 +61,7 @@ Read more about submitting Input data to an API below.
 | **Disabled** | Disables input/selection to the widget. The widget will remain visible to the user but user input/selection will not be allowed. |
 | **Server Side Filtering** | Enables server side filtering of the  via an API / Query request. Use this property when your Select option data is being bound to an API / Query. |
 
-| Action | Description |
+| Events | Description |
 | :--- | :--- |
 | **onOptionChange** | Sets the action to be run when the user selects/unselects an option. See a list of [supported actions](../core-concepts/writing-code/appsmith-framework.md) |
 | **onFilterUpdate** | Trigger an action on change of `filterText`. See a list of [supported actions](../core-concepts/writing-code/appsmith-framework.md) |

--- a/widget-reference/filepicker.md
+++ b/widget-reference/filepicker.md
@@ -37,7 +37,7 @@ See our guides on
 | **Required** | When turned on, it makes a user input required and disables any form submission until an input is made. |
 | **Visible** | Controls widget's visibility on the page. When turned off, the widget will not be visible when the app is published |
 
-| Action | Description |
+| Events | Description |
 | :--- | :--- |
 | **onFilesSelected** | Sets the action to be run when the user selects files to be uploaded. See a list of [supported actions](../core-concepts/writing-code/appsmith-framework.md). You can immediately call an API or the S3 plugin to upload the base64 of the file to your cloud storage |
 

--- a/widget-reference/form.md
+++ b/widget-reference/form.md
@@ -49,7 +49,7 @@ The form button is provided by default to every form. It is used for form submis
 | **Visible** | Controls widget's visibility on the page. When turned off, the widget will not be visible when the app is published |
 | **Disabled** | Disables input to the widget. The widget will remain visible to the user but a user input will not be allowed. |
 
-| Action | Description |
+| Events | Description |
 | :--- | :--- |
 | **onClick** | Sets the action to be run when the user clicks the form button. See a list of [supported actions](../core-concepts/writing-code/appsmith-framework.md) |
 

--- a/widget-reference/icon-button.md
+++ b/widget-reference/icon-button.md
@@ -19,7 +19,7 @@ description: 'Icon button widget is just an icon, along with all other button pr
 | **isDisabled** | Disables input to the widget. |
 | **isVisible** | Controls the visibility of the widget. |
 
-| Action | Description |
+| Events | Description |
 | :--- | :--- |
 | **onClick** | Sets the action to be run when an icon button is clicked. |
 

--- a/widget-reference/iframe.md
+++ b/widget-reference/iframe.md
@@ -18,7 +18,7 @@ description: Iframe widget is used to display iframes in your app.
 | **borderOpacity** | Sets the color opacity of the border surrounding the page to embed. |
 | **borderWidth** | Sets the width of the border surrounding the page to embed. |
 
-| Action | Description |
+| Events | Description |
 | :--- | :--- |
 | **onURLChanged** | Sets the action to be run when the source url is changed. |
 | **onMessageReceived** | Sets the action to be run when a postMessage event is received from the embedded page. |

--- a/widget-reference/image.md
+++ b/widget-reference/image.md
@@ -16,7 +16,7 @@ description: >-
 | **Max Zoom Level** | Sets the maximum allowable zoom level for the image view |
 | **Enable Rotation** | Controls if the image is allowed to rotate |
 
-| Action | Description |
+| Events | Description |
 | :--- | :--- |
 | **onClick** | Sets the action to be run when the user clicks the image. See a list of [supported actions](../core-concepts/writing-code/appsmith-framework.md). |
 

--- a/widget-reference/input.md
+++ b/widget-reference/input.md
@@ -60,7 +60,7 @@ Read more about submitting Input data to an API below
 | **Visible** | Controls widget's visibility on the page. When turned off, the widget will not be visible when the app is published |
 | **Disabled** | Disables input to the widget. The widget will remain visible to the user but a user input will not be allowed. |
 
-| Action | Description |
+| Events | Description |
 | :--- | :--- |
 | **onTextChanged** | Sets the action to be run when the user inputs text. See a list of [supported actions](../core-concepts/writing-code/appsmith-framework.md). |
 

--- a/widget-reference/list.md
+++ b/widget-reference/list.md
@@ -63,7 +63,7 @@ Note: currentItem and currentIndex is only available in the autocomplete of cont
 | **Item Background** | sets the background color of list items |
 | **Grid Gap** | sets the margin between list items in pixels |
 
-| Actions | Description |
+| Events | Description |
 | :--- | :--- |
 | **onListItemClick** | Sets the action to be run when the user clicks on a list item. See a list of [supported actions](../core-concepts/writing-code/appsmith-framework.md) |
 

--- a/widget-reference/maps.md
+++ b/widget-reference/maps.md
@@ -24,7 +24,7 @@ description: >-
 | **Visible** | Controls widget's visibility on the page. When turned off, the widget will not be visible when the app is published |
 | **Zoom Level** | Sets the default zoom level of the map |
 
-| Action | Description |
+| Events | Description |
 | :--- | :--- |
 | **onMarkerClick** | Sets the action to be run when the user clicks a marker on the map. See a list of [supported actions](../core-concepts/writing-code/appsmith-framework.md). |
 | **onMarkerCreated** | Sets the action to be run when the user creates a new marker on the map. See a list of [supported actions](../core-concepts/writing-code/appsmith-framework.md) |

--- a/widget-reference/menu-button.md
+++ b/widget-reference/menu-button.md
@@ -36,7 +36,7 @@ Each menu item can now be customized through a set of properties by clicking on 
 | **iconColor** | Sets the icon color of the selected icon. |
 | **iconAlign** | Sets the alignment of the selected icon . |
 
-| Action | Description |
+| Events | Description |
 | :--- | :--- |
 | **onClick** | Sets the action to be run when the a menu item is clicked. |
 

--- a/widget-reference/multiselect.md
+++ b/widget-reference/multiselect.md
@@ -62,7 +62,7 @@ Read more about submitting Input data to an API below.
 | **Disabled** | Disables input/selection to the widget. The widget will remain visible to the user but user input/selection will not be allowed. |
 | **Server Side Filtering** | Enables server side filtering of the  via an API / Query request. Use this property when your Select option data is being bound to an API / Query. |
 
-| Action | Description |
+| Events | Description |
 | :--- | :--- |
 | **onOptionChange** | Sets the action to be run when the user selects/unselects an option. See a list of [supported actions](../core-concepts/writing-code/appsmith-framework.md) |
 | **onFilterUpdate** | Trigger an action on change of `filterText`. See a list of [supported actions](../core-concepts/writing-code/appsmith-framework.md) |

--- a/widget-reference/radio.md
+++ b/widget-reference/radio.md
@@ -30,7 +30,7 @@ A Radio Button's **options** can be populated from a data source like an API / Q
 | **Required** | When turned on, it makes a user input required and disables any form submission until an input is made. |
 | **Visible** | Controls widget's visibility on the page. When turned off, the widget will not be visible when the app is published |
 
-| Action | Description |
+| Events | Description |
 | :--- | :--- |
 | **onSelectionChange** | Sets the action to be run when a user changes a selected option. Default supported actions are: Call API, Navigate to Page, Navigate to URL, or Show Alert. |
 

--- a/widget-reference/rich-text-editor.md
+++ b/widget-reference/rich-text-editor.md
@@ -20,7 +20,7 @@ description: >-
 | **Visible** | Controls widget's visibility on the page. When turned off, the widget will not be visible when the app is published |
 | **Disabled** | Disables input to the widget. The widget will remain visible to the user but a user input will not be allowed. |
 
-| Action | Description |
+| Events | Description |
 | :--- | :--- |
 | **onTextChanged** | Sets the action to be run when the user inputs text. See a list of [supported actions](../core-concepts/writing-code/appsmith-framework.md) |
 

--- a/widget-reference/switch.md
+++ b/widget-reference/switch.md
@@ -22,7 +22,7 @@ description: >-
 | **Visible** | Controls widget's visibility on the page. When turned off, the widget will not be visible when the app is published |
 | **Disabled** | Disables input to the widget. The widget will remain visible to the user but user input will not be allowed. |
 
-| Action | Description |
+| Events | Description |
 | :--- | :--- |
 | **onChange** | Sets the action to be run when the user toggles the switch. See a list of [supported actions](../core-concepts/writing-code/appsmith-framework.md) |
 

--- a/widget-reference/table.md
+++ b/widget-reference/table.md
@@ -37,7 +37,7 @@ Tables are useful to view large lists of data. To drill down into the data of a 
 | **Enable multi-row selection** | Allows multiple rows of a table to be selected. The rows are populated in the selectedRows field |
 | **Enable inline row editing selection** | Allows inline editing in each row of a table. The updated data in a row is populated in the selectedRow field |
 
-| Action | Description |
+| Events | Description |
 | :--- | :--- |
 | **onRowSelected** | Sets the action to run when the user selects a row. See a list of [supported actions](../core-concepts/writing-code/appsmith-framework.md) |
 | **onRowUpdate** | Sets the action to run when the user edits a row \(inline row editing\). See a list of [supported actions](../core-concepts/writing-code/appsmith-framework.md) |

--- a/widget-reference/tabs.md
+++ b/widget-reference/tabs.md
@@ -30,7 +30,7 @@ You can create separate UIs in each tab container and dynamically switch between
 | **Scroll Contents** | This property enables scrolling within the contents of each tab |
 | **Visible** | Controls widget's visibility on the page. When turned off, the widget will not be visible when the app is published |
 
-| Action | Description |
+| Events | Description |
 | :--- | :--- |
 | **onTabSelected** | Sets the action to be run when the user selects a tab. See a list of [supported actions](../core-concepts/writing-code/appsmith-framework.md) |
 

--- a/widget-reference/video.md
+++ b/widget-reference/video.md
@@ -15,7 +15,7 @@ description: >-
 | **AutoPlay** | Plays video automatically, without action from a user |
 | **Visible** | Controls widget's visibility on the page. When turned off, the widget will not be visible when the app is published |
 
-| Action | Description |
+| Events | Description |
 | :--- | :--- |
 | **onPlay** | Sets the action to be run when the video plays. Some default supported actions are: Call API, Navigate to Page, Navigate to URL, Open Modal, or Show Message. |
 | **onPause** | Sets the action to be run when the video pauses. Some default supported actions are: Call API, Navigate to Page, Navigate to URL, Open Modal, or Show Message. |


### PR DESCRIPTION
This PR renames the 'Actions' section in the widget docs to 'Events'. It also updates other relevant parts of the docs.

Linked Issue https://github.com/appsmithorg/appsmith/issues/4495
Linked Code PR https://github.com/appsmithorg/appsmith/pull/8579