### PR TITLE
fix: Notes for lack of HS256 support

### DIFF
--- a/website/docs/getting-started/setup/instance-configuration/authentication/openid-connect-oidc/active-directory.md
+++ b/website/docs/getting-started/setup/instance-configuration/authentication/openid-connect-oidc/active-directory.md
@@ -51,7 +51,7 @@ On the application homepage, go to the overview tab and perform the following ac
 
 ![Appsmith - OIDC Setup](/img/Appsmith-Admin-Settings-Authentication-OIDC-Setup.png)
 
-> `RS256` is the default Token Signing Algorithm used by Appsmith and most identity providers. If you have a custom setup, you can choose from one of the supported algorithms under the Advanced section of the Appsmith OIDC setup page. Please note, the `HS256` algorithm isn't supported for signing tokens.
+> `RS256` is the default Token Signing Algorithm used by Appsmith and most identity providers. If you have a custom setup, you can choose from one of the supported algorithms under the Advanced section of the Appsmith OIDC setup page. Please note, verifying tokens signed with the `HS256` algorithm isn't supported.
 
 ### Configure Scopes
 

--- a/website/docs/getting-started/setup/instance-configuration/authentication/openid-connect-oidc/active-directory.md
+++ b/website/docs/getting-started/setup/instance-configuration/authentication/openid-connect-oidc/active-directory.md
@@ -51,6 +51,8 @@ On the application homepage, go to the overview tab and perform the following ac
 
 ![Appsmith - OIDC Setup](/img/Appsmith-Admin-Settings-Authentication-OIDC-Setup.png)
 
+> `RS256` is the default Token Signing Algorithm used by Appsmith and most identity providers. If you have a custom setup, you can choose from one of the supported algorithms under the Advanced section of the OIDC page. Please note, the `HS256` algorithm isn't supported for signing tokens.
+
 ### Configure Scopes
 
 The scope defines the OpenID Connect (OIDC) scopes that allow you to authorize the access of user details ( after a user is successfully authenticated) like name, email, profile picture, and more. Each scope maps to a set of user attributes and returns its value. You'll see the Scope field below the **JSON Web Key Set**:

--- a/website/docs/getting-started/setup/instance-configuration/authentication/openid-connect-oidc/active-directory.md
+++ b/website/docs/getting-started/setup/instance-configuration/authentication/openid-connect-oidc/active-directory.md
@@ -51,7 +51,7 @@ On the application homepage, go to the overview tab and perform the following ac
 
 ![Appsmith - OIDC Setup](/img/Appsmith-Admin-Settings-Authentication-OIDC-Setup.png)
 
-> `RS256` is the default Token Signing Algorithm used by Appsmith and most identity providers. If you have a custom setup, you can choose from one of the supported algorithms under the Advanced section of the OIDC page. Please note, the `HS256` algorithm isn't supported for signing tokens.
+> `RS256` is the default Token Signing Algorithm used by Appsmith and most identity providers. If you have a custom setup, you can choose from one of the supported algorithms under the Advanced section of the Appsmith OIDC setup page. Please note, the `HS256` algorithm isn't supported for signing tokens.
 
 ### Configure Scopes
 

--- a/website/docs/getting-started/setup/instance-configuration/authentication/openid-connect-oidc/auth0.md
+++ b/website/docs/getting-started/setup/instance-configuration/authentication/openid-connect-oidc/auth0.md
@@ -46,7 +46,7 @@ To continue with the OIDC setup on Appsmith, navigate to Auth0 configurations an
 
 ![Appsmith OIDC Configurations](/img/Appsmith-Admin-Settings-Authentication-OIDC-Setup.png)
 
-> `RS256` is the default Token Signing Algorithm used by Appsmith and most IDPs. If you have a custom setup, you can choose from one of our supported algorithms under the Advanced section of the OIDC page. Please note, the `HS256` algorithm is not supported for signing tokens.
+> `RS256` is the default Token Signing Algorithm used by Appsmith and most identity providers. If you have a custom setup, you can choose from one of the supported algorithms under the Advanced section of the OIDC page. Please note, the `HS256` algorithm isn't supported for signing tokens.
 
 ### Configuring Scopes for Auth0
 

