### PR TITLE
fix: Simplify messaging example and fix markup

### DIFF
--- a/website/docs/reference/widgets/iframe.md
+++ b/website/docs/reference/widgets/iframe.md
@@ -51,22 +51,18 @@ You can try out the message property by following the steps below:
 
 2. We need to embed a page that is able to send a message with `postMessage()`. In the iframe widget’s settings, copy and paste the following snippet into its **srcDoc** property:
 
-```html
-{{
-    `
-        <input id="messageinput" type="text"></input>
-        <input type="button" onclick="sendMyMessage()" value="SEND" />
-        <script>
-            function sendMyMessage() {
-                const msgText = document.getElementById("messageinput").value;
-                window.parent.postMessage(msgText, "*");
-            }
-        </script>
-    `
-}}
-```
+   ```html
+   <input id="messageinput" type="text"></input>
+   <input type="button" onclick="sendMyMessage()" value="SEND" />
+   <script>
+       function sendMyMessage() {
+           const msgText = document.getElementById("messageinput").value;
+           window.parent.postMessage(msgText, "*");
+       }
+   </script>
+   ```
 
-You’ve created a very simple HTML document in the iframe containing a text input, a button, and a script to handle sending the message.
+   You’ve created a very simple HTML document in the iframe containing a text input, a button, and a script to handle sending the message.
 
 3. Drag and drop a new [Text](text.md) widget onto the canvas, and set its Text property to `{{Iframe1.message}}`.
 


### PR DESCRIPTION
There's two changes in this.

1. The example code is wrapped in a backtick-string, inside double-braces, but doesn't use any interpolation. So, it's the same thing as directly writing the markup.

2. The code block and the following paragraph need to be part of the 2nd point. For this, they need to be lined up with `We need to embed...`. See the markup and layout in the screenshots to understand this. I can elaborate further on why this is important if needed. Let me know.

## Before
![Screenshot 2022-11-04 at 9 59 59 AM](https://user-images.githubusercontent.com/120119/199888325-b65aedbe-fb1d-43e8-a025-85602cafc51a.png)


## After
![Screenshot 2022-11-04 at 9 58 33 AM](https://user-images.githubusercontent.com/120119/199888339-fc2ca79b-0294-4413-97eb-105426de199e.png)

