### PR TITLE
fix: Fix edit link and remove misleading comments

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -27,28 +27,12 @@ const config = {
       /** @type {import('@docusaurus/preset-classic').Options} */
       ({
        docs: {
-          /*lastVersion: 'current',
-          versions: {
-            current: {
-              label: '1.5',
-              path: '1.5',
-            },
-          },*/
           routeBasePath: '/',
           sidebarPath: require.resolve('./sidebars.js'),
-          // Please change this to your repo.
-          // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/appsmithorg/appsmith-docs/blob/main/website/',
+            'https://github.com/appsmithorg/appsmith-docs/edit/main/website/',
         },
         blog: false,
-        /*blog: {
-          showReadingTime: true,
-          // Please change this to your repo.
-          // Remove this to remove the "edit this page" links.
-          editUrl:
-            'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',
-        },*/
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },


### PR DESCRIPTION
The link to edit pages reads "Edit this page", but clicking it actually _views_ the page, not edit it. This PR changes it to actually edit the page directly.

Also removed some comments that are not needed, and are a little misleading now.