--- a/website/docs/getting-started/setup/instance-configuration/authentication/openid-connect-oidc/auth0.md
+++ b/website/docs/getting-started/setup/instance-configuration/authentication/openid-connect-oidc/auth0.md
@@ -46,7 +46,7 @@ To continue with the OIDC setup on Appsmith, navigate to Auth0 configurations an
 
 ![Appsmith OIDC Configurations](/img/Appsmith-Admin-Settings-Authentication-OIDC-Setup.png)
 
-> `RS256` is the default Token Signing Algorithm used by Appsmith and most identity providers. If you have a custom setup, you can choose from one of the supported algorithms under the Advanced section of the OIDC page. Please note, the `HS256` algorithm isn't supported for signing tokens.
+> `RS256` is the default Token Signing Algorithm used by Appsmith and most identity providers. If you have a custom setup, you can choose from one of the supported algorithms under the Advanced section of the Appsmith OIDC setup page. Please note, the `HS256` algorithm isn't supported for signing tokens.
 
 ### Configuring Scopes for Auth0
 

--- a/website/docs/getting-started/setup/instance-configuration/authentication/openid-connect-oidc/auth0.md
+++ b/website/docs/getting-started/setup/instance-configuration/authentication/openid-connect-oidc/auth0.md
@@ -46,6 +46,8 @@ To continue with the OIDC setup on Appsmith, navigate to Auth0 configurations an
 
 ![Appsmith OIDC Configurations](/img/Appsmith-Admin-Settings-Authentication-OIDC-Setup.png)
 
+> `RS256` is the default Token Signing Algorithm used by Appsmith and most IDPs. If you have a custom setup, you can choose from one of our supported algorithms under the Advanced section of the OIDC page. Please note, the `HS256` algorithm is not supported for signing tokens.
+
 ### Configuring Scopes for Auth0
 
 The scope defines the OpenID Connect (OIDC) scopes that allow you to authorize the access of user details (after a user is successfully authenticated) like name, email, profile picture, and more. Each scope maps to a set of user attributes and returns its value. Just below the **JSON Web Key Set,** you’ll see the **Scope** field:

--- a/website/docs/getting-started/setup/instance-configuration/authentication/openid-connect-oidc/auth0.md
+++ b/website/docs/getting-started/setup/instance-configuration/authentication/openid-connect-oidc/auth0.md
@@ -46,7 +46,7 @@ To continue with the OIDC setup on Appsmith, navigate to Auth0 configurations an
 
 ![Appsmith OIDC Configurations](/img/Appsmith-Admin-Settings-Authentication-OIDC-Setup.png)
 
-> `RS256` is the default Token Signing Algorithm used by Appsmith and most identity providers. If you have a custom setup, you can choose from one of the supported algorithms under the Advanced section of the Appsmith OIDC setup page. Please note, the `HS256` algorithm isn't supported for signing tokens.
+> `RS256` is the default Token Signing Algorithm used by Appsmith and most identity providers. If you have a custom setup, you can choose from one of the supported algorithms under the Advanced section of the Appsmith OIDC setup page. Please note, verifying tokens signed with the `HS256` algorithm isn't supported.
 
 ### Configuring Scopes for Auth0
 

--- a/website/docs/getting-started/setup/instance-configuration/authentication/openid-connect-oidc/okta.md
+++ b/website/docs/getting-started/setup/instance-configuration/authentication/openid-connect-oidc/okta.md
@@ -70,6 +70,8 @@ To continue with the OIDC setup on Appsmith, navigate to the fields on the Okta 
 
 ![Appsmith - OIDC Setup](/img/Appsmith-Admin-Settings-Authentication-OIDC-Setup.png)
 
