### PR TITLE
Addresses 'typo in tutorial' issue #371

### DIFF
--- a/website/docs/learning-and-resources/tutorials/building-a-store-catalog-manager/using-forms.md
+++ b/website/docs/learning-and-resources/tutorials/building-a-store-catalog-manager/using-forms.md
@@ -263,7 +263,7 @@ Your **ProductListPage** now looks like this:
 
 ![](/img/as_storeTutorial_navButton.png)
 
-Let's test it out: Click on the "**Add New Product"** button on the **ProductListPage**. You'll see that the **AddProductForm** page opens up, ready for user input.
+Let's test it out: Click on the "**Add New Product"** button on the **ProductListPage**. You'll see that the **NewProductPage** form opens up, ready for user input.
 
 By selecting the [Navigate To](../../../reference/appsmith-framework/widget-actions/navigate-to.md) option, you set up the button to open a new page when it is clicked. You then specified the name of that page in your app, so Appsmith knows where to redirect the user.
 


### PR DESCRIPTION
Changed the word 'AddProductForm' on the 'Connecting multiple pages' section of the 'building a store catalog manager' tutorial to NewProductPage to match the picture shown, and earlier references using this name.
