### PR TITLE
feat: 668 widget focus and blur events

### DIFF
--- a/website/docs/reference/widgets/currency-input.md
+++ b/website/docs/reference/widgets/currency-input.md
@@ -217,6 +217,8 @@ Let's take a widget `currencyinput1` use this property to display the selected c
 | Event             | Description                                                                                                                                                                                                                                              |
 | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **onTextChanged** | Sets an an action to take place when the input's value is changed. Can be set from the GUI list of common actions ([examples here](../appsmith-framework/widget-actions/)), or you can define a custom JavaScript function to call instead. |
+| **onFocus**      | Sets an an action to take place when the input area in the currency widget is focused. Can be set from the GUI list of common actions ([examples here](../appsmith-framework/widget-actions/)), or you can define a custom JavaScript function to call instead. |
+| **onBlur**      | Sets an an action to take place when the input area in the currency widget loses focus. Can be set from the GUI list of common actions ([examples here](../appsmith-framework/widget-actions/)), or you can define a custom JavaScript function to call instead. |
 | **onSubmit**      | Sets an an action to take place when the input is submitted with the ENTER key. Can be set from the GUI list of common actions ([examples here](../appsmith-framework/widget-actions/)), or you can define a custom JavaScript function to call instead. |
 
 ### Label

--- a/website/docs/reference/widgets/currency-input.md
+++ b/website/docs/reference/widgets/currency-input.md
@@ -216,10 +216,10 @@ Let's take a widget `currencyinput1` use this property to display the selected c
 
 | Event             | Description                                                                                                                                                                                                                                              |
 | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **onTextChanged** | Sets an an action to take place when the input's value is changed. Can be set from the GUI list of common actions ([examples here](../appsmith-framework/widget-actions/)), or you can define a custom JavaScript function to call instead. |
-| **onFocus**      | Sets an an action to take place when the input area in the currency widget is focused. Can be set from the GUI list of common actions ([examples here](../appsmith-framework/widget-actions/)), or you can define a custom JavaScript function to call instead. |
-| **onBlur**      | Sets an an action to take place when the input area in the currency widget loses focus. Can be set from the GUI list of common actions ([examples here](../appsmith-framework/widget-actions/)), or you can define a custom JavaScript function to call instead. |
-| **onSubmit**      | Sets an an action to take place when the input is submitted with the ENTER key. Can be set from the GUI list of common actions ([examples here](../appsmith-framework/widget-actions/)), or you can define a custom JavaScript function to call instead. |
+| **onTextChanged** | Sets an action to take place when the input's value is changed. Can be set from the GUI list of common actions ([examples here](../appsmith-framework/widget-actions/)), or you can define a custom JavaScript function to call instead. |
+| **onFocus**      | Sets an action to take place when the input area in the currency widget is focused. Can be set from the GUI list of common actions ([examples here](../appsmith-framework/widget-actions/)), or you can define a custom JavaScript function to call instead. |
+| **onBlur**      | Sets an action to take place when the input area in the currency widget loses focus. Can be set from the GUI list of common actions ([examples here](../appsmith-framework/widget-actions/)), or you can define a custom JavaScript function to call instead. |
+| **onSubmit**      | Sets an action to take place when the input is submitted with the ENTER key. Can be set from the GUI list of common actions ([examples here](../appsmith-framework/widget-actions/)), or you can define a custom JavaScript function to call instead. |
 
 ### Label
 

--- a/website/docs/reference/widgets/datepicker.md
+++ b/website/docs/reference/widgets/datepicker.md
@@ -47,6 +47,8 @@ You can define functions that will be called when these events are triggered in 
 | Event              | Description                                                                                                                                                                                                                       |
 | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **onDateSelected** | Sets an an action to take place when a date is selected. Can be set from the GUI list of common actions ([examples here](../appsmith-framework/widget-actions/)), or you can define a custom JavaScript function to call instead. |
+| **onFocus** | Sets an an action to take place when a datepicker is focused. Can be set from the GUI list of common actions ([examples here](../appsmith-framework/widget-actions/)), or you can define a custom JavaScript function to call instead. |
+| **onBlur** | Sets an an action to take place when a datepicker loses focus. Can be set from the GUI list of common actions ([examples here](../appsmith-framework/widget-actions/)), or you can define a custom JavaScript function to call instead. |
 
 ### Label
 

