### PR TITLE
Updated Readme.md and fixed broken YouTube URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,57 +2,53 @@
 
 Appsmith is a low code, open-source framework to build internal applications.
 
-With our JavaScript-based visual development platform, build CRUD apps, Dashboards, Admin Panels, and many more 10x faster.   
+With our JavaScript-based visual development platform, build CRUD apps, Dashboards, Admin Panels, and many more 10x faster.  
 You can use our pre-built UI widgets, connect them to your APIs and databases to build dynamic apps and complex workflows. And the best part? Deploy these apps on the technology you prefer! \(self-host for free!\).
 
 ## How does Appsmith work?
 
 Here are five simple steps to create an app in Appsmith:
 
-* **Connect Any Datasource**: You can integrate any database with Appsmith, including REST APIs, MySQL, Postgres, MongoDB, Google Sheets, and others;
-* **Build UI**: With pre-built widgets, you can create UI in seconds;
-* **Create and Execute Queries**: Write queries and business logic in the SQL or JS Editor and then bind responses;
-* **Customize with Ease**: Write JS everywhere, even inside your DB queries, to customize your app;
-* **Collaborate and Deploy**: Invite your colleagues and friends to work with you and deploy your app with just a click.
+- **Connect Any Datasource**: You can integrate any database with Appsmith, including REST APIs, MySQL, Postgres, MongoDB, Google Sheets, and others;
+- **Build UI**: With pre-built widgets, you can create UI in seconds;
+- **Create and Execute Queries**: Write queries and business logic in the SQL or JS Editor and then bind responses;
+- **Customize with Ease**: Write JS everywhere, even inside your DB queries, to customize your app;
+- **Collaborate and Deploy**: Invite your colleagues and friends to work with you and deploy your app with just a click.
 
-With these simple steps, you can create simple CRUD apps to complicated multi-step workflows. Appsmith makes it easy to build a UI that talks to any data source. 
+With these simple steps, you can create simple CRUD apps to complicated multi-step workflows. Appsmith makes it easy to build a UI that talks to any data source.
 
-Watch this 5-minute video on how to use Appsmith.
+## Watch this 5-minute video on how to use Appsmith.
 
