### PR TITLE
fix: Copy button copies four spaces in the start

### DIFF
--- a/website/docs/getting-started/setup/installation-guides/docker/install-business-edition.mdx
+++ b/website/docs/getting-started/setup/installation-guides/docker/install-business-edition.mdx
@@ -8,7 +8,7 @@ Follow the steps listed below to install Appsmith on docker:
 <ul class="circle"> 
 <li>Download and place the <a href="https://bit.ly/docker-compose-business"><code>docker-compose.yml</code></a> file in the Appsmith installation folder or run the cURL command.
 
-        curl -L https://bit.ly/docker-compose-business -o $PWD/docker-compose.yml
+    curl -L https://bit.ly/docker-compose-business -o $PWD/docker-compose.yml
     
 </li> 
 <li>Start the Docker container using the command <code>docker-compose up -d</code> (You may need to run with <code>sudo</code>).</li> 

--- a/website/docs/getting-started/setup/installation-guides/docker/install-business-edition.mdx
+++ b/website/docs/getting-started/setup/installation-guides/docker/install-business-edition.mdx
@@ -8,7 +8,7 @@ Follow the steps listed below to install Appsmith on docker:
 <ul class="circle"> 
 <li>Download and place the <a href="https://bit.ly/docker-compose-business"><code>docker-compose.yml</code></a> file in the Appsmith installation folder or run the cURL command.
 
-    curl -L https://bit.ly/docker-compose-business -o $PWD/docker-compose.yml
+        curl -L https://bit.ly/docker-compose-business -o $PWD/docker-compose.yml
     
 </li> 
 <li>Start the Docker container using the command <code>docker-compose up -d</code> (You may need to run with <code>sudo</code>).</li> 


### PR DESCRIPTION
The copy button on this code block is copying the curl command with four additional spaces in the start. This PR fixes that.