--- a/website/docs/reference/widgets/datepicker.md
+++ b/website/docs/reference/widgets/datepicker.md
@@ -46,9 +46,9 @@ You can define functions that will be called when these events are triggered in 
 
 | Event              | Description                                                                                                                                                                                                                       |
 | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **onDateSelected** | Sets an an action to take place when a date is selected. Can be set from the GUI list of common actions ([examples here](../appsmith-framework/widget-actions/)), or you can define a custom JavaScript function to call instead. |
-| **onFocus** | Sets an an action to take place when a datepicker is focused. Can be set from the GUI list of common actions ([examples here](../appsmith-framework/widget-actions/)), or you can define a custom JavaScript function to call instead. |
-| **onBlur** | Sets an an action to take place when a datepicker loses focus. Can be set from the GUI list of common actions ([examples here](../appsmith-framework/widget-actions/)), or you can define a custom JavaScript function to call instead. |
+| **onDateSelected** | Sets an action to take place when a date is selected. Can be set from the GUI list of common actions ([examples here](../appsmith-framework/widget-actions/)), or you can define a custom JavaScript function to call instead. |
+| **onFocus** | Sets an action to take place when a datepicker is focused. Can be set from the GUI list of common actions ([examples here](../appsmith-framework/widget-actions/)), or you can define a custom JavaScript function to call instead. |
+| **onBlur** | Sets an action to take place when a datepicker loses focus. Can be set from the GUI list of common actions ([examples here](../appsmith-framework/widget-actions/)), or you can define a custom JavaScript function to call instead. |
 
 ### Label
 

--- a/website/docs/reference/widgets/input.md
+++ b/website/docs/reference/widgets/input.md
@@ -205,6 +205,8 @@ Property binding has other applications. For example, it helps in parsing the va
 | Event             | Description                                                                                                                                                                                                                                              |
 | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **onTextChanged** | Sets an an action to take place when the input's value is changed. Can be set from the GUI list of common actions ([examples here](../appsmith-framework/widget-actions/)), or you can define a custom JavaScript function to call instead.              |
+| **onFocus**      | Sets an an action to take place when the input is focused. Can be set from the GUI list of common actions ([examples here](../appsmith-framework/widget-actions/)), or you can define a custom JavaScript function to call instead. |
+| **onBlur**      | Sets an an action to take place when the input is blurred or loses focus. Can be set from the GUI list of common actions ([examples here](../appsmith-framework/widget-actions/)), or you can define a custom JavaScript function to call instead. |
 | **onSubmit**      | Sets an an action to take place when the input is submitted with the ENTER key. Can be set from the GUI list of common actions ([examples here](../appsmith-framework/widget-actions/)), or you can define a custom JavaScript function to call instead. |
 
 ### Label

--- a/website/docs/reference/widgets/input.md
+++ b/website/docs/reference/widgets/input.md
@@ -204,10 +204,10 @@ Property binding has other applications. For example, it helps in parsing the va
 
 | Event             | Description                                                                                                                                                                                                                                              |
 | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **onTextChanged** | Sets an an action to take place when the input's value is changed. Can be set from the GUI list of common actions ([examples here](../appsmith-framework/widget-actions/)), or you can define a custom JavaScript function to call instead.              |
-| **onFocus**      | Sets an an action to take place when the input is focused. Can be set from the GUI list of common actions ([examples here](../appsmith-framework/widget-actions/)), or you can define a custom JavaScript function to call instead. |
-| **onBlur**      | Sets an an action to take place when the input is blurred or loses focus. Can be set from the GUI list of common actions ([examples here](../appsmith-framework/widget-actions/)), or you can define a custom JavaScript function to call instead. |
-| **onSubmit**      | Sets an an action to take place when the input is submitted with the ENTER key. Can be set from the GUI list of common actions ([examples here](../appsmith-framework/widget-actions/)), or you can define a custom JavaScript function to call instead. |
+| **onTextChanged** | Sets an action to take place when the input's value is changed. Can be set from the GUI list of common actions ([examples here](../appsmith-framework/widget-actions/)), or you can define a custom JavaScript function to call instead.              |
+| **onFocus**      | Sets an action to take place when the input is focused. Can be set from the GUI list of common actions ([examples here](../appsmith-framework/widget-actions/)), or you can define a custom JavaScript function to call instead. |
+| **onBlur**      | Sets an action to take place when the input is blurred or loses focus. Can be set from the GUI list of common actions ([examples here](../appsmith-framework/widget-actions/)), or you can define a custom JavaScript function to call instead. |
+| **onSubmit**      | Sets an action to take place when the input is submitted with the ENTER key. Can be set from the GUI list of common actions ([examples here](../appsmith-framework/widget-actions/)), or you can define a custom JavaScript function to call instead. |
 
 ### Label
 

