### PR TITLE
fix: Update migrate-to-helm-chart-v2-ce backup file name

### DIFF
--- a/website/docs/getting-started/setup/installation-guides/kubernetes/migrate-to-helm-chart-v2-ce.md
+++ b/website/docs/getting-started/setup/installation-guides/kubernetes/migrate-to-helm-chart-v2-ce.md
@@ -17,7 +17,7 @@ Take a backup using the [`appsmithctl backup`](/getting-started/setup/instance-m
 2. Copy the backup to local disk. The actual backup file's name should be available in the output of the previous step.
 
    ```bash
-   kubectl cp <NAMESPACE>/<POD_NAME>:/appsmith-stacks/data/backup/<APPSMITH_BACKUP_GENERATED_NAME>.tar.gz appsmith_backup.tar.gz
+   kubectl cp <NAMESPACE>/<POD_NAME>:/appsmith-stacks/data/backup/<APPSMITH_BACKUP_GENERATED_NAME>.tar.gz <APPSMITH_BACKUP_GENERATED_NAME>.tar.gz
    ```
 
 ## Uninstall old Helm chart


### PR DESCRIPTION
The backup tar must have timestamp it in, otherwise `backup` would not work.