### PR TITLE
docs: Mentioned Watchtower needs hooks enabled for auto-backup 

### DIFF
--- a/.github/styles/Microsoft/Auto.yml
+++ b/.github/styles/Microsoft/Auto.yml
@@ -9,3 +9,5 @@ action:
     - simple
 tokens:
   - 'auto-\w+'
+exceptions:
+  - auto-backup

--- a/website/docs/getting-started/setup/installation-guides/docker/README.mdx
+++ b/website/docs/getting-started/setup/installation-guides/docker/README.mdx
@@ -1,4 +1,4 @@
----
+  ---
 description: Appsmith can be deployed locally or on a private instance using Docker
 sidebar_position: 1
 ---
@@ -7,7 +7,7 @@ import TabItem from '@theme/TabItem';
 
 # Docker
 
-Docker is an open source [containerization](https://www.ibm.com/in-en/cloud/learn/containerization) platform. It enables developers to package applications into standardized executable components called containers. These containers combine the application's source code with the Operating System (OS) libraries and dependencies required to run that code in any environment.
+Docker is an open-source [containerization](https://www.ibm.com/in-en/cloud/learn/containerization) platform. It enables developers to package applications into standardized executable components called containers. These containers combine the application's source code with the Operating System (OS) libraries and dependencies required to run that code in any environment.
 
 <VideoEmbed host="youtube" videoId="Tde7GqE6FQQ" /> 
 
@@ -21,12 +21,12 @@ Docker is an open source [containerization](https://www.ibm.com/in-en/cloud/lear
 
 ## Setup with Docker Compose _(recommended)_
 
-The Appsmith Docker image contains all the components required to run, within a single Docker container. All these multiple processes are managed by a [Supervisord](http://supervisord.org/) instance, which is a lightweight process manager.
+The Appsmith Docker image contains all the components required to run within a single Docker container. All these multiple processes are managed by a [Supervisord](http://supervisord.org/) instance, which is a lightweight process manager.
 
 <Tabs groupId="editions" >
    <TabItem label="Community Edition" value="community">
 
-1. Click to download the [`docker-compose.yml`](https://bit.ly/3h08WqB) file, and place it into the Appsmith installation folder.
+1. Click to download the [`docker-compose.yml`](https://bit.ly/3h08WqB) file and place it into the Appsmith installation folder.
 
    **OR,** run the following cURL:
 
@@ -40,7 +40,7 @@ The Appsmith Docker image contains all the components required to run, within a 
    docker-compose up -d
    ```
 
-The Appsmith server should be up and running soon, and it can be accessed at [http://localhost](http://localhost). Check the [Docker logs](#docker-logs) to verify that the instance is working correctly.
+The Appsmith server should be up and running soon and can be accessed at [http://localhost](http://localhost). Check the [Docker logs](#docker-logs) to verify that the instance is working correctly.
 
    </TabItem>
    <TabItem label="Business Edition" value="business">
@@ -74,14 +74,14 @@ To upgrade from Community Edition to Business Edition, [follow these instruction
    docker-compose up -d
    ```
 
-The Appsmith server should be up and running soon, and it can be accessed at [http://localhost](http://localhost). Check the [Docker logs](#docker-logs) to verify that the instance is working correctly.
+The Appsmith server should be up and running soon and can be accessed at [http://localhost](http://localhost). Check the [Docker logs](#docker-logs) to verify that the instance is working correctly.
 
    </TabItem>
 </Tabs>
 
 ### Updating Appsmith
 :::caution
-   It's recommended to take a backup of the Appsmith instance before performing an update. For more information, see [How to create a backup](https://docs.appsmith.com/getting-started/setup/instance-management/appsmithctl#backup-appsmith-instance).
+   It's recommended to backup the Appsmith instance before performing an update. For more information, see [How to create a backup](https://docs.appsmith.com/getting-started/setup/instance-management/appsmithctl#backup-appsmith-instance).
 :::
 
 To update Appsmith manually, go to the root directory of the installation and run the following command:
@@ -90,7 +90,7 @@ To update Appsmith manually, go to the root directory of the installation and ru
 docker-compose pull && docker-compose rm -fsv appsmith && docker-compose up -d
 ```
 
-### Enabling Appsmith auto updates
+### Enabling Appsmith auto-updates
 
 Automatic updates are turned off by default in the `docker-compose.yml` file. To enable them, please follow these steps:
 
@@ -107,13 +107,13 @@ Automatic updates are turned off by default in the `docker-compose.yml` file. To
    docker-compose up -d
    ```
 
-In addition to automatic updates, Appsmith also offers an auto backup feature. Before any update, Appsmith creates a backup, which can be used to rollback to a previous version of Appsmith, in case the update needs to be undone. For more information, see [the rollback instructions using appsmithctl command](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance). To ensure successful auto backup and update tasks, a minimum of 2 GB of free storage must be available; otherwise, both the backup and update tasks may fail.
+In addition to automatic updates, Appsmith also offers an auto backup feature. Before any update, Appsmith creates a backup, which can be used to rollback to a previous version of Appsmith in case the update needs to be undone. For more information, see [the rollback instructions using the `appsmithctl` command](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance). To ensure successful auto backup and update tasks, a minimum of 2 GB of free storage must be available; otherwise, both the backup and update tasks may fail.
 
 :::note 
 To ensure automatic backups before updates, enable the `WATCHTOWER_LIFECYCLE_HOOKS` environment variable in the [docker-compose.yaml](https://bit.ly/3h08WqB) file on the Watchtower instance.
 :::
 
-If you update your Appsmith instance and face any issues you can rollback the changes and [restore the Appsmith instance](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance) from a backup archive. This configuration runs an Appsmith instance and a Watchtower instance to keep Appsmith automatically up-to-date. The installation is now configured to stay up-to-date automatically.
+If you have updated your Appsmith instance and face any issues. You can rollback the changes and [restore the Appsmith instance](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance) from a backup archive. This configuration runs an Appsmith instance and a Watchtower instance to keep Appsmith automatically up-to-date. The installation is now configured to stay up-to-date automatically.
 
 ---
 
@@ -183,12 +183,12 @@ You can follow the **frontend logs** with the following command:
 docker logs -f appsmith
 ```
 
-**Backend logs** are stored in `stacks/logs/backend/backend.log`. Backend logs can assist in debugging by providing information on requests, responses, and errors. They can help identify and resolve problems in your application. For more information on backend logs, check this [guide](https://github.com/felix-appsmith/guide-how-to-get-logs-appsmith).
+**Backend logs** are stored in `stacks/logs/backend/backend.log`. Backend logs can assist debugging by providing information on requests, responses, and errors. They can help identify and resolve problems in your application. For more information, see [How to get backend logs](https://github.com/felix-appsmith/guide-how-to-get-logs-appsmith).
 
 
 ## Restarting containers
 
-If the Docker containers are failing to restart, download ,and run the [`restart-container.sh`](/img/restart-container.sh) script linked below to bring them up:
+If the Docker containers are failing to restart, download and run the [`restart-container.sh`](/img/restart-container.sh) script linked below to bring them up:
 
 Copy the script (`restart-container.sh`) to the installation folder and make it executable:
 
@@ -199,10 +199,12 @@ chmod +x restart-container.sh
 
 ## Troubleshooting
 
-If there are any errors during this process, follow the guide on [debugging deployment errors](/help-and-support/troubleshooting-guide/deployment-errors). If there are still issues, please contact [support@appsmith.com](mailto:support@appsmith.com) or join the Appsmith [Discord Server](https://discord.com/invite/rBTTVJp) to speak to the Appsmith team directly.
+If there are any errors during this process, follow the guide on [debugging deployment errors](/help-and-support/troubleshooting-guide/deployment-errors). If there are still issues, please get in touch with [support@appsmith.com](mailto:support@appsmith.com) or join the Appsmith [Discord Server](https://discord.com/invite/rBTTVJp) to speak to the Appsmith team directly.
 
 ## Further reading
 
 * [Configuring Self Hosted Instances](/getting-started/setup/instance-configuration/#configuring-docker-installations)
 * [Managing the Appsmith instance](/getting-started/setup/instance-management/)
 * [Tutorials](/learning-and-resources/tutorials/)
+
+  

--- a/website/docs/getting-started/setup/installation-guides/docker/README.mdx
+++ b/website/docs/getting-started/setup/installation-guides/docker/README.mdx
@@ -110,7 +110,7 @@ To complement automatic updates, Appsmith also has an auto backup feature. Befor
 :::note Appsmith relies on the Watchtower hook to perform an auto-backup before an update. Ensure that the WATCHTOWER_LIFECYCLE_HOOKS environment variable is enabled on the Watchtower instance in the [docker-compose.yaml](https://bit.ly/3h08WqB).
 :::
 
-Please refer to this(/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance) to rollback the Appsmith data using the backup archives.
+If you update your Appsmith instance and face any issues you can rollback the changes and [restore the Appsmith instance](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance) from a backup archive.
 
 This configuration runs an Appsmith instance and a Watchtower instance to keep Appsmith automatically up-to-date. The installation is now configured to stay up-to-date automatically.
 

--- a/website/docs/getting-started/setup/installation-guides/docker/README.mdx
+++ b/website/docs/getting-started/setup/installation-guides/docker/README.mdx
@@ -80,6 +80,8 @@ The Appsmith server should be up and running soon, and it can be accessed at [ht
 </Tabs>
 
 ### Updating Appsmith
+::::info
+   We recommend creating a backup of the Appsmith instance before performing an update. Please refer to the instructions here (https://docs.appsmith.com/getting-started/setup/instance-management/appsmithctl#backup-appsmith-instance) to create a backup.
 
 To update Appsmith manually, go to the root directory of the installation and run the following command:
 
@@ -106,7 +108,9 @@ Automatic updates are turned off by default in the docker-compose.yml file. To e
 
 :::info
 To complement automatic updates, Appsmith also has an auto backup feature. Before an automatic update, Appsmith first creates a backup to allow [rolling back](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance) an update to a previous version of Appsmith if necessary. For this auto backup to work, please ensure that there is a minimum of 2 GB of free storage; otherwise, both the backup and update tasks fail.
-:::
+Appsmith relies on the Watchtower hook to perform an auto-backup before an update. Please ensure the WATCHTOWER_LIFECYCLE_HOOKS env is enabled on the Watchtower instance. Refer to the docker-compose.yaml at https://bit.ly/3h08WqB.
+
+Please refer to this(/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance) to rollback the Appsmith data using the backup archives.
 
 This configuration runs an Appsmith instance and a Watchtower instance to keep Appsmith automatically up-to-date. The installation is now configured to stay up-to-date automatically.
 

--- a/website/docs/getting-started/setup/installation-guides/docker/README.mdx
+++ b/website/docs/getting-started/setup/installation-guides/docker/README.mdx
@@ -81,7 +81,8 @@ The Appsmith server should be up and running soon, and it can be accessed at [ht
 
 ### Updating Appsmith
 :::caution
-   We recommend creating a backup of the Appsmith instance before performing an update. Please refer to the instructions here (https://docs.appsmith.com/getting-started/setup/instance-management/appsmithctl#backup-appsmith-instance) to create a backup.
+   It's recommended to take a backup of the Appsmith instance before performing an update. For more information, see [How to create a backup](https://docs.appsmith.com/getting-started/setup/instance-management/appsmithctl#backup-appsmith-instance).
+:::
 
 To update Appsmith manually, go to the root directory of the installation and run the following command:
 
@@ -91,7 +92,7 @@ docker-compose pull && docker-compose rm -fsv appsmith && docker-compose up -d
 
 ### Enabling Appsmith auto updates
 
-Automatic updates are turned off by default in the docker-compose.yml file. To enable them, please follow these steps:
+Automatic updates are turned off by default in the `docker-compose.yml` file. To enable them, please follow these steps:
 
 1. Go to the root directory of the Appsmith installation and run:
 
@@ -106,13 +107,13 @@ Automatic updates are turned off by default in the docker-compose.yml file. To e
    docker-compose up -d
    ```
 
-To complement automatic updates, Appsmith also has an auto backup feature. Before an automatic update, Appsmith first creates a backup to provide a way to [rollback](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance) the update to a previous version of Appsmith if necessary. For this auto backup to work, please ensure that there is a minimum of 2 GB of free storage; otherwise, both the backup and update tasks may fail.
-:::note Appsmith relies on the Watchtower hook to perform an auto-backup before an update. Ensure that the WATCHTOWER_LIFECYCLE_HOOKS environment variable is enabled on the Watchtower instance in the [docker-compose.yaml](https://bit.ly/3h08WqB).
+In addition to automatic updates, Appsmith also offers an auto backup feature. Before any update, Appsmith creates a backup, which can be used to rollback to a previous version of Appsmith, in case the update needs to be undone. For more information, see [the rollback instructions using appsmithctl command](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance). To ensure successful auto backup and update tasks, a minimum of 2 GB of free storage must be available; otherwise, both the backup and update tasks may fail.
+
+:::note 
+To ensure automatic backups before updates, enable the `WATCHTOWER_LIFECYCLE_HOOKS` environment variable in the [docker-compose.yaml](https://bit.ly/3h08WqB) file on the Watchtower instance.
 :::
 
-If you update your Appsmith instance and face any issues you can rollback the changes and [restore the Appsmith instance](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance) from a backup archive.
-
-This configuration runs an Appsmith instance and a Watchtower instance to keep Appsmith automatically up-to-date. The installation is now configured to stay up-to-date automatically.
+If you update your Appsmith instance and face any issues you can rollback the changes and [restore the Appsmith instance](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance) from a backup archive. This configuration runs an Appsmith instance and a Watchtower instance to keep Appsmith automatically up-to-date. The installation is now configured to stay up-to-date automatically.
 
 ---
 

--- a/website/docs/getting-started/setup/installation-guides/docker/README.mdx
+++ b/website/docs/getting-started/setup/installation-guides/docker/README.mdx
@@ -1,4 +1,4 @@
-  ---
+---
 description: Appsmith can be deployed locally or on a private instance using Docker
 sidebar_position: 1
 ---
@@ -7,7 +7,7 @@ import TabItem from '@theme/TabItem';
 
 # Docker
 
-Docker is an open-source [containerization](https://www.ibm.com/in-en/cloud/learn/containerization) platform. It enables developers to package applications into standardized executable components called containers. These containers combine the application's source code with the Operating System (OS) libraries and dependencies required to run that code in any environment.
+Docker is an open source [containerization](https://www.ibm.com/in-en/cloud/learn/containerization) platform. It enables developers to package applications into standardized executable components called containers. These containers combine the application's source code with the Operating System (OS) libraries and dependencies required to run that code in any environment.
 
 <VideoEmbed host="youtube" videoId="Tde7GqE6FQQ" /> 
 
@@ -90,7 +90,7 @@ To update Appsmith manually, go to the root directory of the installation and ru
 docker-compose pull && docker-compose rm -fsv appsmith && docker-compose up -d
 ```
 
-### Enabling Appsmith auto-updates
+### Enabling Appsmith auto updates
 
 Automatic updates are turned off by default in the `docker-compose.yml` file. To enable them, please follow these steps:
 
@@ -188,7 +188,7 @@ docker logs -f appsmith
 
 ## Restarting containers
 
-If the Docker containers are failing to restart, download and run the [`restart-container.sh`](/img/restart-container.sh) script linked below to bring them up:
+If the Docker containers are failing to restart, download, and run the [`restart-container.sh`](/img/restart-container.sh) script linked below to bring them up:
 
 Copy the script (`restart-container.sh`) to the installation folder and make it executable:
 
@@ -199,7 +199,7 @@ chmod +x restart-container.sh
 
 ## Troubleshooting
 
-If there are any errors during this process, follow the guide on [debugging deployment errors](/help-and-support/troubleshooting-guide/deployment-errors). If there are still issues, please get in touch with [support@appsmith.com](mailto:support@appsmith.com) or join the Appsmith [Discord Server](https://discord.com/invite/rBTTVJp) to speak to the Appsmith team directly.
+If there are any errors during this process, follow the guide on [debugging deployment errors](/help-and-support/troubleshooting-guide/deployment-errors) or send an email to [support@appsmith.com](mailto:support@appsmith.com) or join the Appsmith [Discord Server](https://discord.com/invite/rBTTVJp) to speak to the Appsmith team directly.
 
 ## Further reading
 

--- a/website/docs/getting-started/setup/installation-guides/docker/README.mdx
+++ b/website/docs/getting-started/setup/installation-guides/docker/README.mdx
@@ -80,7 +80,7 @@ The Appsmith server should be up and running soon, and it can be accessed at [ht
 </Tabs>
 
 ### Updating Appsmith
-::::info
+:::caution
    We recommend creating a backup of the Appsmith instance before performing an update. Please refer to the instructions here (https://docs.appsmith.com/getting-started/setup/instance-management/appsmithctl#backup-appsmith-instance) to create a backup.
 
 To update Appsmith manually, go to the root directory of the installation and run the following command:

--- a/website/docs/getting-started/setup/installation-guides/docker/README.mdx
+++ b/website/docs/getting-started/setup/installation-guides/docker/README.mdx
@@ -106,7 +106,7 @@ Automatic updates are turned off by default in the docker-compose.yml file. To e
    docker-compose up -d
    ```
 
-To complement automatic updates, Appsmith also has an auto backup feature. Before an automatic update, Appsmith first creates a backup to allow [rolling back](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance) an update to a previous version of Appsmith if necessary. For this auto backup to work, please ensure that there is a minimum of 2 GB of free storage; otherwise, both the backup and update tasks fail.
+To complement automatic updates, Appsmith also has an auto backup feature. Before an automatic update, Appsmith first creates a backup to provide a way to [rollback](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance) the update to a previous version of Appsmith if necessary. For this auto backup to work, please ensure that there is a minimum of 2 GB of free storage; otherwise, both the backup and update tasks may fail.
 :::note Appsmith relies on the Watchtower hook to perform an auto-backup before an update. Ensure that the WATCHTOWER_LIFECYCLE_HOOKS environment variable is enabled on the Watchtower instance in the [docker-compose.yaml](https://bit.ly/3h08WqB).
 :::
 

--- a/website/docs/getting-started/setup/installation-guides/docker/README.mdx
+++ b/website/docs/getting-started/setup/installation-guides/docker/README.mdx
@@ -106,7 +106,6 @@ Automatic updates are turned off by default in the docker-compose.yml file. To e
    docker-compose up -d
    ```
 
-:::info
 To complement automatic updates, Appsmith also has an auto backup feature. Before an automatic update, Appsmith first creates a backup to allow [rolling back](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance) an update to a previous version of Appsmith if necessary. For this auto backup to work, please ensure that there is a minimum of 2 GB of free storage; otherwise, both the backup and update tasks fail.
 Appsmith relies on the Watchtower hook to perform an auto-backup before an update. Please ensure the WATCHTOWER_LIFECYCLE_HOOKS env is enabled on the Watchtower instance. Refer to the docker-compose.yaml at https://bit.ly/3h08WqB.
 

--- a/website/docs/getting-started/setup/installation-guides/docker/README.mdx
+++ b/website/docs/getting-started/setup/installation-guides/docker/README.mdx
@@ -107,7 +107,8 @@ Automatic updates are turned off by default in the docker-compose.yml file. To e
    ```
 
 To complement automatic updates, Appsmith also has an auto backup feature. Before an automatic update, Appsmith first creates a backup to allow [rolling back](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance) an update to a previous version of Appsmith if necessary. For this auto backup to work, please ensure that there is a minimum of 2 GB of free storage; otherwise, both the backup and update tasks fail.
-Appsmith relies on the Watchtower hook to perform an auto-backup before an update. Please ensure the WATCHTOWER_LIFECYCLE_HOOKS env is enabled on the Watchtower instance. Refer to the docker-compose.yaml at https://bit.ly/3h08WqB.
+:::note Appsmith relies on the Watchtower hook to perform an auto-backup before an update. Ensure that the WATCHTOWER_LIFECYCLE_HOOKS environment variable is enabled on the Watchtower instance in the [docker-compose.yaml](https://bit.ly/3h08WqB).
+:::
 
 Please refer to this(/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance) to rollback the Appsmith data using the backup archives.
 


### PR DESCRIPTION
- Adding more Instructions to map backup/restore with Appsmith updates, so that searching for rollback points to appsmithctl backup/restore.
    - Recommend users to backup before manual update
    - Link to restore using a backup on auto-backup section
- Mentioned Watchtower requirements for auto-backup to be enabled.