--- a/website/docs/reference/widgets/multi-tree-select.md
+++ b/website/docs/reference/widgets/multi-tree-select.md
@@ -83,6 +83,8 @@ They're a set of actions that you can perform on the widget. The following table
 | Events             | Description                                                                                                                                    |
 | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | **onOptionChange** | Sets the action to be run when the user selects/unselects an option. See a list of [supported actions](../appsmith-framework/widget-actions/). |
+| **onDropdownOpen** | Sets the action to be run when the user opens the dropdown. See a list of [supported actions](../appsmith-framework/widget-actions/). |
+| **onDropdownClose** | Sets the action to be run when the user opens the dropdown. See a list of [supported actions](../appsmith-framework/widget-actions/). |
 
 ### Label
 

--- a/website/docs/reference/widgets/multiselect.md
+++ b/website/docs/reference/widgets/multiselect.md
@@ -47,6 +47,8 @@ They are a set of actions that you can perform on the widget. The following tabl
 | Events             | Description                                                                                                                                    |
 | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | **onOptionChange** | Sets the action to be run when the user selects/unselects an option. See a list of [supported actions](../appsmith-framework/widget-actions/). |
+| **onDropdownOpen** | Sets the action to be run when the user opens the dropdown. See a list of [supported actions](../appsmith-framework/widget-actions/). |
+| **onDropdownClose** | Sets the action to be run when the user opens the dropdown. See a list of [supported actions](../appsmith-framework/widget-actions/). |
 
 ### Label
 

--- a/website/docs/reference/widgets/phone-input.md
+++ b/website/docs/reference/widgets/phone-input.md
@@ -225,6 +225,8 @@ They are a set of actions that you can perform on the widget. The following tabl
 | Event             | Description                                                                                                                                  |
 | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | **onTextChanged** | Sets the action to run when the user enters or changes its inputs. See a list of [supported actions](../appsmith-framework/widget-actions/). |
+| **onFocus** | Sets the action to run when the input area in the phone widget is focused. See a list of [supported actions](../appsmith-framework/widget-actions/). |
+| **onBlur** | Sets the action to run when the input area in the phone widget loses focus. See a list of [supported actions](../appsmith-framework/widget-actions/). |
 | **onSubmit**      | Triggers an action on submit (when the enter key is pressed). See a list of [supported actions](../appsmith-framework/widget-actions/).      |
 
 ### Label

--- a/website/docs/reference/widgets/select.md
+++ b/website/docs/reference/widgets/select.md
@@ -79,6 +79,8 @@ These are functions that are called when event listeners are triggered in the wi
 | Events             | Description                                                                                                                                    |
 | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | **onOptionChange** | Sets the action to be run when the user selects/unselects an option. See a list of [supported actions](../appsmith-framework/widget-actions/). |
+| **onDropdownOpen** | Sets the action to be run when the user opens the dropdown. See a list of [supported actions](../appsmith-framework/widget-actions/). |
+| **onDropdownClose** | Sets the action to be run when the user opens the dropdown. See a list of [supported actions](../appsmith-framework/widget-actions/). |
 
 ### Label
 

--- a/website/docs/reference/widgets/tree-select.md
+++ b/website/docs/reference/widgets/tree-select.md
@@ -81,6 +81,8 @@ They are a set of actions that you can perform on the widget. The following tabl
 | Events             | Description                                                                                                                 |
 | ------------------ | --------------------------------------------------------------------------------------------------------------------------- |
 | **onOptionChange** | Triggers an action when a user selects an option. See a list of [supported actions](../appsmith-framework/widget-actions/). |
+| **onDropdownOpen** | Sets the action to be run when the user opens the dropdown. See a list of [supported actions](../appsmith-framework/widget-actions/). |
+| **onDropdownClose** | Sets the action to be run when the user opens the dropdown. See a list of [supported actions](../appsmith-framework/widget-actions/). |
 
 ### Label
 


### PR DESCRIPTION
Fixes - #668 

Within the following widgets there are new events
1. Input widgets - Input, currency, phone - They now support onFocus and onBlur functionality
2. Select widgets - Select, multiselect, multi-tree, tree - They now support onDropdownOpen and onDropdownClose functionality
3. Datepicker - It now supports onFocus and onBlur functionality
