### PR TITLE
fix: update watchtower hook env and tag

### DIFF
--- a/.gitbook/assets/docker-compose.yml
+++ b/.gitbook/assets/docker-compose.yml
@@ -10,14 +10,18 @@ services:
     volumes:
       - ./stacks:/appsmith-stacks
     restart: unless-stopped
-  #   # Uncomment the lines below to enable auto-update
-  #   labels:
-  #     com.centurylinklabs.watchtower.enable: "true"
+    # Uncomment the lines below to enable auto-update
+    #labels:
+    #  com.centurylinklabs.watchtower.enable: "true"
 
-  # auto_update:
-  #   image: containrrr/watchtower:latest-dev
-  #   volumes:
-  #     - /var/run/docker.sock:/var/run/docker.sock
-  #   # Update check interval in seconds.
-  #   command: --schedule "0 0 * ? * *" --label-enable --cleanup
-  #   restart: unless-stopped
+  #auto_update:
+  #  image: containrrr/watchtower
+  #  volumes:
+  #    - /var/run/docker.sock:/var/run/docker.sock
+  #  # Update check interval in seconds.
+  #  command: --schedule "0 0 * ? * *" --label-enable --cleanup
+  #  restart: unless-stopped
+  #  depends_on:
+  #    - appsmith
+  #  environment:
+  #    - WATCHTOWER_LIFECYCLE_HOOKS=true


### PR DESCRIPTION
Updated the docker-compose.yml in the old gitbook assets since our marketplace builds still use this resource.