### PR TITLE
fix: Notes on git branch protections

### DIFF
--- a/website/docs/advanced-concepts/version-control-with-git/working-with-branches.md
+++ b/website/docs/advanced-concepts/version-control-with-git/working-with-branches.md
@@ -8,14 +8,15 @@ The initial commit while connecting to a repository is made to the master branch
 To create a new branch -
 
 * Click on the branch button at the bottom left corner. You can switch to an existing branch or create a new one from the branch pop-up.
-* When you switch to another branch, the uncommitted changes in your current branch won’t carry over to the destination branch.
+* If you create a new branch, it will have the uncommitted changes of your parent branch. 
+* When you switch to another branch, the uncommitted changes in your current branch won’t be carried over to the destination branch.
 
 However, if you create a new branch, it will have the uncommitted changes of your parent branch.
 
 :::info
 * Branch names should **not** start with `origin/` since this prefix is used to distinguish between local and remote versions of a branch.
 * Checking out a remote branch with a local counterpart already available would result in an error.
-* If you create a new branch, it will have the uncommitted changes of your parent branch. When you switch to another branch, the uncommitted changes in your current branch won’t be carried over to the destination branch. In both cases, the current branch will retain the uncommitted changes.
+* Branch protections on remote repository will cause errors with some operations involving Git push.
 :::
 
 #### Syncing Local with Remote Branch

--- a/website/docs/advanced-concepts/version-control-with-git/working-with-branches.md
+++ b/website/docs/advanced-concepts/version-control-with-git/working-with-branches.md
@@ -16,7 +16,7 @@ However, if you create a new branch, it will have the uncommitted changes of you
 :::info
 * Branch names should **not** start with `origin/` since this prefix is used to distinguish between local and remote versions of a branch.
 * Checking out a remote branch with a local counterpart already available would result in an error.
-* Branch protections on remote repository will cause errors with some operations involving Git push.
+* Branch protections on remote repository may cause errors with some operations involving Git push.
 :::
 
 #### Syncing Local with Remote Branch


### PR DESCRIPTION
Note for errors caused by remote branch protections.