### PR TITLE
fix: use latest watchtower tag

### DIFF
--- a/website/static/img/docker-compose_(3).yml
+++ b/website/static/img/docker-compose_(3).yml
@@ -15,7 +15,7 @@ services:
     #  com.centurylinklabs.watchtower.enable: "true"
 
   #auto_update:
-  #  image: containrrr/watchtower:latest-dev
+  #  image: containrrr/watchtower
   #  volumes:
   #    - /var/run/docker.sock:/var/run/docker.sock
   #  # Update check interval in seconds.


### PR DESCRIPTION
Updated docker-compose.yml : Watcher now uses latest image tag