### PR TITLE
fix: update regex suggestion and error message in part-2-using-forms.md

### DIFF
--- a/tutorials/building-a-store-catalog-manager/part-2-using-forms.md
+++ b/tutorials/building-a-store-catalog-manager/part-2-using-forms.md
@@ -135,8 +135,8 @@ Your form now has all the required widgets in place with some basic properties c
 Start with **ProductNameInput**:
 
 1. Open its properties modal 
-2. Set **Regex** to `^\s*[a-zA-Z]{3,50}\s*$`
-3. Set **Error Message** to **Must be alphanumeric having length between 3 and 50**
+2. Set **Regex** to `^[A-Za-z][A-Za-z -]{3,50}$`
+3. Set **Error Message** to **Must contain only letters, spaces, or dashes and have a length between 3 and 50**
 
 Let’s see what you did there:
 


### PR DESCRIPTION
The current regex doesn't match more than one word limiting product names to strings without spaces. This fix updates the suggested regex to match only letters but for multiple words, and adds pattern matching for dashes to support product names that match early entries in the DB. It also does not allow a space as the first character which prevents blank entries.

The fix also updates the error message to be consistent with the new regex pattern.