### PR TITLE
fix: Update instructions for existing deployments on Heroku

### DIFF
--- a/getting-started/setup/installation-guides/heroku.md
+++ b/getting-started/setup/installation-guides/heroku.md
@@ -100,6 +100,11 @@ Then follow the steps below:
       git clone --branch master https://github.com/appsmithorg/appsmith
       cd ./appsmith/deploy/heroku
     ```
+*   For existing repository, pull the fresh Appsmith image:
+
+    ```
+      docker pull appsmith/appsmith-ce
+    ```
 *   Login to Heroku CLI.
 
     ```


### PR DESCRIPTION
The problem is that `Dockerfile` in the repository is only a wrapper over `appsmith/appsmith-ce` docker image. If the local image is outdated, docker will not by default pull a fresh one, thus current instructions will actually not lead to the AppSmith instance on Heroku being updated. If you pull image manually before executing these steps, it works fine.