### PR TITLE
docs: changed the documentation for updatedRow property of tablewidget

### DIFF
--- a/.github/styles/Vocab/technical/accept.txt
+++ b/.github/styles/Vocab/technical/accept.txt
@@ -26,7 +26,7 @@ Protocol
 host
 JSON
 async
-updateRow
+updatedRow
 onSave
 onSubmit
 onDiscard

--- a/.github/styles/Vocab/technical/accept.txt
+++ b/.github/styles/Vocab/technical/accept.txt
@@ -26,4 +26,8 @@ Protocol
 host
 JSON
 async
-
+updateRow
+onSave
+onSubmit
+onDiscard
+updatedRows

--- a/.github/styles/Vocab/technical/accept.txt
+++ b/.github/styles/Vocab/technical/accept.txt
@@ -3,6 +3,7 @@ pageinfo
 Appsmith
 appsmith
 Datasource
+datasource
 datasources
 application
 URL
@@ -31,3 +32,4 @@ onSave
 onSubmit
 onDiscard
 updatedRows
+newRow

--- a/website/docs/reference/widgets/table/inline-editing.md
+++ b/website/docs/reference/widgets/table/inline-editing.md
@@ -148,7 +148,7 @@ Valid property shows the validity of the cell. When the expression evaluates to 
 2. `currentIndex` - index of the current editable row.
 3. `editedValue` - the newly entered value on the editable input.
 
-For example: Imagine you want the updated value to be "John". In the **Valid** property field, add:
+For example, imagine you want the updated value to be `John`. In the **Valid** property field, add:
 
 ```
 {{editedValue == "John"}}
@@ -287,7 +287,7 @@ While the "Add new row" mode is enabled in the Table widget, `isAddRowInProgress
 
 #### newRow
 
-When a new row is being added to the Table, this variable contains a reference to that new row object being added; otherwise, it's `undefined`. This is useful for accessing the user input to send it via query once the user is ready to submit the new data.
+When a new row is being added to the Table, this variable contains a reference to that new row object being added; otherwise, it is `undefined`. This is useful for accessing the user input to send it via query once the user is ready to submit the new data.
 
 #### isNewRow
 
@@ -356,7 +356,7 @@ To update the original datasource with the new data, you might execute a query l
 
 Assuming that the POST request is successful, the `myAPI` datasource receives the new information, and the Table should contain the new row the next time it updates.
 
-## What's next?
+## Further reading
 
 The following resources can come in handy as you need to learn new tricks:
 

--- a/website/docs/reference/widgets/table/inline-editing.md
+++ b/website/docs/reference/widgets/table/inline-editing.md
@@ -148,11 +148,7 @@ Valid property shows the validity of the cell. When the expression evaluates to 
 2. `currentIndex` - index of the current editable row.
 3. `editedValue` - the newly entered value on the editable input.
 
-<<<<<<< HEAD
 For example, imagine you want the updated value to be `John`. In the **Valid** property field, add:
-=======
-For example: Imagine you want the updated value to be `John`. In the **Valid** property field, add:
->>>>>>> 9282c33acf2dea9dea036d58b0def9c22455c6ea
 
 ```
 {{editedValue == "John"}}

--- a/website/docs/reference/widgets/table/inline-editing.md
+++ b/website/docs/reference/widgets/table/inline-editing.md
@@ -240,6 +240,9 @@ The default value for this property is an object with keys as column names and b
 	"status": ""
 }
 ```
+The value gets available as soon as a user updates a table cell. Not edits, but updates.
+
+The `updatedRow` property will get reset to the default value whenever the value is saved(onSave) or when it is discarded(onDiscard).
 
 ### Events
 

--- a/website/docs/reference/widgets/table/inline-editing.md
+++ b/website/docs/reference/widgets/table/inline-editing.md
@@ -56,10 +56,6 @@ This column can't be deleted. It can only be made hidden. This column gets delet
 Users can customize the appearance of the Save and Discard button in the column settings. There are two events available `onSave,` and `onDiscard`, which users can use to trigger an action when the corresponding button is clicked.
 
 :::info
