### PR TITLE
feat: added segment analytics

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -20,6 +20,15 @@ const config = {
     defaultLocale: 'en',
     locales: ['en'],
   },
+  plugins: [
+    [
+      '@twilio-labs/docusaurus-plugin-segment',
+      {
+        writeKey: '5mV2pPUXuzTRHzZET0fv8PJrBrwQ2EeH',
+        allowedInDev: false,
+      },
+    ],
+  ],
 
   presets: [
     [

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -12,6 +12,7 @@
         "@docusaurus/plugin-client-redirects": "^2.1.0",
         "@docusaurus/preset-classic": "2.1.0",
         "@mdx-js/react": "^1.6.22",
+        "@twilio-labs/docusaurus-plugin-segment": "^0.1.0",
         "aws-sdk": "^2.1231.0",
         "clsx": "^1.2.1",
         "prism-react-renderer": "^1.3.5",
@@ -3152,6 +3153,238 @@
       "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/@twilio-labs/docusaurus-plugin-segment": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@twilio-labs/docusaurus-plugin-segment/-/docusaurus-plugin-segment-0.1.0.tgz",
+      "integrity": "sha512-8Xeu8CuSNJMXEek2BK9PsBPS2rhj6vwICANskd2+ZlURlGDdZbV66DASRcF3LLJdLyEAsEa+iqdvgh7t9YHGGQ==",
+      "dependencies": {
+        "@docusaurus/core": "2.0.0-beta.21",
+        "@docusaurus/types": "2.0.0-beta.21",
+        "@docusaurus/utils-validation": "2.0.0-beta.21",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@twilio-labs/docusaurus-plugin-segment/node_modules/@docusaurus/core": {
+      "version": "2.0.0-beta.21",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.0-beta.21.tgz",
+      "integrity": "sha512-qysDMVp1M5UozK3u/qOxsEZsHF7jeBvJDS+5ItMPYmNKvMbNKeYZGA0g6S7F9hRDwjIlEbvo7BaX0UMDcmTAWA==",
+      "dependencies": {
+        "@babel/core": "^7.18.2",
+        "@babel/generator": "^7.18.2",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+        "@babel/plugin-transform-runtime": "^7.18.2",
+        "@babel/preset-env": "^7.18.2",
+        "@babel/preset-react": "^7.17.12",
+        "@babel/preset-typescript": "^7.17.12",
+        "@babel/runtime": "^7.18.3",
+        "@babel/runtime-corejs3": "^7.18.3",
+        "@babel/traverse": "^7.18.2",
+        "@docusaurus/cssnano-preset": "2.0.0-beta.21",
+        "@docusaurus/logger": "2.0.0-beta.21",
+        "@docusaurus/mdx-loader": "2.0.0-beta.21",
+        "@docusaurus/react-loadable": "5.5.2",
+        "@docusaurus/utils": "2.0.0-beta.21",
+        "@docusaurus/utils-common": "2.0.0-beta.21",
+        "@docusaurus/utils-validation": "2.0.0-beta.21",
+        "@slorber/static-site-generator-webpack-plugin": "^4.0.4",
+        "@svgr/webpack": "^6.2.1",
+        "autoprefixer": "^10.4.7",
+        "babel-loader": "^8.2.5",
+        "babel-plugin-dynamic-import-node": "^2.3.3",
+        "boxen": "^6.2.1",
+        "chalk": "^4.1.2",
+        "chokidar": "^3.5.3",
+        "clean-css": "^5.3.0",
+        "cli-table3": "^0.6.2",
+        "combine-promises": "^1.1.0",
+        "commander": "^5.1.0",
+        "copy-webpack-plugin": "^11.0.0",
+        "core-js": "^3.22.7",
+        "css-loader": "^6.7.1",
+        "css-minimizer-webpack-plugin": "^4.0.0",
+        "cssnano": "^5.1.9",
+        "del": "^6.1.1",
+        "detect-port": "^1.3.0",
+        "escape-html": "^1.0.3",
+        "eta": "^1.12.3",
+        "file-loader": "^6.2.0",
+        "fs-extra": "^10.1.0",
+        "html-minifier-terser": "^6.1.0",
+        "html-tags": "^3.2.0",
+        "html-webpack-plugin": "^5.5.0",
+        "import-fresh": "^3.3.0",
+        "leven": "^3.1.0",
+        "lodash": "^4.17.21",
+        "mini-css-extract-plugin": "^2.6.0",
+        "postcss": "^8.4.14",
+        "postcss-loader": "^7.0.0",
+        "prompts": "^2.4.2",
+        "react-dev-utils": "^12.0.1",
+        "react-helmet-async": "^1.3.0",
+        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
+        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
+        "react-router": "^5.3.3",
+        "react-router-config": "^5.1.1",
+        "react-router-dom": "^5.3.3",
+        "remark-admonitions": "^1.2.1",
+        "rtl-detect": "^1.0.4",
+        "semver": "^7.3.7",
+        "serve-handler": "^6.1.3",
+        "shelljs": "^0.8.5",
+        "terser-webpack-plugin": "^5.3.1",
+        "tslib": "^2.4.0",
+        "update-notifier": "^5.1.0",
+        "url-loader": "^4.1.1",
+        "wait-on": "^6.0.1",
+        "webpack": "^5.72.1",
+        "webpack-bundle-analyzer": "^4.5.0",
+        "webpack-dev-server": "^4.9.0",
+        "webpack-merge": "^5.8.0",
+        "webpackbar": "^5.0.2"
+      },
+      "bin": {
+        "docusaurus": "bin/docusaurus.mjs"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@twilio-labs/docusaurus-plugin-segment/node_modules/@docusaurus/cssnano-preset": {
+      "version": "2.0.0-beta.21",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-beta.21.tgz",
+      "integrity": "sha512-fhTZrg1vc6zYYZIIMXpe1TnEVGEjqscBo0s1uomSwKjjtMgu7wkzc1KKJYY7BndsSA+fVVkZ+OmL/kAsmK7xxw==",
+      "dependencies": {
+        "cssnano-preset-advanced": "^5.3.5",
+        "postcss": "^8.4.14",
+        "postcss-sort-media-queries": "^4.2.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      }
+    },
+    "node_modules/@twilio-labs/docusaurus-plugin-segment/node_modules/@docusaurus/logger": {
+      "version": "2.0.0-beta.21",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.0.0-beta.21.tgz",
+      "integrity": "sha512-HTFp8FsSMrAj7Uxl5p72U+P7rjYU/LRRBazEoJbs9RaqoKEdtZuhv8MYPOCh46K9TekaoquRYqag2o23Qt4ggA==",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      }
+    },
+    "node_modules/@twilio-labs/docusaurus-plugin-segment/node_modules/@docusaurus/mdx-loader": {
+      "version": "2.0.0-beta.21",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-beta.21.tgz",
+      "integrity": "sha512-AI+4obJnpOaBOAYV6df2ux5Y1YJCBS+MhXFf0yhED12sVLJi2vffZgdamYd/d/FwvWDw6QLs/VD2jebd7P50yQ==",
+      "dependencies": {
+        "@babel/parser": "^7.18.3",
+        "@babel/traverse": "^7.18.2",
+        "@docusaurus/logger": "2.0.0-beta.21",
+        "@docusaurus/utils": "2.0.0-beta.21",
+        "@mdx-js/mdx": "^1.6.22",
+        "escape-html": "^1.0.3",
+        "file-loader": "^6.2.0",
+        "fs-extra": "^10.1.0",
+        "image-size": "^1.0.1",
+        "mdast-util-to-string": "^2.0.0",
+        "remark-emoji": "^2.2.0",
+        "stringify-object": "^3.3.0",
+        "tslib": "^2.4.0",
+        "unist-util-visit": "^2.0.3",
+        "url-loader": "^4.1.1",
+        "webpack": "^5.72.1"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@twilio-labs/docusaurus-plugin-segment/node_modules/@docusaurus/types": {
+      "version": "2.0.0-beta.21",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.0-beta.21.tgz",
+      "integrity": "sha512-/GH6Npmq81eQfMC/ikS00QSv9jNyO1RXEpNSx5GLA3sFX8Iib26g2YI2zqNplM8nyxzZ2jVBuvUoeODTIbTchQ==",
+      "dependencies": {
+        "commander": "^5.1.0",
+        "history": "^4.9.0",
+        "joi": "^17.6.0",
+        "react-helmet-async": "^1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.72.1",
+        "webpack-merge": "^5.8.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@twilio-labs/docusaurus-plugin-segment/node_modules/@docusaurus/utils": {
+      "version": "2.0.0-beta.21",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-beta.21.tgz",
+      "integrity": "sha512-M/BrVCDmmUPZLxtiStBgzpQ4I5hqkggcpnQmEN+LbvbohjbtVnnnZQ0vptIziv1w8jry/woY+ePsyOO7O/yeLQ==",
+      "dependencies": {
+        "@docusaurus/logger": "2.0.0-beta.21",
+        "@svgr/webpack": "^6.2.1",
+        "file-loader": "^6.2.0",
+        "fs-extra": "^10.1.0",
+        "github-slugger": "^1.4.0",
+        "globby": "^11.1.0",
+        "gray-matter": "^4.0.3",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "micromatch": "^4.0.5",
+        "resolve-pathname": "^3.0.0",
+        "shelljs": "^0.8.5",
+        "tslib": "^2.4.0",
+        "url-loader": "^4.1.1",
+        "webpack": "^5.72.1"
+      },
+      "engines": {
+        "node": ">=16.14"
+      }
+    },
+    "node_modules/@twilio-labs/docusaurus-plugin-segment/node_modules/@docusaurus/utils-common": {
+      "version": "2.0.0-beta.21",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.0-beta.21.tgz",
+      "integrity": "sha512-5w+6KQuJb6pUR2M8xyVuTMvO5NFQm/p8TOTDFTx60wt3p0P1rRX00v6FYsD4PK6pgmuoKjt2+Ls8dtSXc4qFpQ==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      }
+    },
+    "node_modules/@twilio-labs/docusaurus-plugin-segment/node_modules/@docusaurus/utils-validation": {
+      "version": "2.0.0-beta.21",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.0-beta.21.tgz",
+      "integrity": "sha512-6NG1FHTRjv1MFzqW//292z7uCs77vntpWEbZBHk3n67aB1HoMn5SOwjLPtRDjbCgn6HCHFmdiJr6euCbjhYolg==",
+      "dependencies": {
+        "@docusaurus/logger": "2.0.0-beta.21",
+        "@docusaurus/utils": "2.0.0-beta.21",
+        "joi": "^17.6.0",
+        "js-yaml": "^4.1.0",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
       }
     },
     "node_modules/@types/body-parser": {
@@ -10252,12 +10485,88 @@
         "jsesc": "bin/jsesc"
       }
     },
+    "node_modules/rehype-parse": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-6.0.2.tgz",
+      "integrity": "sha512-0S3CpvpTAgGmnz8kiCyFLGuW5yA4OQhyNTm/nwPopZ7+PI11WnGl1TTWTGv/2hPEe/g2jRLlhVVSsoDH8waRug==",
+      "dependencies": {
+        "hast-util-from-parse5": "^5.0.0",
+        "parse5": "^5.0.0",
+        "xtend": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-parse/node_modules/hast-util-from-parse5": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-5.0.3.tgz",
+      "integrity": "sha512-gOc8UB99F6eWVWFtM9jUikjN7QkWxB3nY0df5Z0Zq1/Nkwl5V4hAAsl0tmwlgWl/1shlTF8DnNYLO8X6wRV9pA==",
+      "dependencies": {
+        "ccount": "^1.0.3",
+        "hastscript": "^5.0.0",
+        "property-information": "^5.0.0",
+        "web-namespaces": "^1.1.2",
+        "xtend": "^4.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-parse/node_modules/hastscript": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.2.tgz",
+      "integrity": "sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==",
+      "dependencies": {
+        "comma-separated-tokens": "^1.0.0",
+        "hast-util-parse-selector": "^2.0.0",
+        "property-information": "^5.0.0",
+        "space-separated-tokens": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-parse/node_modules/parse5": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="
+    },
     "node_modules/relateurl": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/remark-admonitions": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/remark-admonitions/-/remark-admonitions-1.2.1.tgz",
+      "integrity": "sha512-Ji6p68VDvD+H1oS95Fdx9Ar5WA2wcDA4kwrrhVU7fGctC6+d3uiMICu7w7/2Xld+lnU7/gi+432+rRbup5S8ow==",
+      "dependencies": {
+        "rehype-parse": "^6.0.2",
+        "unified": "^8.4.2",
+        "unist-util-visit": "^2.0.1"
+      }
+    },
+    "node_modules/remark-admonitions/node_modules/unified": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
+      "integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
+      "dependencies": {
+        "bail": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^2.0.0",
+        "trough": "^1.0.0",
+        "vfile": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-emoji": {
@@ -15314,6 +15623,197 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
       "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA=="
+    },
+    "@twilio-labs/docusaurus-plugin-segment": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@twilio-labs/docusaurus-plugin-segment/-/docusaurus-plugin-segment-0.1.0.tgz",
+      "integrity": "sha512-8Xeu8CuSNJMXEek2BK9PsBPS2rhj6vwICANskd2+ZlURlGDdZbV66DASRcF3LLJdLyEAsEa+iqdvgh7t9YHGGQ==",
+      "requires": {
+        "@docusaurus/core": "2.0.0-beta.21",
+        "@docusaurus/types": "2.0.0-beta.21",
+        "@docusaurus/utils-validation": "2.0.0-beta.21",
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "@docusaurus/core": {
+          "version": "2.0.0-beta.21",
+          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.0-beta.21.tgz",
+          "integrity": "sha512-qysDMVp1M5UozK3u/qOxsEZsHF7jeBvJDS+5ItMPYmNKvMbNKeYZGA0g6S7F9hRDwjIlEbvo7BaX0UMDcmTAWA==",
+          "requires": {
+            "@babel/core": "^7.18.2",
+            "@babel/generator": "^7.18.2",
+            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+            "@babel/plugin-transform-runtime": "^7.18.2",
+            "@babel/preset-env": "^7.18.2",
+            "@babel/preset-react": "^7.17.12",
+            "@babel/preset-typescript": "^7.17.12",
+            "@babel/runtime": "^7.18.3",
+            "@babel/runtime-corejs3": "^7.18.3",
+            "@babel/traverse": "^7.18.2",
+            "@docusaurus/cssnano-preset": "2.0.0-beta.21",
+            "@docusaurus/logger": "2.0.0-beta.21",
+            "@docusaurus/mdx-loader": "2.0.0-beta.21",
+            "@docusaurus/react-loadable": "5.5.2",
+            "@docusaurus/utils": "2.0.0-beta.21",
+            "@docusaurus/utils-common": "2.0.0-beta.21",
+            "@docusaurus/utils-validation": "2.0.0-beta.21",
+            "@slorber/static-site-generator-webpack-plugin": "^4.0.4",
+            "@svgr/webpack": "^6.2.1",
+            "autoprefixer": "^10.4.7",
+            "babel-loader": "^8.2.5",
+            "babel-plugin-dynamic-import-node": "^2.3.3",
+            "boxen": "^6.2.1",
+            "chalk": "^4.1.2",
+            "chokidar": "^3.5.3",
+            "clean-css": "^5.3.0",
+            "cli-table3": "^0.6.2",
+            "combine-promises": "^1.1.0",
+            "commander": "^5.1.0",
+            "copy-webpack-plugin": "^11.0.0",
+            "core-js": "^3.22.7",
+            "css-loader": "^6.7.1",
+            "css-minimizer-webpack-plugin": "^4.0.0",
+            "cssnano": "^5.1.9",
+            "del": "^6.1.1",
+            "detect-port": "^1.3.0",
+            "escape-html": "^1.0.3",
+            "eta": "^1.12.3",
+            "file-loader": "^6.2.0",
+            "fs-extra": "^10.1.0",
+            "html-minifier-terser": "^6.1.0",
+            "html-tags": "^3.2.0",
+            "html-webpack-plugin": "^5.5.0",
+            "import-fresh": "^3.3.0",
+            "leven": "^3.1.0",
+            "lodash": "^4.17.21",
+            "mini-css-extract-plugin": "^2.6.0",
+            "postcss": "^8.4.14",
+            "postcss-loader": "^7.0.0",
+            "prompts": "^2.4.2",
+            "react-dev-utils": "^12.0.1",
+            "react-helmet-async": "^1.3.0",
+            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
+            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
+            "react-router": "^5.3.3",
+            "react-router-config": "^5.1.1",
+            "react-router-dom": "^5.3.3",
+            "remark-admonitions": "^1.2.1",
+            "rtl-detect": "^1.0.4",
+            "semver": "^7.3.7",
+            "serve-handler": "^6.1.3",
+            "shelljs": "^0.8.5",
+            "terser-webpack-plugin": "^5.3.1",
+            "tslib": "^2.4.0",
+            "update-notifier": "^5.1.0",
+            "url-loader": "^4.1.1",
+            "wait-on": "^6.0.1",
+            "webpack": "^5.72.1",
+            "webpack-bundle-analyzer": "^4.5.0",
+            "webpack-dev-server": "^4.9.0",
+            "webpack-merge": "^5.8.0",
+            "webpackbar": "^5.0.2"
+          }
+        },
+        "@docusaurus/cssnano-preset": {
+          "version": "2.0.0-beta.21",
+          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-beta.21.tgz",
+          "integrity": "sha512-fhTZrg1vc6zYYZIIMXpe1TnEVGEjqscBo0s1uomSwKjjtMgu7wkzc1KKJYY7BndsSA+fVVkZ+OmL/kAsmK7xxw==",
+          "requires": {
+            "cssnano-preset-advanced": "^5.3.5",
+            "postcss": "^8.4.14",
+            "postcss-sort-media-queries": "^4.2.1",
+            "tslib": "^2.4.0"
+          }
+        },
+        "@docusaurus/logger": {
+          "version": "2.0.0-beta.21",
+          "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.0.0-beta.21.tgz",
+          "integrity": "sha512-HTFp8FsSMrAj7Uxl5p72U+P7rjYU/LRRBazEoJbs9RaqoKEdtZuhv8MYPOCh46K9TekaoquRYqag2o23Qt4ggA==",
+          "requires": {
+            "chalk": "^4.1.2",
+            "tslib": "^2.4.0"
+          }
+        },
+        "@docusaurus/mdx-loader": {
+          "version": "2.0.0-beta.21",
+          "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-beta.21.tgz",
+          "integrity": "sha512-AI+4obJnpOaBOAYV6df2ux5Y1YJCBS+MhXFf0yhED12sVLJi2vffZgdamYd/d/FwvWDw6QLs/VD2jebd7P50yQ==",
+          "requires": {
+            "@babel/parser": "^7.18.3",
+            "@babel/traverse": "^7.18.2",
+            "@docusaurus/logger": "2.0.0-beta.21",
+            "@docusaurus/utils": "2.0.0-beta.21",
+            "@mdx-js/mdx": "^1.6.22",
+            "escape-html": "^1.0.3",
+            "file-loader": "^6.2.0",
+            "fs-extra": "^10.1.0",
+            "image-size": "^1.0.1",
+            "mdast-util-to-string": "^2.0.0",
+            "remark-emoji": "^2.2.0",
+            "stringify-object": "^3.3.0",
+            "tslib": "^2.4.0",
+            "unist-util-visit": "^2.0.3",
+            "url-loader": "^4.1.1",
+            "webpack": "^5.72.1"
+          }
+        },
+        "@docusaurus/types": {
+          "version": "2.0.0-beta.21",
+          "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.0-beta.21.tgz",
+          "integrity": "sha512-/GH6Npmq81eQfMC/ikS00QSv9jNyO1RXEpNSx5GLA3sFX8Iib26g2YI2zqNplM8nyxzZ2jVBuvUoeODTIbTchQ==",
+          "requires": {
+            "commander": "^5.1.0",
+            "history": "^4.9.0",
+            "joi": "^17.6.0",
+            "react-helmet-async": "^1.3.0",
+            "utility-types": "^3.10.0",
+            "webpack": "^5.72.1",
+            "webpack-merge": "^5.8.0"
+          }
+        },
+        "@docusaurus/utils": {
+          "version": "2.0.0-beta.21",
+          "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-beta.21.tgz",
+          "integrity": "sha512-M/BrVCDmmUPZLxtiStBgzpQ4I5hqkggcpnQmEN+LbvbohjbtVnnnZQ0vptIziv1w8jry/woY+ePsyOO7O/yeLQ==",
+          "requires": {
+            "@docusaurus/logger": "2.0.0-beta.21",
+            "@svgr/webpack": "^6.2.1",
+            "file-loader": "^6.2.0",
+            "fs-extra": "^10.1.0",
+            "github-slugger": "^1.4.0",
+            "globby": "^11.1.0",
+            "gray-matter": "^4.0.3",
+            "js-yaml": "^4.1.0",
+            "lodash": "^4.17.21",
+            "micromatch": "^4.0.5",
+            "resolve-pathname": "^3.0.0",
+            "shelljs": "^0.8.5",
+            "tslib": "^2.4.0",
+            "url-loader": "^4.1.1",
+            "webpack": "^5.72.1"
+          }
+        },
+        "@docusaurus/utils-common": {
+          "version": "2.0.0-beta.21",
+          "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.0-beta.21.tgz",
+          "integrity": "sha512-5w+6KQuJb6pUR2M8xyVuTMvO5NFQm/p8TOTDFTx60wt3p0P1rRX00v6FYsD4PK6pgmuoKjt2+Ls8dtSXc4qFpQ==",
+          "requires": {
+            "tslib": "^2.4.0"
+          }
+        },
+        "@docusaurus/utils-validation": {
+          "version": "2.0.0-beta.21",
+          "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.0-beta.21.tgz",
+          "integrity": "sha512-6NG1FHTRjv1MFzqW//292z7uCs77vntpWEbZBHk3n67aB1HoMn5SOwjLPtRDjbCgn6HCHFmdiJr6euCbjhYolg==",
+          "requires": {
+            "@docusaurus/logger": "2.0.0-beta.21",
+            "@docusaurus/utils": "2.0.0-beta.21",
+            "joi": "^17.6.0",
+            "js-yaml": "^4.1.0",
+            "tslib": "^2.4.0"
+          }
+        }
+      }
     },
     "@types/body-parser": {
       "version": "1.19.2",
@@ -20461,10 +20961,74 @@
         }
       }
     },
+    "rehype-parse": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-6.0.2.tgz",
+      "integrity": "sha512-0S3CpvpTAgGmnz8kiCyFLGuW5yA4OQhyNTm/nwPopZ7+PI11WnGl1TTWTGv/2hPEe/g2jRLlhVVSsoDH8waRug==",
+      "requires": {
+        "hast-util-from-parse5": "^5.0.0",
+        "parse5": "^5.0.0",
+        "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "hast-util-from-parse5": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-5.0.3.tgz",
+          "integrity": "sha512-gOc8UB99F6eWVWFtM9jUikjN7QkWxB3nY0df5Z0Zq1/Nkwl5V4hAAsl0tmwlgWl/1shlTF8DnNYLO8X6wRV9pA==",
+          "requires": {
+            "ccount": "^1.0.3",
+            "hastscript": "^5.0.0",
+            "property-information": "^5.0.0",
+            "web-namespaces": "^1.1.2",
+            "xtend": "^4.0.1"
+          }
+        },
+        "hastscript": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.2.tgz",
+          "integrity": "sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==",
+          "requires": {
+            "comma-separated-tokens": "^1.0.0",
+            "hast-util-parse-selector": "^2.0.0",
+            "property-information": "^5.0.0",
+            "space-separated-tokens": "^1.0.0"
+          }
+        },
+        "parse5": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+          "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="
+        }
+      }
+    },
     "relateurl": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog=="
