### PR TITLE
fix: Typo fix in the git readme

### DIFF
--- a/website/docs/advanced-concepts/version-control-with-git/README.md
+++ b/website/docs/advanced-concepts/version-control-with-git/README.md
@@ -30,7 +30,7 @@ In the community edition, You can connect up to **three** private repositories i
 
 ## Git In Action
 
-Once your app connects to the Git repository, you can further learn how version control works on Appsmith.\
+Once your app connects to the Git repository, you can further learn how version control works on Appsmith.
 The flow is similar to how you work on Git -
 
 * [Commit and Push](commit-and-push.md)


### PR DESCRIPTION
Removal of `\` that was showing up in https://docs.appsmith.com/advanced-concepts/version-control-with-git

<img width="687" alt="Screenshot 2023-01-18 at 5 00 51 PM" src="https://user-images.githubusercontent.com/16632903/213161582-72075d74-7de3-4735-a436-08922608a1b7.png">
