### PR TITLE
Adds info for new chart widget property - Series Color

### DIFF
--- a/website/docs/learning-and-resources/tutorials/review-moderator-dashboard/creating-interactive-views-using-lists-and-charts.md
+++ b/website/docs/learning-and-resources/tutorials/review-moderator-dashboard/creating-interactive-views-using-lists-and-charts.md
@@ -165,6 +165,7 @@ There are almost 100+ variants of Fusion Chart Configuration; learn more from th
 Appsmith uses the Chart Series property head to supply the data and details related to identifying the data points.
 
 * `Series Title` - the name of the series.
+* `Series Color` - a color picker input to select the color of the series.
 * `Series Data` - stores the data points for the total bugs.
 * `X-axis Label` - to define a title for the x-axis.
 * `Y-axis Label` - to define a title for the y-axis

--- a/website/docs/reference/widgets/chart.md
+++ b/website/docs/reference/widgets/chart.md
@@ -94,6 +94,7 @@ Let’s use a line chart to visualize the data.
 As you can see in the video, we use the `Chart Series` property head to supply the data and details related to identifying the data points.
 
 * `Series Title` - the name of the series. In the example above, it is _**Total Bugs**_.
+* `Series Color` - a color picker input to select the color of the series.
 * `Series Data` - stores the data points for the total bugs.
 * `X-axis Label` - to define a title for the x-axis.
 * `Y-axis Label` - to define a title for the y-axis.


### PR DESCRIPTION
In default charts, only series title and series data could be provided by developer.
We have added the Series Color property as well in this PR to control the color of all the default charts (Except Pie Chart).

- Not applicable for custom charts
- Series Color will only work with hex code values as of now
- Series Color not applicable for Pie Chart and hence this feature is not available for Pie Chart