+    },
+    "remark-admonitions": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/remark-admonitions/-/remark-admonitions-1.2.1.tgz",
+      "integrity": "sha512-Ji6p68VDvD+H1oS95Fdx9Ar5WA2wcDA4kwrrhVU7fGctC6+d3uiMICu7w7/2Xld+lnU7/gi+432+rRbup5S8ow==",
+      "requires": {
+        "rehype-parse": "^6.0.2",
+        "unified": "^8.4.2",
+        "unist-util-visit": "^2.0.1"
+      },
+      "dependencies": {
+        "unified": {
+          "version": "8.4.2",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
+          "integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
+          "requires": {
+            "bail": "^1.0.0",
+            "extend": "^3.0.0",
+            "is-plain-obj": "^2.0.0",
+            "trough": "^1.0.0",
+            "vfile": "^4.0.0"
+          }
+        }
+      }
     },
     "remark-emoji": {
       "version": "2.2.0",

--- a/website/package.json
+++ b/website/package.json
@@ -18,6 +18,7 @@
     "@docusaurus/plugin-client-redirects": "^2.1.0",
     "@docusaurus/preset-classic": "2.1.0",
     "@mdx-js/react": "^1.6.22",
+    "@twilio-labs/docusaurus-plugin-segment": "^0.1.0",
     "aws-sdk": "^2.1231.0",
     "clsx": "^1.2.1",
     "prism-react-renderer": "^1.3.5",


### PR DESCRIPTION
# Analytics for Docs
- Added segment analytics using `@twilio-labs/docusaurus-plugin-segment` plugin.
- Other analytics snippets like Google Analytics will be loaded in via segment. 
- Uses the same `writeKey` as `app.appsmith.com` and `www.appsmith.com` so that we can track user journeys.
- Manually tested and verified that the script executes as expected.