+> `RS256` is the default Token Signing Algorithm used by Appsmith and most identity providers. If you have a custom setup, you can choose from one of the supported algorithms under the Advanced section of the Appsmith OIDC setup page. Please note, the `HS256` algorithm isn't supported for signing tokens.
+
 ### Configure Scopes for Okta
 
 The scope defines the OpenID Connect (OIDC) scopes that allow you to authorize the access of user details ( after a user is successfully authenticated) like name, email, profile picture, and more. Each scope maps to a set of user attributes and returns its value. Just below the **JSON Web Key Set,** you’ll see the **Scope** field:

--- a/website/docs/getting-started/setup/instance-configuration/authentication/openid-connect-oidc/okta.md
+++ b/website/docs/getting-started/setup/instance-configuration/authentication/openid-connect-oidc/okta.md
@@ -70,7 +70,7 @@ To continue with the OIDC setup on Appsmith, navigate to the fields on the Okta 
 
 ![Appsmith - OIDC Setup](/img/Appsmith-Admin-Settings-Authentication-OIDC-Setup.png)
 
-> `RS256` is the default Token Signing Algorithm used by Appsmith and most identity providers. If you have a custom setup, you can choose from one of the supported algorithms under the Advanced section of the Appsmith OIDC setup page. Please note, the `HS256` algorithm isn't supported for signing tokens.
+> `RS256` is the default Token Signing Algorithm used by Appsmith and most identity providers. If you have a custom setup, you can choose from one of the supported algorithms under the Advanced section of the Appsmith OIDC setup page. Please note, verifying tokens signed with the `HS256` algorithm isn't supported.
 
 ### Configure Scopes for Okta
 

--- a/website/docs/getting-started/setup/instance-configuration/authentication/openid-connect-oidc/ping-identity.md
+++ b/website/docs/getting-started/setup/instance-configuration/authentication/openid-connect-oidc/ping-identity.md
@@ -61,7 +61,7 @@ To continue with the OIDC setup on Appsmith, navigate to the fields on the Ping 
 
 ![Appsmith - OIDC Setup](/img/Appsmith-Admin-Settings-Authentication-OIDC-Setup.png)
 
-> `RS256` is the default Token Signing Algorithm used by Appsmith and most identity providers. If you have a custom setup, you can choose from one of the supported algorithms under the Advanced section of the Appsmith OIDC setup page. Please note, the `HS256` algorithm isn't supported for signing tokens.
+> `RS256` is the default Token Signing Algorithm used by Appsmith and most identity providers. If you have a custom setup, you can choose from one of the supported algorithms under the Advanced section of the Appsmith OIDC setup page. Please note, verifying tokens signed with the `HS256` algorithm isn't supported.
 
 ### Configure Scopes for Ping Identity
 

--- a/website/docs/getting-started/setup/instance-configuration/authentication/openid-connect-oidc/ping-identity.md
+++ b/website/docs/getting-started/setup/instance-configuration/authentication/openid-connect-oidc/ping-identity.md
@@ -61,6 +61,8 @@ To continue with the OIDC setup on Appsmith, navigate to the fields on the Ping 
 
 ![Appsmith - OIDC Setup](/img/Appsmith-Admin-Settings-Authentication-OIDC-Setup.png)
 
+> `RS256` is the default Token Signing Algorithm used by Appsmith and most identity providers. If you have a custom setup, you can choose from one of the supported algorithms under the Advanced section of the Appsmith OIDC setup page. Please note, the `HS256` algorithm isn't supported for signing tokens.
+
 ### Configure Scopes for Ping Identity
 
 The scope defines the OpenID Connect (OIDC) scopes that allow you to authorize the access of user details ( after a user is successfully authenticated) like name, email, profile picture, and more. Each scope maps to a set of user attributes and returns its value. Just below the **JSON Web Key Set,** you’ll see the **Scope** field:


### PR DESCRIPTION
Adding a note for the lack of support of the HS256 algorithm in OIDC token signing.

I've added the note in each IDP page subtly because this is an edge case setup. I'm worried that users might get unnecessarily distracted if we show the note promptly or on the OIDC page.