### PR TITLE
docs: Add docs on configuring frame-ancestors

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -36,6 +36,7 @@
         * [Okta](setup/instance-configuration/single-sign-on-sso/security-assertion-markup-language-saml/okta.md)
         * [Active Directory](setup/instance-configuration/single-sign-on-sso/security-assertion-markup-language-saml/active-directory.md)
     * [Custom CA Root Certificate](setup/instance-configuration/custom-ca-root-certificate.md)
+    * [Frame Ancestors](setup/instance-configuration/frame-ancestors.md)
   * [Instance Management](setup/instance-management.md)
   * [Migrate from Multi-Container setup](setup/migrate.md)
 * [Tutorials](tutorials/README.md)

--- a/setup/instance-configuration/README.md
+++ b/setup/instance-configuration/README.md
@@ -73,3 +73,4 @@ It may take a minute for the new ECS Task to start running.
 * [Disable Intercom](disable-intercom.md)
 * [Single Sign-On (SSO)](single-sign-on-sso/)
 * [Custom CA Root Certificate](custom-ca-root-certificate.md)
+* [Frame Ancestors](frame-ancestors.md)

--- a/setup/instance-configuration/frame-ancestors.md
+++ b/setup/instance-configuration/frame-ancestors.md
@@ -1,0 +1,27 @@
+# Frame Ancestors
+
+Starting with Appsmith v1.7.10, you can control where your apps can be loaded in a frame.
+
+Why should I control this? Allowing your Appsmith apps to be embedded on any website makes them susceptible to clickjacking attacks. Controlling this is one of the simplest ways to avoid these attacks.
+
+By default, starting Appsmith v1.7.10, apps **cannot** be loaded in a frame/iframe, on domains other than the domain of the app. That is, if your Appsmith is available at `http://mydomain.com`, then only pages on `http://mydomain.com` will be able to embed apps.
+
+To change/customize this, we've introduced `APPSMITH_ALLOWED_FRAME_ANCESTORS` environment variable. To allow another domain like `http://trusted-other.com` to also embed apps from your Appsmith, use:
+
+```sh
+APPSMITH_ALLOWED_FRAME_ANCESTORS="'self' http://trusted-other.com"
+```
+
+Or, to allow all subdomains on `mycompany.com`, use:
+
+```sh
+APPSMITH_ALLOWED_FRAME_ANCESTORS="'self' http://*.mycompany.com"
+```
+
+You can add multiple such entries by separating with spaces. For example:
+
+```sh
+APPSMITH_ALLOWED_FRAME_ANCESTORS="'self' http://trusted-other.com http://*.mycompany.com"
+```
+
+Under the covers, this feature uses a `Content-Security-Policy` header with `frame-ancestors` directive. Learn more at <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors>.


### PR DESCRIPTION
This should go along with the next tag, v1.7.10.