-{% embed url="https://www.youtube.com/watch?v=mzqK0QIZRLs&feature=youtu.be" caption="" %}
+[![How to use Appsmith](https://img.youtube.com/vi/mzqK0QIZRLs/0.jpg)](https://www.youtube.com/watch?v=mzqK0QIZRLs&feature=youtu.be)
 
 ## Creating an Account
 
-Try Appsmith by creating an account in our cloud environment \(Read about our [data security.](faq.md#what-type-of-data-security-does-appsmith-provide)\). Alternatively, you can also deploy Appsmith on your local machine or private server instance. Follow the links below for more information:  
+Try Appsmith by creating an account in our cloud environment \(Read about our [data security](faq.md#what-type-of-data-security-does-appsmith-provide)\). Alternatively, you can also deploy Appsmith on your local machine or private server instance. Follow the links below for more information:
 
-
-* [Create an account on Appsmith Cloud](https://app.appsmith.com)  \(Recommended as it comes with a mock database\);
-* [Deploy Appsmith on my machine](setup/) 
+- [Create an account on Appsmith Cloud](https://app.appsmith.com) \(Recommended as it comes with a mock database\);
+- [Deploy Appsmith on my machine](setup/)
 
 ## Getting Started with Appsmith
 
-Our documentation takes you on a journey that starts from the basics of Appsmith to solving a specific problem. Here’s how we’ve structured the different parts of our docs: 
+Our documentation takes you on a journey that starts from the basics of Appsmith to solving a specific problem. Here’s how we’ve structured the different parts of our docs:
 
-* [The Tutorial](tutorials/) - With our step-by-step and detailed explanations, you can create a sample app using our mock data. ****
-* [Core Concepts](core-concepts/connecting-to-data-sources/) - Find everything you need to know about building an app on Appsmith by getting your fundamentals right! See all about connecting, displaying, reading, and binding data here.
-* [How to Guides](how-to-guides/) -  ****Here, we help you DIY! For those already familiar with the basics of Appsmith, you can find short guides to help you DIY. 
+- [The Tutorial](tutorials/) - With our step-by-step and detailed explanations, you can create a sample app using our mock data.
+- [Core Concepts](core-concepts/connecting-to-data-sources/) - Find everything you need to know about building an app on Appsmith by getting your fundamentals right! See all about connecting, displaying, reading, and binding data here.
+- [How to Guides](how-to-guides/) - Here, we help you DIY! For those already familiar with the basics of Appsmith, you can find short guides to help you DIY.
 
 We’ve also put together a detailed reference system. In case you’re looking for information about widgets, data sources, or Framework, refer to the following docs:
 
-* [Datasource Reference](core-concepts/connecting-to-data-sources/connecting-to-databases.md#supported-databases)
-* [Framework Reference](core-concepts/writing-code/appsmith-framework.md)
-* [Widget Reference](core-concepts/displaying-data-read/#widgets)
+- [Datasource Reference](core-concepts/connecting-to-data-sources/connecting-to-databases.md#supported-databases)
+- [Framework Reference](core-concepts/writing-code/appsmith-framework.md)
+- [Widget Reference](core-concepts/displaying-data-read/#widgets)
 
-We are working hard to keep our documentation up to date and expansive. However, we might not be able to cover everything. If you think we need to include something here, please fill out this [short questionnaire](https://e1fms9m33tg.typeform.com/to/fRiiqHPt)! Alternatively, you can shoot an email to [docs@appsmith.com](mailto:docs@appsmith.com), and we’ll get working on it!   
-
+We are working hard to keep our documentation up to date and expansive. However, we might not be able to cover everything. If you think we need to include something here, please fill out this [short questionnaire](https://e1fms9m33tg.typeform.com/to/fRiiqHPt)! Alternatively, you can shoot an email to [docs@appsmith.com](mailto:docs@appsmith.com), and we’ll get working on it!
 
 ## Help Center
 
-* Have a look at our [FAQs](https://docs.appsmith.com/faq), and you might find your questions answered there;
-* Looking for specific information? Try the[ Widget Reference](https://docs.appsmith.com/widget-reference), [Framework Reference](https://docs.appsmith.com/function-reference) or [Datasource Reference](https://docs.appsmith.com/core-concepts/connecting-to-data-sources/connecting-to-databases#supported-databases)  ;
-* See our guides and tutorials on[ YouTube](https://www.youtube.com/appsmith);
-* Report bugs with Appsmith through[ Github issues](https://github.com/appsmithorg/appsmith/issues).
+- Have a look at our [FAQs](https://docs.appsmith.com/faq), and you might find your questions answered there;
+- Looking for specific information? Try the[ Widget Reference](https://docs.appsmith.com/widget-reference), [Framework Reference](https://docs.appsmith.com/function-reference) or [Datasource Reference](https://docs.appsmith.com/core-concepts/connecting-to-data-sources/connecting-to-databases#supported-databases) ;
+- See our guides and tutorials on[ YouTube](https://www.youtube.com/appsmith);
+- Report bugs with Appsmith through[ Github issues](https://github.com/appsmithorg/appsmith/issues).
 
-Still, having trouble? We want to help! Reach out to us on[ Discord](https://discord.com/invite/rBTTVJp) to get support and ask questions on our [community forum](https://community.appsmith.com/).  
-
-
+Still, having trouble? We want to help! Reach out to us on[ Discord](https://discord.com/invite/rBTTVJp) to get support and ask questions on our [community forum](https://community.appsmith.com/).


### PR DESCRIPTION
Documentation Link:
https://github.com/appsmithorg/appsmith-docs/blob/v1.3/README.md?plain=1#L22

Problem:
Instead of showing thumbnail of YouTube video, it is showing YouTube video embed URL. Also in Getting started with AppSmith section, there are 3 redundant asterisks are present which are not required.

Improvement: Fixed embed URL of YouTube video, and remove some redundant astericks.