### PR TITLE
#16844 Connect Gmail app pwd docs to SMTP docs page

### DIFF
--- a/website/docs/getting-started/setup/instance-configuration/email/gmail.md
+++ b/website/docs/getting-started/setup/instance-configuration/email/gmail.md
@@ -11,7 +11,7 @@ To configure Gmail as your [SMTP server](https://developer.mozilla.org/en-US/doc
 To use App Passwords, please enable 2-factor authentication for your Gmail account. For more information on App Passwords, see [this reference](https://support.google.com/accounts/answer/185833?hl=en).
 :::
 
-* Navigate to your [Google account settings dashboard](https://myaccount.google.com), and go to the Security tab.
+* Navigate to your [Google Account settings dashboard](https://myaccount.google.com), and go to the Security tab.
 
 ![Find the "App Passwords" section under the Security tab.](/img/Security\_Full.png)
 
@@ -21,9 +21,9 @@ To use App Passwords, please enable 2-factor authentication for your Gmail accou
 ![](/img/dropdowns.png)
 
 * In the **Select app** box, choose **Mail**.
-* In the **Select device** box, choose **Other** and enter a name for the Appsmith platform, e.g., “MyAppsmithInstance.”
+* In the **Select device** box, choose **Other** and enter a name for your Appsmith instance.
 * Click **Generate** to create your App password.
-* The next screen will contain your App password. Copy this password to your clipboard.
+* The next screen contains your App password. Copy this password to your clipboard.
 
 ![Generate App Password](/img/app\_pass\_generated\_edit.png)
 

--- a/website/docs/getting-started/setup/instance-configuration/email/gmail.md
+++ b/website/docs/getting-started/setup/instance-configuration/email/gmail.md
@@ -27,7 +27,9 @@ To use App Passwords, please enable 2-factor authentication for your Gmail accou
 
 ![Generate App Password](/img/app\_pass\_generated\_edit.png)
 
+* Paste your new Gmail App Password into your SMTP datasource's `Password` field.
+
 :::info
-You can also configure the email service provider using [Admin settings](./#configure-using-admin-settings). Add `Gmail App Password` in the `SMTP Password` Field.
+You can also configure the email service provider using [Admin settings](./#configure-using-admin-settings).
 :::
 

--- a/website/docs/reference/datasources/using-smtp.md
+++ b/website/docs/reference/datasources/using-smtp.md
@@ -23,7 +23,7 @@ The SMTP datasource requires the following information to establish a connection
 1. **Host address:** This is the host address of the SMTP server.
 2. **Port:** The port over which you will communicate with the SMTP server. Typically this is 25 or 587.
 3. **Username:** The username of the SMTP server.
-4. **Password:** The password of the SMTP server. Please note that if you have a multi-factor authentication setup for your SMTP server, your normal password may not work. You may have to generate a separate password from your provider, which will work without multi-factor authentication.
+4. **Password:** The password of the SMTP server. Please note that if you have a multi-factor authentication setup for your SMTP server, your normal password may not work. You may have to generate a separate password from your provider, which will work without multi-factor authentication. For example, Gmail requires that you generate an app password to use as authentication; see [here](/getting-started/setup/instance-configuration/email/gmail) to read more.
 
 ## Send Email
 

--- a/website/docs/reference/datasources/using-smtp.md
+++ b/website/docs/reference/datasources/using-smtp.md
@@ -7,43 +7,43 @@ sidebar_position: 16
 The following document assumes that you understand the [basics of connecting to a datasource on Appsmith](/core-concepts/connecting-to-data-sources/connecting-to-databases.md#connecting-to-a-database). If not, please go over them before reading further.
 :::
 
-The SMTP plugin can connect to an SMTP server to send the dynamic email(s) to a list of recipients.
+The SMTP plugin can connect to an SMTP server and send dynamic emails to a list of recipients.
 
 <figure>
   <object data="https://www.youtube.com/embed/hAln7o1aUA4?autoplay=0" width='750px' height='400px'></object> 
   <figcaption align="center"><i></i></figcaption>
 </figure>
 
-## Connection Settings
+## Connection settings
 
 The SMTP datasource requires the following information to establish a connection. All fields are mandatory.
 
 ![Click to expand](/img/smtp_create_datasource.png)
 
 1. **Host address:** This is the host address of the SMTP server.
-2. **Port:** The port over which you will communicate with the SMTP server. Typically this is 25 or 587.
+2. **Port:** The port for communication with the SMTP server. Typically this is 25 or 587.
 3. **Username:** The username of the SMTP server.
-4. **Password:** The password of the SMTP server. Please note that if you have a multi-factor authentication setup for your SMTP server, your normal password may not work. You may have to generate a separate password from your provider, which will work without multi-factor authentication. For example, Gmail requires that you generate an app password to use as authentication; see [here](/getting-started/setup/instance-configuration/email/gmail) to read more.
+4. **Password:** The password of the SMTP server. Please note that if you have a multi-factor authentication setup for your SMTP server, your normal password may not work. You may have to generate a separate password from your provider which won't require multi-factor authentication. For example, Gmail requires that you generate an app password to use as authentication; see [here](/getting-started/setup/instance-configuration/email/gmail) to read more.
 
-## Send Email
+## Send email
 
-This action sends an email with a dynamic subject and body to a list of the recipient(s). You can also optionally attach files along with this email.
+This action sends an email with a dynamic subject and body to a list of recipients. You can also optionally attach files along with this email.
 
 | Property Name      | Description                                                                                           | Type      |
 | ------------------ | ----------------------------------------------------------------------------------------------------- | --------- |
-| From email         | This is the email address that the email will be sent from.                                           | Mandatory |
-| Set Reply To Email | Toggle to set if the reply to email ID needs to be set                                                | Optional  |
-| Reply to email     | This is the email address that responses to your email will be sent to.                               | Optional  |
-| To email(s)        | This is the email address(es) of the recipients. Multiple email IDs must be comma separated.          | Mandatory |
-| CC email(s)        | List of email adderess(es) of the recipients to be CC'd. Multiple email IDs must be comma separated.  | Optional  |
-| BCC email(s)       | List of email adderess(es) of the recipients to be BCC'd. Multiple email IDs must be comma separated. | Optional  |
+| From email         | This is the email address to send from.                                                               | Mandatory |
+| Set Reply To email | Toggle to set whether the reply to email ID needs to be set                                           | Optional  |
+| Reply to email     | This is the email address that should receive the replies.                                            | Optional  |
+| To emails          | This is the email address(es) of the recipients. Multiple email IDs must be comma separated.          | Mandatory |
+| CC emails          | List of email adderess(es) of the recipients to CC. Multiple email IDs must be comma separated.       | Optional  |
+| BCC emails         | List of email adderess(es) of the recipients to BCC. Multiple email IDs must be comma separated.      | Optional  |
 | Subject            | The subject of the email                                                                              | Optional  |
 | Body               | The body of the email                                                                                 | Optional  |
-| Attachment(s)      | List of file paths of the attachments to be attached to the email.                                    | Optional  |
+| Attachments        | List of file paths of the attachments to be attached to the email.                                    | Optional  |
 
-### Response Format
+### Response format
 
-If the email has been sent successfully, the response will be a JSON object with the following structure:
+On successful sending, the response is a JSON object with the following structure:
 
 ```
 {
@@ -52,11 +52,11 @@ If the email has been sent successfully, the response will be a JSON object with
 }
 ```
 
-On the other hand, if Appsmith encounters an error while sending the email, an error will be displayed on the screen. An example is shown below: ![Click to expand](/img/smtp_error_response.png)
+If Appsmith encounters an error while sending the email, an error is displayed on the screen. An example is shown below: ![Click to expand](/img/smtp_error_response.png)
 
-## Using Queries in applications
+## Using queries in applications
 
-Once you have successfully run a Query, you can use it in your application to
+Once you have successfully run a Query, you can use it in your app to
 
 * [Display Data](/core-concepts/data-access-and-binding/displaying-data-read/)
 * [Capture Data](/core-concepts/data-access-and-binding/capturing-data-write/)

--- a/website/docs/reference/datasources/using-smtp.md
+++ b/website/docs/reference/datasources/using-smtp.md
@@ -23,7 +23,7 @@ The SMTP datasource requires the following information to establish a connection
 1. **Host address:** This is the host address of the SMTP server.
 2. **Port:** The port for communication with the SMTP server. Typically this is 25 or 587.
 3. **Username:** The username of the SMTP server.
-4. **Password:** The password of the SMTP server. Please note that if you have a multi-factor authentication setup for your SMTP server, your normal password may not work. You may have to generate a separate password from your provider which won't require multi-factor authentication. For example, Gmail requires that you generate an app password to use as authentication; see [here](/getting-started/setup/instance-configuration/email/gmail) to read more.
+4. **Password:** The password of the SMTP server. Please note that if you have a multi-factor authentication setup for your SMTP server, your normal password may not work. You may have to generate a separate password from your provider which won't require multi-factor authentication. For example, Gmail requires that you [generate an app password](https://support.google.com/mail/answer/185833?hl=en) to use as authentication instead of your regular password.
 
 ## Send email
 


### PR DESCRIPTION
This PR adds a segue + link from the SMTP datasource docs -> the instructions for setting up a Gmail App Password, as well as a slight clarification on the latter page.

Also includes a pass of small tweaks to satisfy the linter. (The first two commits are the ones that affect this ticket, the third is the linter stuff).

Resolves [ticket #16844](https://github.com/appsmithorg/appsmith/issues/16844).