-`updatedRow` can be used to access the row that triggered the event
-:::
-
-:::info
 ONLY single row cells are editable in row-level update mode. Users should save or discard the edited row before editing another row.
 :::
 
@@ -105,7 +101,7 @@ Properties allow you to edit the widget, connect it with other widgets and custo
 | **Max**                      | Validation  | Sets the maximum allowed value.                                                                               | NA                             |
 | **updatedRows**              | Binding     | This property contains all the details of the edited rows.                                                    | `{{Table1.updatedRows}}`       |
 | **updatedRowIndices**        | Binding     | This property contains an array of edited row indices.                                                        | `{{Table1.updatedRowIndices}}` |
-| **updatedRow**               | Binding     | This property contains the details of the row that triggered the action (`onSubmit`, `onSave` or `onDiscard`) | `{{Table1.updatedRow}}`|
+| **updatedRow**               | Binding     | This property consists of the details of the row that recently got updated | `{{Table1.updatedRow}}`|
 
 #### Update mode
 
@@ -225,14 +221,23 @@ For example, if you updated the second row of a table. Now, when you bind this p
 
 #### updatedRow
 
-This property contains the details of the row that triggered the action (`onSubmit`, `onSave` or `onDiscard`). For example, if you bind this property into a text widget, you get an output something like this:
+This property consists of the details of the row that recently got updated. Irrespective of the update mode, the `updatedRow` property consists of the row that got recently updated.
 
 ```
 {
-  "Name": "Updated Name",
-  "Date": "Updated Date",
-  "Status ": "Updated Status",
-  "rowIndex": "Row Index"
+	"step": "Updated step",
+	"task": "Updated task",
+	"status": "Updated status"
+}
+```
+
+The default value for this property is an object with keys as column names and blank string as its values. For example,
+
+```
+{
+	"step": "",
+	"task": "",
+	"status": ""
 }
 ```
 

--- a/website/docs/reference/widgets/table/inline-editing.md
+++ b/website/docs/reference/widgets/table/inline-editing.md
@@ -55,9 +55,8 @@ This column can't be deleted. It can only be made hidden. This column gets delet
 
 Users can customize the appearance of the Save and Discard button in the column settings. There are two events available `onSave,` and `onDiscard`, which users can use to trigger an action when the corresponding button is clicked.
 
-:::info
-ONLY single row cells are editable in row-level update mode. Users should save or discard the edited row before editing another row.
-:::
+> Only single row cells are editable in row-level update mode. Users should save or discard the edited row before editing another row.
+
 
 #### Custom mode
 
@@ -101,7 +100,7 @@ Properties allow you to edit the widget, connect it with other widgets and custo
 | **Max**                      | Validation  | Sets the maximum allowed value.                                                                               | NA                             |
 | **updatedRows**              | Binding     | This property contains all the details of the edited rows.                                                    | `{{Table1.updatedRows}}`       |
 | **updatedRowIndices**        | Binding     | This property contains an array of edited row indices.                                                        | `{{Table1.updatedRowIndices}}` |
-| **updatedRow**               | Binding     | This property consists of the details of the row that recently got updated | `{{Table1.updatedRow}}`|
+| **updatedRow**               | Binding     | This property contains all the details of the row that recently got updated | `{{Table1.updatedRow}}`|
 
 #### Update mode
 
@@ -242,7 +241,7 @@ The default value for this property is an object with keys as column names and b
 ```
 The value gets available as soon as a user updates a table cell. Not edits, but updates.
 
-The `updatedRow` property will get reset to the default value whenever the value is saved(onSave) or when it is discarded(onDiscard).
+The `updatedRow` property gets reset to the default value whenever the value is saved(onSave) or when it's discarded(onDiscard).
 
 ### Events
 


### PR DESCRIPTION
This PR adds changes to the `updatedRow` property of the table widget. 
Please refer to the issue: Issue: #618 