### PR TITLE
chore: fix broken links

### DIFF
--- a/website/docs/core-concepts/connecting-to-data-sources/README.md
+++ b/website/docs/core-concepts/connecting-to-data-sources/README.md
@@ -10,7 +10,7 @@ Before connecting to a data source, you must whitelist the IP address of the App
 
 **18.223.74.85** and **3.131.104.27** are the IP addresses of the Appsmith cloud instances that need to be whitelisted
 
-This is a guide on how to [whitelist appsmith on AWS.](learning-and-resources/how-to-guides/aws-whitelist)
+This is a guide on how to [whitelist appsmith on AWS.](/learning-and-resources/how-to-guides/aws-whitelist)
 :::
 
 ## Security

--- a/website/docs/core-concepts/connecting-to-data-sources/authentication/README.md
+++ b/website/docs/core-concepts/connecting-to-data-sources/authentication/README.md
@@ -27,7 +27,7 @@ It is advisable that you give a meaningful name to your Authenticated API dataso
 
 ### URL
 
-Use this field to add the API URL you would like to access. For example, I would like to access the mock API of Appsmith, and for that, I’ll supply the URL as  [`https://mock-api.appsmith.com`](https://mock-api.appsmith.com)``
+Use this field to add the API URL you would like to access. For example, I would like to access the mock API of Appsmith, and for that, I’ll supply the URL as `https://mock-api.appsmith.com`
 
 ### Headers
 

--- a/website/docs/learning-and-resources/integrations.md
+++ b/website/docs/learning-and-resources/integrations.md
@@ -160,7 +160,7 @@ Appsmith provides **native** integrations with many [databases](/reference/datas
             <img class="containerImage" src="/img/xano-logo_nnco8rx_b.png" alt="Xano-logo"/>
         </div> <hr/>
         <div class="containerDescription"><strong>Xano</strong> is the fastest no-code backend development platform.<br/><br/></div>
-         <div class="containerTutorialLink"><a href="https://www.appsmith.com/blog/adding-social-authentication-for-your-internal-applications-without-writing-any-code"><strong>View Tutorial</strong></a> </div>
+         <div class="containerTutorialLink"><a href="https://www.appsmith.com/blog/adding-social-authentication"><strong>View Tutorial</strong></a> </div>
     </div>
 </div>
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -84,7 +84,7 @@ const config = {
             position: 'right',
           },
           {
-            href: 'https://www.appsmith.com/blog-categories/tutorial',
+            href: 'https://www.appsmith.com/blog?cat=Tutorial',
             label: 'Tutorials',
             position: 'right',
           },


### PR DESCRIPTION
Fixed broken links for following:
- updated the correct link to point-> learning-and-resources/how-to-guides/aws-whitelist
- updated the tutorial link to point -> https://www.appsmith.com/blog?cat=Tutorial
- Removed link from the example - `https://mock-api.appsmith.com/`