### PR TITLE
fix: Rehaul docker installation guide

### DIFF
--- a/.github/styles/Vocab/technical/accept.txt
+++ b/.github/styles/Vocab/technical/accept.txt
@@ -259,4 +259,4 @@ CSV
 FilePicker
 isDirty
 drag and drop
-
+uncomment

--- a/website/docs/getting-started/setup/installation-guides/docker/README.mdx
+++ b/website/docs/getting-started/setup/installation-guides/docker/README.mdx
@@ -8,10 +8,6 @@ import TabItem from '@theme/TabItem';
 
 This page provides stepwise instructions to help you install Appsmith using Docker.
 
-:::info
-To upgrade your Community Edition Docker installation to Business Edition Docker installation, see [Upgrade to Business Edition using Docker](/getting-started/setup/upgrade-to-business-edition/docker).
-:::
-
 <VideoEmbed host="youtube" videoId="Tde7GqE6FQQ" title="How to install Appsmith using Docker" 
 caption="How to install Appsmith using Docker"/> 
 
@@ -30,7 +26,11 @@ Follow the steps below to install Appsmith using Docker Compose:
 <Tabs groupId="editions" >
 <TabItem label="Community Edition" value="community">
 
-Download the [`docker-compose.yml`](https://bit.ly/docker-compose-CE) file and place it into the Appsmith installation folder. Or run the following cURL:
+There are two ways in which you can download the `docker-compose.yml` file:
+   
+* Download the [`docker-compose.yml`](https://bit.ly/docker-compose-CE) file and place it into the Appsmith installation folder. 
+
+* Or run the following cURL command:
 
 ```bash
 curl -L https://bit.ly/docker-compose-CE -o $PWD/docker-compose.yml
@@ -39,30 +39,44 @@ curl -L https://bit.ly/docker-compose-CE -o $PWD/docker-compose.yml
 </TabItem>
 <TabItem label="Business Edition" value="business">
 
-Download the [`docker-compose.yml`](https://bit.ly/docker-compose-be) file, and place it into the Appsmith installation folder. Or run the following cURL command:
+:::info
+To upgrade your Community Edition to Business Edition, see [Upgrade to Business Edition using Docker](/getting-started/setup/upgrade-to-business-edition/docker).
+:::
 
-```bash
- curl -L https://bit.ly/docker-compose-be -o $PWD/docker-compose.yml
-```
+1. Sign up on [customer.appsmith.com](https://customer.appsmith.com) and generate a trial license key.
+
+2. There are two ways in which you can download the `docker-compose.yml` file:
+   * Download the [`docker-compose.yml`](https://bit.ly/docker-compose-be) file, and place it into the Appsmith installation folder. 
+   
+   * Run the following cURL command:
+
+   ```bash
+   curl -L https://bit.ly/docker-compose-be -o $PWD/docker-compose.yml
+   ```
 
 </TabItem>
 </Tabs>
 
-2. To start the Docker container, use the following command. If you're unable to access `docker` and `docker-compose`, you may need to run the command with `sudo`. The below command downloads the Docker image if not present on your computer.
+2. To start the Docker container, use the following command. You may have to run the command with `sudo` if you don't have permission to execute `docker-compose`. The below command downloads the Docker image if not present locally.
 
-   ```bash
-   docker-compose up -d
-   ```
+```bash
+docker-compose up -d
+```
 
-The server deploys Appsmith at startup, and you can access it at [http://localhost](http://localhost). You can check the  [instance logs](/learning-and-resources/how-to-guides/how-to-get-container-logs#docker) to verify that the instance is up and running.
+The server deploys Appsmith at startup, and you can access it at [http://localhost](http://localhost). You can also check the message "Appsmith is Running!" displayed in docker logs by using `docker logs -f appsmith` command.
+
+![Appsmith is running message](/img/InstallationGuides__Docker__AppsmithRunningMessage.png)
 
 :::info important
-If you are on a Business Edition, after logging into your Appsmith account, enter your license key to activate the instance. If you need a license key, sign up for a free trial at [customer.appsmith.com](https://customer.appsmith.com).
+If you are on a Business Edition, after logging into your Appsmith account, enter your license key to activate the instance.
 :::
 
 ## Troubleshooting
 
-If you see any errors during deployment, refer to [Deployment Errors](/help-and-support/troubleshooting-guide/deployment-errors) troubleshooting guide. This guide provides detailed information on troubleshooting common deployment errors you may encounter.
+If you see any errors during deployment, refer to:
+* [Ports unavailable](/help-and-support/troubleshooting-guide/deployment-errors#ports-unavailable)
+* [Containers failed to restart](/help-and-support/troubleshooting-guide/deployment-errors#containers-failed-to-start)
+* [Unable to access Appsmith](/help-and-support/troubleshooting-guide/deployment-errors#unable-to-access-appsmith) 
 
 ## Further reading
 

--- a/website/docs/getting-started/setup/installation-guides/docker/README.mdx
+++ b/website/docs/getting-started/setup/installation-guides/docker/README.mdx
@@ -7,198 +7,102 @@ import TabItem from '@theme/TabItem';
 
 # Docker
 
-This page provides stepwise instructions to help you install Appsmith on Docker.
+This page provides stepwise instructions to help you install Appsmith using Docker.
+
+:::info
+To upgrade your Community Edition Docker installation to Business Edition Docker installation, see [Upgrade to Business Edition using Docker](/getting-started/setup/upgrade-to-business-edition/docker).
+:::
 
 <VideoEmbed host="youtube" videoId="Tde7GqE6FQQ" title="How to install Appsmith using Docker" 
 caption="How to install Appsmith using Docker"/> 
 
 ## Prerequisites
 
-* [Docker](https://docs.docker.com/get-docker/) (version 20.10.7 or later)
-* [Docker-Compose](https://docs.docker.com/compose/install/) (version 1.29.2 or later)
+1. [Docker](https://docs.docker.com/get-docker/) (version 20.10.7 or later)
+2. [Docker-Compose](https://docs.docker.com/compose/install/) (version 1.29.2 or later)
+3. Create a folder named `appsmith` for deployment and data storage, then navigate to it using `cd` command.
 
-1. Create an installation folder called `appsmith` for deployment and data storage.
-2. `cd` into the installation folder.
+:::info
+Boost your app development with advanced features offered by Appsmith Business Edition. For more information, see [Business Edition](https://www.appsmith.com/pricing).
+:::
 
-## Setup with Docker Compose _(recommended)_
+## Install
 
-The Appsmith Docker image contains all the components required to run within a single Docker container. All these multiple processes are managed by a [Supervisord](http://supervisord.org/) instance, which is a lightweight process manager.
+Follow the steps below to install Appsmith using Docker Compose:
 
-<Tabs groupId="editions" >
-   <TabItem label="Community Edition" value="community">
+1. Download the `docker-compose.yml` file for the edition that you are using:
 
-1. Click to download the [`docker-compose.yml`](https://bit.ly/docker-compose-CE) file and place it into the Appsmith installation folder.
+   * **Community Edition** - Click to download the [`docker-compose.yml`](https://bit.ly/docker-compose-CE) file and place it into the Appsmith installation folder. **Or,** run the following cURL:
 
-   **OR,** run the following cURL:
+      ```bash
+      curl -L https://bit.ly/docker-compose-CE -o $PWD/docker-compose.yml
+      ```
+   * **Business Edition** - Click to download the [`docker-compose.yml`](https://bit.ly/docker-compose-be) file, and place it into the Appsmith installation folder. **Or,** run the following cURL command:
+
+      ```bash
+         curl -L https://bit.ly/docker-compose-be -o $PWD/docker-compose.yml
+      ```
+
+2. Use the below command to start the Docker container. If you can't access `docker` and `docker-compose`, you may need to run the command with `sudo`. The command downloads the docker image if not available on your computer.
+
+   ```bash
+   docker-compose up -d
+   ```
+Upon restarting the server, Appsmith is deployed and accessible through [http://localhost](http://localhost). You may verify that the instance is functioning correctly by checking the [instance logs](/learning-and-resources/how-to-guides/how-to-get-container-logs#docker).
+
+:::info important
+If you already have a **Business Edition** license key, sign in to your Appsmith account, and enter your license key to activate the instance. If you need a license key, sign up on [customer.appsmith.com](https://customer.appsmith.com).
+:::
+
+## Install
+
+Follow the steps below to install Appsmith using Docker Compose:
+
+1. Download the `docker-compose.yml` file for the Appsmith edition that you are using:
+
+<details id="Community Edition">
+    <summary><b>Community Edition</b></summary>
+
+* Click to download the [`docker-compose.yml`](https://bit.ly/docker-compose-CE) file and place it into the Appsmith installation folder.
+
+* Or run the following cURL:
 
    ```bash
    curl -L https://bit.ly/docker-compose-CE -o $PWD/docker-compose.yml
    ```
 
-2. Start the Docker container by running the command below. This may need to be run with sudo if `docker` and `docker-compose` aren't accessible by the user. If the image doesn't exist locally, this command downloads the necessary Docker image and starts the container.
+</details>
+
+<details id="Business Edition">
+    <summary><b>Business Edition</b> </summary>
+
+* Click to download the [`docker-compose.yml`](https://bit.ly/docker-compose-be) file, and place it into the Appsmith installation folder. 
+      
+* Or, run the following cURL command:
+
+   ```bash
+   curl -L https://bit.ly/docker-compose-be -o $PWD/docker-compose.yml
+   ```
+
+</details>
+
+2. Use the below command to start the Docker container. If you can't access `docker` and `docker-compose`, you may need to run the command with `sudo`. The command downloads the docker image if not available on your computer.
 
    ```bash
    docker-compose up -d
    ```
 
-The Appsmith server should be up and running soon and can be accessed at [http://localhost](http://localhost). Check the [Docker logs](#docker-logs) to verify that the instance is working correctly.
+Upon restarting the server, Appsmith is deployed and accessible through [http://localhost](http://localhost). You may verify that the instance is functioning correctly by checking the [instance logs](/learning-and-resources/how-to-guides/how-to-get-container-logs#docker).
 
-   </TabItem>
-   <TabItem label="Business Edition" value="business">
-
-:::note
-To upgrade from Community Edition to Business Edition, [follow these instructions](/getting-started/setup/upgrade-to-business-edition/docker).
+:::info important
+If you already have a **Business Edition** license key, sign in to your Appsmith account, and enter your license key to activate the instance. If you need a license key, sign up on [customer.appsmith.com](https://customer.appsmith.com).
 :::
-
-   1. Sign up on [customer.appsmith.com](https://customer.appsmith.com/) and generate a trial license key.
-
-   2. Click to download the [`docker-compose.yml`](https://bit.ly/docker-compose-be) file, and place it into the Appsmith installation folder.
-
-   **OR,** run the following cURL command:
-
-   ```bash
-      curl -L https://bit.ly/docker-compose-be -o $PWD/docker-compose.yml
-   ```
-   3. Start the Docker container by running the command below. This may need to be run with sudo if `docker` and `docker-compose` aren't accessible by the user. If the image doesn't exist locally, this command downloads the necessary Docker image and starts the container.
-      ```bash
-      docker-compose up -d
-      ```
-   4. The Appsmith server should be up and running soon and can be accessed at [http://localhost](http://localhost). Check the [Docker logs](#docker-logs) to verify that the instance is working correctly.
-   5. Create or sign in to your Appsmith account, and enter your license key to activate the instance.
-
-</TabItem>
-</Tabs>
-
-### Updating Appsmith
-:::caution
- * [Create a backup](https://docs.appsmith.com/getting-started/setup/instance-management/appsmithctl#backup-appsmith-instance) of the Appsmith instance before performing a manual update.
-* If your version is less than v1.9.2, [upgrade to the checkpoint](/getting-started/setup/instance-management#checkpoint-upgrade) version v1.9.2 before upgrading to the latest version.
-:::
-
-
-To update Appsmith manually, go to the root directory of the installation and run the following command:
-
-```
-docker-compose pull && docker-compose rm -fsv appsmith && docker-compose up -d
-```
-
-### Enabling Appsmith auto updates
-
-Automatic updates are turned off by default in the `docker-compose.yml` file. To enable them, please follow these steps:
-
-1. Go to the root directory of the Appsmith installation and run:
-
-   ```
-   docker-compose down
-   ```
-
-2. Open the `docker-compose.yml` file with any text editor and un-comment lines 13-23.
-3. Save the file and run:
-
-   ```
-   docker-compose up -d
-   ```
-
-In addition to automatic updates, Appsmith also offers an auto backup feature. Before any update, Appsmith creates a backup, which can be used to rollback to a previous version of Appsmith in case the update needs to be undone. For more information, see [the rollback instructions using the `appsmithctl` command](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance). To ensure successful auto backup and update tasks, a minimum of 2 GB of free storage must be available; otherwise, both the backup and update tasks may fail.
-
-:::note 
-To ensure automatic backups before updates, enable the `WATCHTOWER_LIFECYCLE_HOOKS` environment variable in the [docker-compose.yaml](https://bit.ly/3h08WqB) file on the Watchtower instance.
-:::
-
-If you have updated your Appsmith instance and face any issues. You can rollback the changes and [restore the Appsmith instance](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance) from a backup archive. This configuration runs an Appsmith instance and a Watchtower instance to keep Appsmith automatically up-to-date. The installation is now configured to stay up-to-date automatically.
-
----
-
-## Setup with Docker run
-
-<Tabs groupId="editions">
-   <TabItem label="Community Edition" value="community">
-
-This command downloads the image and starts Appsmith:
-
-```bash
-docker run -d --name appsmith -p 80:80 -v "$PWD/stacks:/appsmith-stacks" --pull always appsmith/appsmith-ce
-```
-
-   </TabItem>
-   <TabItem label="Business Edition" value="business">
-
-This command downloads the image and starts Appsmith:
-
-```bash
-docker run -d --name appsmith -p 80:80 -v "$PWD/stacks:/appsmith-stacks" --pull always appsmith/appsmith-ee
-```
-
-   </TabItem>
-</Tabs>
-
-### Updating Appsmith
-
-<Tabs groupId="editions">
-   <TabItem label="Community Edition" value="community">
-
-To update Appsmith manually, go to the root directory of the installation and run the following commands:
-
-```bash
-docker rmi appsmith/appsmith-ce -f
-docker pull appsmith/appsmith-ce
-docker rm -f appsmith
-docker run -d --name appsmith -p 80:80 -v "$PWD/stacks:/appsmith-stacks" appsmith/appsmith-ce
-```
-
-   </TabItem>
-   <TabItem label="Business Edition" value="business">
-
-To update Appsmith manually, go to the root directory of the installation and run the following commands:
-
-```bash
-docker rmi appsmith/appsmith-ee -f
-docker pull appsmith/appsmith-ee
-docker rm -f appsmith
-docker run -d --name appsmith -p 80:80 -v "$PWD/stacks:/appsmith-stacks" appsmith/appsmith-ee
-```
-
-   </TabItem>
-</Tabs>
-
-Once the download is complete, the server should be up soon. You can verify that it's working correctly in the [Docker logs](#docker-logs).
-
-## Docker logs
-
-Once the Appsmith container is ready, the message "Appsmith is Running!" is displayed in the Docker logs.
-
-![Appsmith is running message](/img/InstallationGuides__Docker__AppsmithRunningMessage.png)
-
-You can follow the logs with the following command:
-
-```bash
-docker logs -f appsmith
-```
-
-**Server logs** are stored in `stacks/logs/backend/backend.log`. 
-
-Logs can assist when debugging or analyzing a problem because they offer valuable information about what went wrong. For more information, see [How to get container logs](/learning-and-resources/how-to-guides/how-to-get-container-logs).
-
-
-## Restarting containers
-
-If the Docker containers are failing to restart, download, and run the [`restart-container.sh`](/img/restart-container.sh) script linked below to bring them up:
-
-Copy the script (`restart-container.sh`) to the installation folder and make it executable:
-
-```bash
-chmod +x restart-container.sh
-./restart-container.sh
-```
 
 ## Troubleshooting
 
-If there are any errors during this process, follow the guide on [debugging deployment errors](/help-and-support/troubleshooting-guide/deployment-errors) or send an email to [support@appsmith.com](mailto:support@appsmith.com) or join the Appsmith [Discord Server](https://discord.com/invite/rBTTVJp) to speak to the Appsmith team directly.
+If you see any errors during deployment, refer to [Deployment Errors](/help-and-support/troubleshooting-guide/deployment-errors) troubleshooting guide. This guide provides detailed information on troubleshooting common deployment errors you may encounter.
 
 ## Further reading
 
-* [Configuring Self Hosted Instances](/getting-started/setup/instance-configuration/#configuring-docker-installations)
-* [Managing the Appsmith instance](/getting-started/setup/instance-management/)
-* [Tutorials](/learning-and-resources/tutorials/)
-
-  
+* [Configure Appsmith instance](/getting-started/setup/instance-configuration#configure-docker-installations)
+* [Manage the Appsmith instance](/getting-started/setup/instance-management/)

--- a/website/docs/getting-started/setup/installation-guides/docker/README.mdx
+++ b/website/docs/getting-started/setup/installation-guides/docker/README.mdx
@@ -1,12 +1,12 @@
 ---
-description: Follow these steps to deploy Appsmith on your Docker Compose platform.
+description: Follow these steps to deploy Appsmith on Docker.
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 # Docker
 
-This page provides instructions to install Appsmith using Docker.
+This page provides instructions to install Appsmith on Docker.
 
 <VideoEmbed host="youtube" videoId="Tde7GqE6FQQ" title="How to install Appsmith using Docker" 
 caption="How to install Appsmith using Docker Compose"/> 
@@ -20,27 +20,26 @@ caption="How to install Appsmith using Docker Compose"/>
 ## Install
 Go to the `appsmith` folder and follow the steps below to install Appsmith:
 
-<Tabs groupId="editions" >
-<TabItem label="Community Edition" value="community">
+<Tabs queryString="current-edition">
+<TabItem label="Community Edition" value="community_edition">
 
-1. There are two ways in which you can download the `docker-compose.yml` file:  
-   * Download the [`docker-compose.yml`](https://bit.ly/docker-compose-CE) file and place it into the Appsmith installation folder. 
+1. To download the `docker-compose.yml` file, run this cURL command:
+```bash
+curl -L https://bit.ly/docker-compose-CE -o $PWD/docker-compose.yml
+```
+This saves the file in the current directory.
 
-   * **Or** run the below cURL command:
-
-   ```bash
-   curl -L https://bit.ly/docker-compose-CE -o $PWD/docker-compose.yml
-   ```
-2. To start the Docker container, use the below command. You may have to run the command with `sudo` if you don't have permission to execute `docker-compose`. The below command downloads the Docker image if not present locally.
+2. Use this command to start the Docker container. If you don't have permission to run `docker-compose`, you may need to use `sudo`. The command downloads the Docker image if it's not already present.
 
 ```bash
 docker-compose up -d
 ```
-
-The server deploys Appsmith at startup, and you can access it at [http://localhost](http://localhost). You can also check the logs when deployment is in progress. Use the `docker logs -f appsmith` command to verify logs. After the deployment is complete, a message stating 'Appsmith is Running!' is displayed in the logs.
+:::info
+ The Appsmith deployment may take up to 5 minutes to complete. To confirm that the deployment is complete, run the command `docker logs -f appsmith`. When the deployment is complete, you can see the message 'Appsmith is Running!' in the logs. You can access it at [http://localhost](http://localhost).
+:::
 
 </TabItem>
-<TabItem label="Business Edition" value="business">
+<TabItem label="Business Edition" value="business_edition">
 
 :::info
 To upgrade your Community Edition to Business Edition, see [Upgrade to Business Edition](/getting-started/setup/upgrade-to-business-edition/docker).
@@ -48,21 +47,22 @@ To upgrade your Community Edition to Business Edition, see [Upgrade to Business 
 
 1. Sign up on [customer.appsmith.com](https://customer.appsmith.com) and generate a trial license key.
 
-2. There are two ways in which you can download the `docker-compose.yml` file:
-   * Download the [`docker-compose.yml`](https://bit.ly/docker-compose-be) file and place it into the Appsmith installation folder. 
-   
-   * **Or** run the below cURL command:
+2. To download the `docker-compose.yml` file, run this cURL command:
 
    ```bash
    curl -L https://bit.ly/docker-compose-be -o $PWD/docker-compose.yml
    ```
-3. To start the Docker container, use the below command. You may have to run the command with `sudo` if you don't have permission to execute `docker-compose`. The below command downloads the Docker image if not present locally.
+This saves the file in the current directory.
+
+3. Use this command to start the Docker container. If you don't have permission to run `docker-compose`, you may need to use `sudo`. The command downloads the Docker image if it's not already present.
 
 ```bash
 docker-compose up -d
 ```
 
-Starting the server deploys Appsmith. You can access it at [http://localhost](http://localhost). You can check the logs when deployment is in progress. Use the `docker logs -f appsmith` command to verify logs. After the deployment is complete, a message 'Appsmith is Running!' is displayed in the logs.
+:::info
+ The Appsmith deployment may take up to 5 minutes to complete. To confirm that the deployment is complete, run the command `docker logs -f appsmith`. When the deployment is complete, you can see the message 'Appsmith is Running!' in the logs. You can access Appsmith at [http://localhost](http://localhost).
+:::
 
 4. Log into your Appsmith account, and enter your license key to activate the instance.
 
@@ -76,9 +76,9 @@ Some common errors that you may face during installation:
 * [Containers failed to restart](/help-and-support/troubleshooting-guide/deployment-errors#containers-failed-to-start)
 * [Unable to access Appsmith](/help-and-support/troubleshooting-guide/deployment-errors#unable-to-access-appsmith) 
 
-If you continue to face issues, reach out to the support team on the <a href="#!" onclick="Intercom('show')">chat widget</a>.
+If you continue to face issues, reach out to the [support team](mailto:support@appsmith.com).
 
 ## Further reading
 
 * [Configure Appsmith instance](/getting-started/setup/instance-configuration#configure-docker-installations)
-* [Manage the Appsmith instance](/getting-started/setup/instance-management/)
+* [Manage Appsmith instance](/getting-started/setup/instance-management/)

--- a/website/docs/getting-started/setup/installation-guides/docker/README.mdx
+++ b/website/docs/getting-started/setup/installation-guides/docker/README.mdx
@@ -7,9 +7,10 @@ import TabItem from '@theme/TabItem';
 
 # Docker
 
-Docker is an open source [containerization](https://www.ibm.com/in-en/cloud/learn/containerization) platform. It enables developers to package applications into standardized executable components called containers. These containers combine the application's source code with the Operating System (OS) libraries and dependencies required to run that code in any environment.
+This page provides stepwise instructions to help you install Appsmith on Docker.
 
-<VideoEmbed host="youtube" videoId="Tde7GqE6FQQ" /> 
+<VideoEmbed host="youtube" videoId="Tde7GqE6FQQ" title="How to install Appsmith using Docker" 
+caption="How to install Appsmith using Docker"/> 
 
 ## Prerequisites
 

--- a/website/docs/getting-started/setup/installation-guides/docker/README.mdx
+++ b/website/docs/getting-started/setup/installation-guides/docker/README.mdx
@@ -15,10 +15,9 @@ caption="How to install Appsmith using Docker Compose"/>
 
 1. [Docker](https://docs.docker.com/get-docker/) (version 20.10.7 or later)
 2. [Docker-Compose](https://docs.docker.com/compose/install/) (version 1.29.2 or later)
-3. Create `appsmith` folder
 
 ## Install
-Go to the `appsmith` folder and follow the steps below to install Appsmith:
+To install Appsmith, first create a folder named `appsmith` to be used for deployment and data storage. Then, navigate to this folder using the `cd` command and follow the steps below:
 
 <Tabs queryString="current-edition">
 <TabItem label="Community Edition" value="community_edition">
@@ -35,8 +34,10 @@ This saves the file in the current directory.
 docker-compose up -d
 ```
 :::info
- The Appsmith deployment may take up to 5 minutes to complete. To confirm that the deployment is complete, run the command `docker logs -f appsmith`. When the deployment is complete, you can see the message 'Appsmith is Running!' in the logs. You can access it at [http://localhost](http://localhost).
+ The Appsmith deployment may take up to 5 minutes to complete.
 :::
+
+3. To confirm that the deployment is complete, run the command `docker logs -f appsmith`. When the deployment is complete, you can see the message 'Appsmith is Running!' in the logs. You can access it at [http://localhost](http://localhost).
 
 </TabItem>
 <TabItem label="Business Edition" value="business_edition">
@@ -61,10 +62,12 @@ docker-compose up -d
 ```
 
 :::info
- The Appsmith deployment may take up to 5 minutes to complete. To confirm that the deployment is complete, run the command `docker logs -f appsmith`. When the deployment is complete, you can see the message 'Appsmith is Running!' in the logs. You can access Appsmith at [http://localhost](http://localhost).
+ The Appsmith deployment may take up to 5 minutes to complete. 
 :::
 
-4. Log into your Appsmith account, and enter your license key to activate the instance.
+4. To confirm that the deployment is complete, run the command `docker logs -f appsmith`. When the deployment is complete, you can see the message 'Appsmith is Running!' in the logs. You can access Appsmith at [http://localhost](http://localhost).
+
+5. Log into your Appsmith account, and enter your license key to activate the instance.
 
 </TabItem>
 </Tabs>

--- a/website/docs/getting-started/setup/installation-guides/docker/README.mdx
+++ b/website/docs/getting-started/setup/installation-guides/docker/README.mdx
@@ -32,16 +32,31 @@ Follow the steps below to install Appsmith using Docker Compose:
 
 1. Download the `docker-compose.yml` file for the edition that you are using:
 
-   * **Community Edition** - Click to download the [`docker-compose.yml`](https://bit.ly/docker-compose-CE) file and place it into the Appsmith installation folder. **Or,** run the following cURL:
+<Tabs groupId="editions" >
+<TabItem label="Community Edition" value="community">
+   You can download the `docker-compose.yml` file from one of the below ways:
+
+   1. Click to download the [`docker-compose.yml`](https://bit.ly/docker-compose-CE) file and place it into the Appsmith installation folder. 
+   2. Run the following cURL:
 
       ```bash
       curl -L https://bit.ly/docker-compose-CE -o $PWD/docker-compose.yml
       ```
-   * **Business Edition** - Click to download the [`docker-compose.yml`](https://bit.ly/docker-compose-be) file, and place it into the Appsmith installation folder. **Or,** run the following cURL command:
+
+</TabItem>
+<TabItem label="Business Edition" value="business">
+
+   You can download the `docker-compose.yml` file from one of the below ways:
+   
+   1. Click to download the [`docker-compose.yml`](https://bit.ly/docker-compose-be) file, and place it into the Appsmith installation folder. 
+   2. Run the following cURL command:
 
       ```bash
          curl -L https://bit.ly/docker-compose-be -o $PWD/docker-compose.yml
       ```
+
+</TabItem>
+</Tabs>
 
 2. Use the below command to start the Docker container. If you can't access `docker` and `docker-compose`, you may need to run the command with `sudo`. The command downloads the docker image if not available on your computer.
 
@@ -62,10 +77,10 @@ Follow the steps below to install Appsmith using Docker Compose:
 
 <details id="Community Edition">
     <summary><b>Community Edition</b></summary>
+To download the `docker-compse.yml` file, you have two options:
 
-* Click to download the [`docker-compose.yml`](https://bit.ly/docker-compose-CE) file and place it into the Appsmith installation folder.
-
-* Or run the following cURL:
+1. Click to download the [`docker-compose.yml`](https://bit.ly/docker-compose-CE) file and place it into the Appsmith installation folder. 
+2. Run the following cURL:
 
    ```bash
    curl -L https://bit.ly/docker-compose-CE -o $PWD/docker-compose.yml
@@ -76,9 +91,9 @@ Follow the steps below to install Appsmith using Docker Compose:
 <details id="Business Edition">
     <summary><b>Business Edition</b> </summary>
 
-* Click to download the [`docker-compose.yml`](https://bit.ly/docker-compose-be) file, and place it into the Appsmith installation folder. 
-      
-* Or, run the following cURL command:
+To download the `docker-compse.yml` file, you have two options:
+1. Click to download the [`docker-compose.yml`](https://bit.ly/docker-compose-be) file, and place it into the Appsmith installation folder. 
+2. Run the following cURL command:
 
    ```bash
    curl -L https://bit.ly/docker-compose-be -o $PWD/docker-compose.yml

--- a/website/docs/getting-started/setup/installation-guides/docker/README.mdx
+++ b/website/docs/getting-started/setup/installation-guides/docker/README.mdx
@@ -6,7 +6,7 @@ import TabItem from '@theme/TabItem';
 
 # Docker
 
-This page provides stepwise instructions to help you install Appsmith using Docker.
+This page provides instructions to install Appsmith locally using Docker.
 
 <VideoEmbed host="youtube" videoId="Tde7GqE6FQQ" title="How to install Appsmith using Docker" 
 caption="How to install Appsmith using Docker"/> 
@@ -15,18 +15,17 @@ caption="How to install Appsmith using Docker"/>
 
 1. [Docker](https://docs.docker.com/get-docker/) (version 20.10.7 or later)
 2. [Docker-Compose](https://docs.docker.com/compose/install/) (version 1.29.2 or later)
-3. Create a folder named `appsmith` for deployment and data storage, then navigate to it using `cd` command.
 
 ## Install
 
 Follow the steps below to install Appsmith using Docker Compose:
 
-1. Download the `docker-compose.yml` file for the edition that you are using:
-
 <Tabs groupId="editions" >
 <TabItem label="Community Edition" value="community">
 
-There are two ways in which you can download the `docker-compose.yml` file:
+1. Create a folder named `appsmith` for deployment and data storage, then navigate to it using `cd` command.
+
+2. There are two ways in which you can download the `docker-compose.yml` file:
    
 * Download the [`docker-compose.yml`](https://bit.ly/docker-compose-CE) file and place it into the Appsmith installation folder. 
 
@@ -35,6 +34,13 @@ There are two ways in which you can download the `docker-compose.yml` file:
 ```bash
 curl -L https://bit.ly/docker-compose-CE -o $PWD/docker-compose.yml
 ```
+3. To start the Docker container, use the following command. You may have to run the command with `sudo` if you don't have permission to execute `docker-compose`. The below command downloads the Docker image if not present locally.
+
+```bash
+docker-compose up -d
+```
+
+The server deploys Appsmith at startup, and you can access it at [http://localhost](http://localhost). You can also check the logs when deployment is in progress. Use the `docker logs -f appsmith` command to verify logs. After the deployment is complete, a message stating 'Appsmith is Running!' is displayed in the logs.
 
 </TabItem>
 <TabItem label="Business Edition" value="business">
@@ -42,10 +48,11 @@ curl -L https://bit.ly/docker-compose-CE -o $PWD/docker-compose.yml
 :::info
 To upgrade your Community Edition to Business Edition, see [Upgrade to Business Edition using Docker](/getting-started/setup/upgrade-to-business-edition/docker).
 :::
+1. Create a folder named `appsmith` for deployment and data storage, then navigate to it using `cd` command.
 
-1. Sign up on [customer.appsmith.com](https://customer.appsmith.com) and generate a trial license key.
+2. Sign up on [customer.appsmith.com](https://customer.appsmith.com) and generate a trial license key.
 
-2. There are two ways in which you can download the `docker-compose.yml` file:
+3. There are two ways in which you can download the `docker-compose.yml` file:
    * Download the [`docker-compose.yml`](https://bit.ly/docker-compose-be) file, and place it into the Appsmith installation folder. 
    
    * Run the following cURL command:
@@ -53,30 +60,27 @@ To upgrade your Community Edition to Business Edition, see [Upgrade to Business 
    ```bash
    curl -L https://bit.ly/docker-compose-be -o $PWD/docker-compose.yml
    ```
-
-</TabItem>
-</Tabs>
-
-2. To start the Docker container, use the following command. You may have to run the command with `sudo` if you don't have permission to execute `docker-compose`. The below command downloads the Docker image if not present locally.
+4. To start the Docker container, use the following command. You may have to run the command with `sudo` if you don't have permission to execute `docker-compose`. The below command downloads the Docker image if not present locally.
 
 ```bash
 docker-compose up -d
 ```
 
-The server deploys Appsmith at startup, and you can access it at [http://localhost](http://localhost). You can also check the message "Appsmith is Running!" displayed in docker logs by using `docker logs -f appsmith` command.
+The server deploys Appsmith at startup, and you can access it at [http://localhost](http://localhost). You can also check the logs when deployment is in progress. Use the `docker logs -f appsmith` command to verify logs. After the deployment is complete, a message stating 'Appsmith is Running!' is displayed in the logs.
 
-![Appsmith is running message](/img/InstallationGuides__Docker__AppsmithRunningMessage.png)
+5. After logging into your Appsmith account, enter your license key to activate the instance.
 
-:::info important
-If you are on a Business Edition, after logging into your Appsmith account, enter your license key to activate the instance.
-:::
+</TabItem>
+</Tabs>
 
 ## Troubleshooting
 
-If you see any errors during deployment, refer to:
+Here are some common problems that you may encounter during installation:
 * [Ports unavailable](/help-and-support/troubleshooting-guide/deployment-errors#ports-unavailable)
 * [Containers failed to restart](/help-and-support/troubleshooting-guide/deployment-errors#containers-failed-to-start)
 * [Unable to access Appsmith](/help-and-support/troubleshooting-guide/deployment-errors#unable-to-access-appsmith) 
+
+If you are still facing issues, reach out to the support team on the <a href="#!" onclick="Intercom('show')">chat widget</a> available on this page.
 
 ## Further reading
 

--- a/website/docs/getting-started/setup/installation-guides/docker/README.mdx
+++ b/website/docs/getting-started/setup/installation-guides/docker/README.mdx
@@ -1,40 +1,37 @@
 ---
-description: Deploy Appsmith locally or on a private instance with ease using Docker Compose. Follow these simple steps to set up Appsmith on your Docker Compose platform.
+description: Follow these steps to deploy Appsmith on your Docker Compose platform.
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 # Docker
 
-This page provides instructions to install Appsmith locally using Docker.
+This page provides instructions to install Appsmith using Docker.
 
 <VideoEmbed host="youtube" videoId="Tde7GqE6FQQ" title="How to install Appsmith using Docker" 
-caption="How to install Appsmith using Docker"/> 
+caption="How to install Appsmith using Docker Compose"/> 
 
 ## Prerequisites
 
 1. [Docker](https://docs.docker.com/get-docker/) (version 20.10.7 or later)
 2. [Docker-Compose](https://docs.docker.com/compose/install/) (version 1.29.2 or later)
+3. Create `appsmith` folder
 
 ## Install
-
-Follow the steps below to install Appsmith using Docker Compose:
+Go to the `appsmith` folder and follow the steps below to install Appsmith:
 
 <Tabs groupId="editions" >
 <TabItem label="Community Edition" value="community">
 
-1. Create a folder named `appsmith` for deployment and data storage, then navigate to it using `cd` command.
+1. There are two ways in which you can download the `docker-compose.yml` file:  
+   * Download the [`docker-compose.yml`](https://bit.ly/docker-compose-CE) file and place it into the Appsmith installation folder. 
 
-2. There are two ways in which you can download the `docker-compose.yml` file:
-   
-* Download the [`docker-compose.yml`](https://bit.ly/docker-compose-CE) file and place it into the Appsmith installation folder. 
+   * **Or** run the below cURL command:
 
-* Or run the following cURL command:
-
-```bash
-curl -L https://bit.ly/docker-compose-CE -o $PWD/docker-compose.yml
-```
-3. To start the Docker container, use the following command. You may have to run the command with `sudo` if you don't have permission to execute `docker-compose`. The below command downloads the Docker image if not present locally.
+   ```bash
+   curl -L https://bit.ly/docker-compose-CE -o $PWD/docker-compose.yml
+   ```
+2. To start the Docker container, use the below command. You may have to run the command with `sudo` if you don't have permission to execute `docker-compose`. The below command downloads the Docker image if not present locally.
 
 ```bash
 docker-compose up -d
@@ -46,41 +43,40 @@ The server deploys Appsmith at startup, and you can access it at [http://localho
 <TabItem label="Business Edition" value="business">
 
 :::info
-To upgrade your Community Edition to Business Edition, see [Upgrade to Business Edition using Docker](/getting-started/setup/upgrade-to-business-edition/docker).
+To upgrade your Community Edition to Business Edition, see [Upgrade to Business Edition](/getting-started/setup/upgrade-to-business-edition/docker).
 :::
-1. Create a folder named `appsmith` for deployment and data storage, then navigate to it using `cd` command.
 
-2. Sign up on [customer.appsmith.com](https://customer.appsmith.com) and generate a trial license key.
+1. Sign up on [customer.appsmith.com](https://customer.appsmith.com) and generate a trial license key.
 
-3. There are two ways in which you can download the `docker-compose.yml` file:
-   * Download the [`docker-compose.yml`](https://bit.ly/docker-compose-be) file, and place it into the Appsmith installation folder. 
+2. There are two ways in which you can download the `docker-compose.yml` file:
+   * Download the [`docker-compose.yml`](https://bit.ly/docker-compose-be) file and place it into the Appsmith installation folder. 
    
-   * Run the following cURL command:
+   * **Or** run the below cURL command:
 
    ```bash
    curl -L https://bit.ly/docker-compose-be -o $PWD/docker-compose.yml
    ```
-4. To start the Docker container, use the following command. You may have to run the command with `sudo` if you don't have permission to execute `docker-compose`. The below command downloads the Docker image if not present locally.
+3. To start the Docker container, use the below command. You may have to run the command with `sudo` if you don't have permission to execute `docker-compose`. The below command downloads the Docker image if not present locally.
 
 ```bash
 docker-compose up -d
 ```
 
-The server deploys Appsmith at startup, and you can access it at [http://localhost](http://localhost). You can also check the logs when deployment is in progress. Use the `docker logs -f appsmith` command to verify logs. After the deployment is complete, a message stating 'Appsmith is Running!' is displayed in the logs.
+Starting the server deploys Appsmith. You can access it at [http://localhost](http://localhost). You can check the logs when deployment is in progress. Use the `docker logs -f appsmith` command to verify logs. After the deployment is complete, a message 'Appsmith is Running!' is displayed in the logs.
 
-5. After logging into your Appsmith account, enter your license key to activate the instance.
+4. Log into your Appsmith account, and enter your license key to activate the instance.
 
 </TabItem>
 </Tabs>
 
 ## Troubleshooting
 
-Here are some common problems that you may encounter during installation:
+Some common errors that you may face during installation:
 * [Ports unavailable](/help-and-support/troubleshooting-guide/deployment-errors#ports-unavailable)
 * [Containers failed to restart](/help-and-support/troubleshooting-guide/deployment-errors#containers-failed-to-start)
 * [Unable to access Appsmith](/help-and-support/troubleshooting-guide/deployment-errors#unable-to-access-appsmith) 
 
-If you are still facing issues, reach out to the support team on the <a href="#!" onclick="Intercom('show')">chat widget</a> available on this page.
+If you continue to face issues, reach out to the support team on the <a href="#!" onclick="Intercom('show')">chat widget</a>.
 
 ## Further reading
 

--- a/website/docs/getting-started/setup/installation-guides/docker/README.mdx
+++ b/website/docs/getting-started/setup/installation-guides/docker/README.mdx
@@ -1,6 +1,5 @@
 ---
-description: Appsmith can be deployed locally or on a private instance using Docker
-sidebar_position: 1
+description: Deploy Appsmith locally or on a private instance with ease using Docker Compose. Follow these simple steps to set up Appsmith on your Docker Compose platform.
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -22,10 +21,6 @@ caption="How to install Appsmith using Docker"/>
 2. [Docker-Compose](https://docs.docker.com/compose/install/) (version 1.29.2 or later)
 3. Create a folder named `appsmith` for deployment and data storage, then navigate to it using `cd` command.
 
-:::info
-Boost your app development with advanced features offered by Appsmith Business Edition. For more information, see [Business Edition](https://www.appsmith.com/pricing).
-:::
-
 ## Install
 
 Follow the steps below to install Appsmith using Docker Compose:
@@ -34,83 +29,35 @@ Follow the steps below to install Appsmith using Docker Compose:
 
 <Tabs groupId="editions" >
 <TabItem label="Community Edition" value="community">
-   You can download the `docker-compose.yml` file from one of the below ways:
 
-   1. Click to download the [`docker-compose.yml`](https://bit.ly/docker-compose-CE) file and place it into the Appsmith installation folder. 
-   2. Run the following cURL:
+Download the [`docker-compose.yml`](https://bit.ly/docker-compose-CE) file and place it into the Appsmith installation folder. Or run the following cURL:
 
-      ```bash
-      curl -L https://bit.ly/docker-compose-CE -o $PWD/docker-compose.yml
-      ```
+```bash
+curl -L https://bit.ly/docker-compose-CE -o $PWD/docker-compose.yml
+```
 
 </TabItem>
 <TabItem label="Business Edition" value="business">
 
-   You can download the `docker-compose.yml` file from one of the below ways:
-   
-   1. Click to download the [`docker-compose.yml`](https://bit.ly/docker-compose-be) file, and place it into the Appsmith installation folder. 
-   2. Run the following cURL command:
+Download the [`docker-compose.yml`](https://bit.ly/docker-compose-be) file, and place it into the Appsmith installation folder. Or run the following cURL command:
 
-      ```bash
-         curl -L https://bit.ly/docker-compose-be -o $PWD/docker-compose.yml
-      ```
+```bash
+ curl -L https://bit.ly/docker-compose-be -o $PWD/docker-compose.yml
+```
 
 </TabItem>
 </Tabs>
 
-2. Use the below command to start the Docker container. If you can't access `docker` and `docker-compose`, you may need to run the command with `sudo`. The command downloads the docker image if not available on your computer.
-
-   ```bash
-   docker-compose up -d
-   ```
-Upon restarting the server, Appsmith is deployed and accessible through [http://localhost](http://localhost). You may verify that the instance is functioning correctly by checking the [instance logs](/learning-and-resources/how-to-guides/how-to-get-container-logs#docker).
-
-:::info important
-If you already have a **Business Edition** license key, sign in to your Appsmith account, and enter your license key to activate the instance. If you need a license key, sign up on [customer.appsmith.com](https://customer.appsmith.com).
-:::
-
-## Install
-
-Follow the steps below to install Appsmith using Docker Compose:
-
-1. Download the `docker-compose.yml` file for the Appsmith edition that you are using:
-
-<details id="Community Edition">
-    <summary><b>Community Edition</b></summary>
-To download the `docker-compse.yml` file, you have two options:
-
-1. Click to download the [`docker-compose.yml`](https://bit.ly/docker-compose-CE) file and place it into the Appsmith installation folder. 
-2. Run the following cURL:
-
-   ```bash
-   curl -L https://bit.ly/docker-compose-CE -o $PWD/docker-compose.yml
-   ```
-
-</details>
-
-<details id="Business Edition">
-    <summary><b>Business Edition</b> </summary>
-
-To download the `docker-compse.yml` file, you have two options:
-1. Click to download the [`docker-compose.yml`](https://bit.ly/docker-compose-be) file, and place it into the Appsmith installation folder. 
-2. Run the following cURL command:
-
-   ```bash
-   curl -L https://bit.ly/docker-compose-be -o $PWD/docker-compose.yml
-   ```
-
-</details>
-
-2. Use the below command to start the Docker container. If you can't access `docker` and `docker-compose`, you may need to run the command with `sudo`. The command downloads the docker image if not available on your computer.
+2. To start the Docker container, use the following command. If you're unable to access `docker` and `docker-compose`, you may need to run the command with `sudo`. The below command downloads the Docker image if not present on your computer.
 
    ```bash
    docker-compose up -d
    ```
 
-Upon restarting the server, Appsmith is deployed and accessible through [http://localhost](http://localhost). You may verify that the instance is functioning correctly by checking the [instance logs](/learning-and-resources/how-to-guides/how-to-get-container-logs#docker).
+The server deploys Appsmith at startup, and you can access it at [http://localhost](http://localhost). You can check the  [instance logs](/learning-and-resources/how-to-guides/how-to-get-container-logs#docker) to verify that the instance is up and running.
 
 :::info important
-If you already have a **Business Edition** license key, sign in to your Appsmith account, and enter your license key to activate the instance. If you need a license key, sign up on [customer.appsmith.com](https://customer.appsmith.com).
+If you are on a Business Edition, after logging into your Appsmith account, enter your license key to activate the instance. If you need a license key, sign up for a free trial at [customer.appsmith.com](https://customer.appsmith.com).
 :::
 
 ## Troubleshooting

--- a/website/docs/getting-started/setup/installation-guides/docker/README.mdx
+++ b/website/docs/getting-started/setup/installation-guides/docker/README.mdx
@@ -6,7 +6,7 @@ import TabItem from '@theme/TabItem';
 
 # Docker
 
-This page provides instructions to install Appsmith on Docker.
+This page provides instructions to install Appsmith using Docker.
 
 <VideoEmbed host="youtube" videoId="Tde7GqE6FQQ" title="How to install Appsmith using Docker" 
 caption="How to install Appsmith using Docker Compose"/> 
@@ -16,24 +16,26 @@ caption="How to install Appsmith using Docker Compose"/>
 1. [Docker](https://docs.docker.com/get-docker/) (version 20.10.7 or later)
 2. [Docker-Compose](https://docs.docker.com/compose/install/) (version 1.29.2 or later)
 
-## Install
-To install Appsmith, first create a folder named `appsmith` to be used for deployment and data storage. Then, navigate to this folder using the `cd` command and follow the steps below:
+## Install Appsmith
+Create a folder named `appsmith` on your machine for deployment and data storage. Then, navigate to this folder using the `cd` command and follow the steps below:
 
 <Tabs queryString="current-edition">
 <TabItem label="Community Edition" value="community_edition">
 
-1. To download the `docker-compose.yml` file, run this cURL command:
+1. To download the `docker-compose.yml` file, run the following cURL command:
 ```bash
 curl -L https://bit.ly/docker-compose-CE -o $PWD/docker-compose.yml
 ```
-This saves the file in the current directory.
+This command saves the file in the current directory.
 
-2. Use this command to start the Docker container. If you don't have permission to run `docker-compose`, you may need to use `sudo`. The command downloads the Docker image if it's not already present.
+2. Start the Docker container using the following command. You may need to run with `sudo` if you don't have permission to run `docker-compose`. 
 
 ```bash
 docker-compose up -d
 ```
-:::info
+If the image doesn't exist locally, this command downloads the necessary Docker image and starts the container.
+
+:::note
  The Appsmith deployment may take up to 5 minutes to complete.
 :::
 
@@ -48,20 +50,22 @@ To upgrade your Community Edition to Business Edition, see [Upgrade to Business 
 
 1. Sign up on [customer.appsmith.com](https://customer.appsmith.com) and generate a trial license key.
 
-2. To download the `docker-compose.yml` file, run this cURL command:
+2. To download the `docker-compose.yml` file, run the following cURL command:
 
    ```bash
    curl -L https://bit.ly/docker-compose-be -o $PWD/docker-compose.yml
    ```
 This saves the file in the current directory.
 
-3. Use this command to start the Docker container. If you don't have permission to run `docker-compose`, you may need to use `sudo`. The command downloads the Docker image if it's not already present.
+3. Start the Docker container using the following command. You may need to run with `sudo` if you don't have permission to run `docker-compose`. 
 
 ```bash
 docker-compose up -d
 ```
 
-:::info
+If the image doesn't exist locally, this command downloads the necessary Docker image and starts the container.
+
+:::note
  The Appsmith deployment may take up to 5 minutes to complete. 
 :::
 

--- a/website/docs/getting-started/setup/instance-management/README.mdx
+++ b/website/docs/getting-started/setup/instance-management/README.mdx
@@ -7,18 +7,6 @@ import TabItem from '@theme/TabItem';
 
 # Instance Management
 
-## Updating to the latest release
-
-You can perform a manual update of your Appsmith instance by running the following commands in the Appsmith installation directory.
-
-```bash
-// To restart appsmith without docker compose
-docker pull appsmith/appsmith-ce && docker restart appsmith
-
-// To restart appsmith with docker compose
-docker-compose pull && docker-compose up -d --force-recreate appsmith
-```
-
 ## Checkpoint version and upgrades
 
 When you upgrade manually, you must upgrade to the checkpoint version released between your version and the latest version.

--- a/website/docs/getting-started/setup/instance-management/update-appsmith.md
+++ b/website/docs/getting-started/setup/instance-management/update-appsmith.md
@@ -12,9 +12,9 @@ The steps below apply to both the Community and Business editions.
 ## Prerequisites
 Before you start the update process, make sure you complete the below steps:
 
-* Ensure that you have at least 2 GB of free storage space for backup and update tasks.
-* You can create a backup of the Appsmith instance before a manual update. To create a backup, see [Backup Appsmith Instance](/getting-started/setup/instance-management/appsmithctl#backup-appsmith-instance) (_Recommended_)
-* If you are on a version earlier than v1.9.2, first upgrade to version v1.9.2.  To upgrade to a checkpoint version, see [Checkpoint version and upgrade](/getting-started/setup/instance-management#checkpoint-version-and-upgrades).
+* Ensure you have at least 2 GB of free storage space for backup and update tasks.
+* You can create a backup of the Appsmith instance before a manual update. For more information, see [Backup Appsmith Instance](/getting-started/setup/instance-management/appsmithctl#backup-appsmith-instance) (_Recommended_)
+* If you are on a version earlier than v1.9.2, first upgrade to version v1.9.2.  For more information, see [Checkpoint version and upgrade](/getting-started/setup/instance-management#checkpoint-version-and-upgrades).
 
 ## Docker Compose
 The steps below work with any platform that supports Docker. For example, Docker, AWS AMI, or DigitalOcean.
@@ -25,7 +25,7 @@ You can update Appsmith in one of the following ways:
 * [Automatic update](#automatic-update)
 
 :::info
-To find the directory where Appsmith is installed, run the following command:
+To find the Appsmith installation directory, run the following command:
 
 ```
 docker inspect -f '{{ (index .Mounts 0).Source }}' <APPSMITH_CONTAINER_ID>
@@ -75,10 +75,10 @@ Before an automatic update, Appsmith creates a backup. You may use this to rollb
    docker-compose up -d
    ```
 
-When the server restarts, Appsmith is updated to the latest version. This configuration runs an Appsmith instance and a Watchtower instance to keep Appsmith updated automatically. You may also schedule automatic updates for your instance. For more information, see [Configure auto-updates](/getting-started/setup/instance-management/maintenance-window#adding-a-configurable-maintenance-window-for-appsmiths-auto-updates).
+When the server restarts, Appsmith updates to the latest version. This setup runs an Appsmith instance and a Watchtower instance to auto-update Appsmith. You may also schedule automatic updates for your instance. For more information, see [Configure auto-updates](/getting-started/setup/instance-management/maintenance-window#adding-a-configurable-maintenance-window-for-appsmiths-auto-updates).
 
 ## Troubleshooting
 
 If you see deployment errors, you can rollback to a previous version to fix the issue. For more information, see [Restore Appsmith instance](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance). 
 
-If you continue to face issues, reach out to the [support team](mailto:support@appsmith.com).
+If you continue to face issues, contact the [support team](mailto:support@appsmith.com).

--- a/website/docs/getting-started/setup/instance-management/update-appsmith.md
+++ b/website/docs/getting-started/setup/instance-management/update-appsmith.md
@@ -29,7 +29,7 @@ docker-compose pull && docker-compose rm -fsv appsmith && docker-compose up -d
 
 ### Automatic update
 
-Follow the below steps to turn on the auto updates:
+When you turn on automatic update, it first creates a backup and then starts the update. Follow the below steps to turn on the auto updates:
 
 1. Go to the root directory of the Appsmith installation and run:
 
@@ -48,6 +48,6 @@ Restarting the server deploys the latest version of Appsmith. You have the optio
 
 ## Troubleshooting
 
-When you turn on automatic update, it first creates a backup and then starts the update. If you see deployment errors, you can roll back to a previous version to fix the issue. To roll back, see [the rollback instructions using the `appsmithctl` command](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance). 
+If you see deployment errors, you can roll back to a previous version to fix the issue. To roll back, see [the rollback instructions using the `appsmithctl` command](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance). 
 
 If you continue to face issues, reach out to the support team on the <a href="#!" onclick="Intercom('show')">chat widget</a>.

--- a/website/docs/getting-started/setup/instance-management/update-appsmith.md
+++ b/website/docs/getting-started/setup/instance-management/update-appsmith.md
@@ -75,7 +75,9 @@ Before an automatic update, Appsmith creates a backup. You may use this to rollb
    docker-compose up -d
    ```
 
-When the server restarts, Appsmith updates to the latest version. This setup runs an Appsmith and a Watchtower container. The Watchtower checks and updates Appsmith whenever a new version becomes available. You may also schedule automatic updates for your instance. For more information, see [Configure auto-updates](/getting-started/setup/instance-management/maintenance-window#adding-a-configurable-maintenance-window-for-appsmiths-auto-updates).
+When the server restarts, Appsmith updates to the latest version. This setup runs an Appsmith and a Watchtower container. The Watchtower checks and updates Appsmith when a new version becomes available. 
+
+You may also schedule automatic updates for your instance. For more information, see [Configure auto-updates](/getting-started/setup/instance-management/maintenance-window#adding-a-configurable-maintenance-window-for-appsmiths-auto-updates).
 
 ## Troubleshooting
 

--- a/website/docs/getting-started/setup/instance-management/update-appsmith.md
+++ b/website/docs/getting-started/setup/instance-management/update-appsmith.md
@@ -75,7 +75,7 @@ Before an automatic update, Appsmith creates a backup. You may use this to rollb
    docker-compose up -d
    ```
 
-When the server restarts, Appsmith updates to the latest version. This setup runs an Appsmith instance and a Watchtower instance to auto update Appsmith. You may also schedule automatic updates for your instance. For more information, see [Configure auto-updates](/getting-started/setup/instance-management/maintenance-window#adding-a-configurable-maintenance-window-for-appsmiths-auto-updates).
+When the server restarts, Appsmith updates to the latest version. This setup runs an Appsmith instance and a Watchtower instance to automate updates. You may also schedule automatic updates for your instance. For more information, see [Configure auto-updates](/getting-started/setup/instance-management/maintenance-window#adding-a-configurable-maintenance-window-for-appsmiths-auto-updates).
 
 ## Troubleshooting
 

--- a/website/docs/getting-started/setup/instance-management/update-appsmith.md
+++ b/website/docs/getting-started/setup/instance-management/update-appsmith.md
@@ -44,7 +44,7 @@ docker-compose pull && docker-compose rm -fsv appsmith && docker-compose up -d
 Follow the below steps to turn on the auto updates:
 
 :::info
-An automatic update creates a backup before starting the update. You can use this backup to roll back the update in case of any issues.
+Before an automatic update, Appsmith creates a backup. This can be used to rollback to a previous version in case case of any issues.
 :::
 
 1. Go to the root directory of the Appsmith installation and run:

--- a/website/docs/getting-started/setup/instance-management/update-appsmith.md
+++ b/website/docs/getting-started/setup/instance-management/update-appsmith.md
@@ -17,7 +17,7 @@ Before you start the update process, make sure you complete the below steps:
 * If you are on a version earlier than v1.9.2, first upgrade to version v1.9.2. To upgrade, see the [Checkpoint version and upgrade](/getting-started/setup/instance-management#checkpoint-version-and-upgrades) section.
 
 ## Docker Compose
-The below steps work on any platform that uses `docker-compose`. For example, Docker, AWS AMI, or DigitalOcean.
+The steps below work with any platform that supports Docker. For example, Docker, AWS AMI, or DigitalOcean.
 
 You can update Appsmith in one of the below ways:
 
@@ -25,7 +25,8 @@ You can update Appsmith in one of the below ways:
 * [Automatic update](#automatic-update)
 
 :::info
-If you don't know the installation directory, run:
+To find where Appsmith is installed, run the below command:
+
 ```
 docker inspect -f '{{ (index .Mounts 0).Source }}' <APPSMITH_CONTAINER_ID>
 ```

--- a/website/docs/getting-started/setup/instance-management/update-appsmith.md
+++ b/website/docs/getting-started/setup/instance-management/update-appsmith.md
@@ -21,7 +21,7 @@ You can update Appsmith in one of the following ways:
 * [Automatic update](#automatic-update)
 
 ### Manual update
-Go to the root directory of the installation and run:
+Go to the root directory of your installation and run:
 
 ```
 docker-compose pull && docker-compose rm -fsv appsmith && docker-compose up -d
@@ -37,7 +37,7 @@ Follow the below steps to turn on the auto updates:
    docker-compose down
    ```
 
-2. Open the `docker-compose.yml` file with any text editor and uncomment lines 13-23.
+2. Open the `docker-compose.yml` file and uncomment lines 13-23.
 3. Save the file and run:
 
    ```
@@ -48,6 +48,6 @@ When you restart the server, the latest version of Appsmith is deployed. You can
 
 ## Troubleshooting
 
-When you turn on automatic updates, it turns on the auto backup feature. And creates a backup before an update. You can roll back to a previous version if you see deployment errors. Refer to [the rollback instructions using the `appsmithctl` command](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance). 
+When you turn on automatic updates, it turns on the auto backup feature. And creates a backup before an update. If you see deployment errors, you can roll back to a previous version to fix the issue. Refer to [the rollback instructions using the `appsmithctl` command](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance). 
 
-If you continue to face issues, reach out to the support team on the <a href="#!" onclick="Intercom('show')">chat widget</a>.
+If you are facing issues, reach out to the support team on the <a href="#!" onclick="Intercom('show')">chat widget</a>.

--- a/website/docs/getting-started/setup/instance-management/update-appsmith.md
+++ b/website/docs/getting-started/setup/instance-management/update-appsmith.md
@@ -75,7 +75,7 @@ Before an automatic update, Appsmith creates a backup. You may use this to rollb
    docker-compose up -d
    ```
 
-When the server restarts, Appsmith updates to the latest version. This setup runs an Appsmith instance and a Watchtower instance. The Watchtower checks and  updates the instance whenever a new version becomes available. You may also schedule automatic updates for your instance. For more information, see [Configure auto-updates](/getting-started/setup/instance-management/maintenance-window#adding-a-configurable-maintenance-window-for-appsmiths-auto-updates).
+When the server restarts, Appsmith updates to the latest version. This setup runs an Appsmith instance and a Watchtower instance. The Watchtower checks and updates the instance whenever a new version becomes available. You may also schedule automatic updates for your instance. For more information, see [Configure auto-updates](/getting-started/setup/instance-management/maintenance-window#adding-a-configurable-maintenance-window-for-appsmiths-auto-updates).
 
 ## Troubleshooting
 

--- a/website/docs/getting-started/setup/instance-management/update-appsmith.md
+++ b/website/docs/getting-started/setup/instance-management/update-appsmith.md
@@ -44,7 +44,7 @@ docker-compose pull && docker-compose rm -fsv appsmith && docker-compose up -d
 Follow the below steps to turn on the auto updates:
 
 :::info
-Before an automatic update, Appsmith creates a backup. You may this to rollback to a previous version in case case of any issues.
+Before an automatic update, Appsmith creates a backup. You may use this to rollback to a previous version in case of any issues.
 :::
 
 1. Go to the root directory of the Appsmith installation and run:

--- a/website/docs/getting-started/setup/instance-management/update-appsmith.md
+++ b/website/docs/getting-started/setup/instance-management/update-appsmith.md
@@ -75,7 +75,7 @@ Before an automatic update, Appsmith creates a backup. You may use this to rollb
    docker-compose up -d
    ```
 
-When the server restarts, Appsmith updates to the latest version. This setup runs an Appsmith instance and a Watchtower instance to auto-update Appsmith. You may also schedule automatic updates for your instance. For more information, see [Configure auto-updates](/getting-started/setup/instance-management/maintenance-window#adding-a-configurable-maintenance-window-for-appsmiths-auto-updates).
+When the server restarts, Appsmith updates to the latest version. This setup runs an Appsmith instance and a Watchtower instance to auto update Appsmith. You may also schedule automatic updates for your instance. For more information, see [Configure auto-updates](/getting-started/setup/instance-management/maintenance-window#adding-a-configurable-maintenance-window-for-appsmiths-auto-updates).
 
 ## Troubleshooting
 

--- a/website/docs/getting-started/setup/instance-management/update-appsmith.md
+++ b/website/docs/getting-started/setup/instance-management/update-appsmith.md
@@ -8,9 +8,9 @@ This page provides instructions to update Appsmith to the latest version.
 ## Prerequisites
 Ensure that you complete the following steps before starting the update process.
 
-* At least 2 GB of free storage.
-* Create a backup of the Appsmith instance before a manual update. Refer to the [Backup Appsmith Instance](/getting-started/setup/instance-management/appsmithctl#backup-appsmith-instance) section.
-* If you are on a version earlier than v1.9.2, first upgrade to version v1.9.2. Refer to the [Checkpoint version and upgrade](/getting-started/setup/instance-management#checkpoint-version-and-upgrades) section.
+* For backup and update tasks, you need at least 2 GB of free storage.
+* You need to create a backup of the Appsmith instance before a manual update. To create a backup, see the [Backup Appsmith Instance](/getting-started/setup/instance-management/appsmithctl#backup-appsmith-instance) section.
+* If you are on a version earlier than v1.9.2, first upgrade to version v1.9.2. To upgrade, see the [Checkpoint version and upgrade](/getting-started/setup/instance-management#checkpoint-version-and-upgrades) section.
 
 ## Docker Compose
 Follow the below steps on Docker or platforms that use `docker-compose`. For example, AWS AMI or DigitalOcean.  
@@ -44,10 +44,10 @@ Follow the below steps to turn on the auto updates:
    docker-compose up -d
    ```
 
-When you restart the server, the latest version of Appsmith is deployed. You can choose to schedule automatic updates. Refer to [Configure a maintenance window](/getting-started/setup/instance-management/maintenance-window#adding-a-configurable-maintenance-window-for-appsmiths-auto-updates).
+Restarting the server deploys the latest version of Appsmith. You have the option to schedule automatic updates for your instance. To schedule automatic updates, see [Configure auto-updates](/getting-started/setup/instance-management/maintenance-window#adding-a-configurable-maintenance-window-for-appsmiths-auto-updates).
 
 ## Troubleshooting
 
-When you turn on automatic updates, it turns on the auto backup feature. And creates a backup before an update. If you see deployment errors, you can roll back to a previous version to fix the issue. Refer to [the rollback instructions using the `appsmithctl` command](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance). 
+When you turn on automatic update, it first creates a backup and then starts the update. If you see deployment errors, you can roll back to a previous version to fix the issue. To roll back, see [the rollback instructions using the `appsmithctl` command](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance). 
 
-If you are facing issues, reach out to the support team on the <a href="#!" onclick="Intercom('show')">chat widget</a>.
+If you continue to face issues, reach out to the support team on the <a href="#!" onclick="Intercom('show')">chat widget</a>.

--- a/website/docs/getting-started/setup/instance-management/update-appsmith.md
+++ b/website/docs/getting-started/setup/instance-management/update-appsmith.md
@@ -44,7 +44,7 @@ docker-compose pull && docker-compose rm -fsv appsmith && docker-compose up -d
 Follow the below steps to turn on the auto updates:
 
 :::info
-Before an automatic update, Appsmith creates a backup. You may use this to rollback to a previous version in case of any issues.
+Before an automatic update, Appsmith creates a backup. You may use this to roll back to a previous version in case of any issues.
 :::
 
 1. Go to the root directory of the Appsmith installation and run:
@@ -79,6 +79,6 @@ When the server restarts, Appsmith updates to the latest version. This setup run
 
 ## Troubleshooting
 
-If you see deployment errors, you can rollback to a previous version to fix the issue. For more information, see [Restore Appsmith instance](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance). 
+If you see deployment errors, you can roll back to a previous version to fix the issue. For more information, see [Restore Appsmith instance](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance). 
 
 If you continue to face issues, contact the [support team](mailto:support@appsmith.com).

--- a/website/docs/getting-started/setup/instance-management/update-appsmith.md
+++ b/website/docs/getting-started/setup/instance-management/update-appsmith.md
@@ -14,18 +14,18 @@ Before you start the update process, make sure you complete the below steps:
 
 * Ensure that you have at least 2 GB of free storage space for backup and update tasks.
 * You can create a backup of the Appsmith instance before a manual update. To create a backup, see [Backup Appsmith Instance](/getting-started/setup/instance-management/appsmithctl#backup-appsmith-instance) (_Recommended_)
-* If you are on a version earlier than v1.9.2, first upgrade to version v1.9.2.  For more information, see [Checkpoint version and upgrade](/getting-started/setup/instance-management#checkpoint-version-and-upgrades).
+* If you are on a version earlier than v1.9.2, first upgrade to version v1.9.2.  To upgrade to a checkpoint version, see [Checkpoint version and upgrade](/getting-started/setup/instance-management#checkpoint-version-and-upgrades).
 
 ## Docker Compose
 The steps below work with any platform that supports Docker. For example, Docker, AWS AMI, or DigitalOcean.
 
-You can update Appsmith in one of the below ways:
+You can update Appsmith in one of the following ways:
 
 * [Manual update](#manual-update)
 * [Automatic update](#automatic-update)
 
 :::info
-To find where Appsmith is installed, run the below command:
+To find the directory where Appsmith is installed, run the following command:
 
 ```
 docker inspect -f '{{ (index .Mounts 0).Source }}' <APPSMITH_CONTAINER_ID>
@@ -44,7 +44,7 @@ docker-compose pull && docker-compose rm -fsv appsmith && docker-compose up -d
 Follow the below steps to turn on the auto updates:
 
 :::info
-Before an automatic update, Appsmith creates a backup. This can be used to rollback to a previous version in case case of any issues.
+Before an automatic update, Appsmith creates a backup. You may this to rollback to a previous version in case case of any issues.
 :::
 
 1. Go to the root directory of the Appsmith installation and run:
@@ -75,7 +75,7 @@ Before an automatic update, Appsmith creates a backup. This can be used to rollb
    docker-compose up -d
    ```
 
-When the server restarts, Appsmith is updated to the latest version. This configuration runs an Appsmith instance and a Watchtower instance to keep Appsmith up-to-date automatically. You may also schedule automatic updates for your instance. For more information, see [Configure auto-updates](/getting-started/setup/instance-management/maintenance-window#adding-a-configurable-maintenance-window-for-appsmiths-auto-updates).
+When the server restarts, Appsmith is updated to the latest version. This configuration runs an Appsmith instance and a Watchtower instance to keep Appsmith updated automatically. You may also schedule automatic updates for your instance. For more information, see [Configure auto-updates](/getting-started/setup/instance-management/maintenance-window#adding-a-configurable-maintenance-window-for-appsmiths-auto-updates).
 
 ## Troubleshooting
 

--- a/website/docs/getting-started/setup/instance-management/update-appsmith.md
+++ b/website/docs/getting-started/setup/instance-management/update-appsmith.md
@@ -44,10 +44,10 @@ Follow the below steps to turn on the auto updates:
    docker-compose up -d
    ```
 
-The server restart updates the Appsmith to the latest version. You can choose to schedule automatic updates. Refer to [Configure a maintenance window](/getting-started/setup/instance-management/maintenance-window#adding-a-configurable-maintenance-window-for-appsmiths-auto-updates).
+When you restart the server, the latest version of Appsmith is deployed. You can choose to schedule automatic updates. Refer to [Configure a maintenance window](/getting-started/setup/instance-management/maintenance-window#adding-a-configurable-maintenance-window-for-appsmiths-auto-updates).
 
 ## Troubleshooting
 
 When you turn on automatic updates, it turns on the auto backup feature. And creates a backup before an update. You can roll back to a previous version if you see deployment errors. Refer to [the rollback instructions using the `appsmithctl` command](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance). 
 
-If you are still having issues, reach out to the support team on the <a href="#!" onclick="Intercom('show')">chat widget</a>.
+If you continue to face issues, reach out to the support team on the <a href="#!" onclick="Intercom('show')">chat widget</a>.

--- a/website/docs/getting-started/setup/instance-management/update-appsmith.md
+++ b/website/docs/getting-started/setup/instance-management/update-appsmith.md
@@ -1,0 +1,56 @@
+---
+description: Keep your Appsmith installation up-to-date. Follow these simple steps to update the Appsmith installation to the latest version for your platform.
+---
+
+# Update Appsmith
+This page describes the steps for updating Appsmith to the latest version for your installation type.
+
+## Prerequisites
+Before you update your Appsmith installation, ensure that you have completed the following steps:
+
+* A minimum of 2 GB of free storage must be available for both the backup and update tasks to run successfully.
+* Create a backup of the Appsmith instance before performing a manual update. For more information about creating a backup, see [Backup Appsmith Instance](/getting-started/setup/instance-management/appsmithctl#backup-appsmith-instance).
+* If you are on a version earlier than v1.9.2, upgrade to version v1.9.2 before upgrading to the latest version. For more information about upgrading to checkpoint version, see [Checkpoint version and upgrade](/getting-started/setup/instance-management#checkpoint-version-and-upgrades).
+
+## Docker Compose
+To update Appsmith, follow these steps on Docker Compose or any other platform that uses docker-compose (like AWS AMI or DigitalOcean). You can update Appsmith by one of the following ways:
+
+* [Update manually](#update-manually)
+* [Automatic update](#automatic-update)
+
+### Update manually
+To update Appsmith manually, go to the root directory of the installation and run the following command:
+
+```
+docker-compose pull && docker-compose rm -fsv appsmith && docker-compose up -d
+```
+
+### Automatic update
+
+To update Appsmith automatically, you need to turn on the automatic updates. Follow the below steps:
+
+1. Go to the root directory of the Appsmith installation and run:
+
+   ```
+   docker-compose down
+   ```
+
+2. Open the `docker-compose.yml` file with any text editor and uncomment lines 13-23.
+3. Save the file and run:
+
+   ```
+   docker-compose up -d
+   ```
+
+The server restart updates the Appsmith to the latest version. 
+
+If you face issues:
+* Try to roll back to a previous version, see [Rollback](#rollback) section.
+* Check the troubleshooting guide, see [Deployment Errors](/help-and-support/troubleshooting-guide/deployment-errors)
+
+## Rollback
+The auto backup feature is also turned on when you turn on automatic updates. This means that Appsmith is first backed up before updating to the latest version. You can use the backup version to roll back if you face any issues during the update. For more information, see [the rollback instructions using the `appsmithctl` command](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance). 
+
+## Troubleshooting
+
+If you see any errors during deployment, refer to [Deployment Errors](/help-and-support/troubleshooting-guide/deployment-errors) troubleshooting guide. This guide provides detailed information on troubleshooting common deployment errors you may encounter.

--- a/website/docs/getting-started/setup/instance-management/update-appsmith.md
+++ b/website/docs/getting-started/setup/instance-management/update-appsmith.md
@@ -44,7 +44,7 @@ docker-compose pull && docker-compose rm -fsv appsmith && docker-compose up -d
 Follow the below steps to turn on the auto updates:
 
 :::info
-Before an automatic update, Appsmith creates a backup. You may use this to roll back to a previous version in case of any issues.
+Before an automatic update, Appsmith creates a backup. You may use this to rollback to a previous version in case of any issues.
 :::
 
 1. Go to the root directory of the Appsmith installation and run:
@@ -75,10 +75,10 @@ Before an automatic update, Appsmith creates a backup. You may use this to roll 
    docker-compose up -d
    ```
 
-When the server restarts, Appsmith updates to the latest version. This setup runs an Appsmith instance and a Watchtower instance to automate updates. You may also schedule automatic updates for your instance. For more information, see [Configure auto-updates](/getting-started/setup/instance-management/maintenance-window#adding-a-configurable-maintenance-window-for-appsmiths-auto-updates).
+When the server restarts, Appsmith updates to the latest version. This setup runs an Appsmith instance and a Watchtower instance. The Watchtower checks and  updates the instance whenever a new version becomes available. You may also schedule automatic updates for your instance. For more information, see [Configure auto-updates](/getting-started/setup/instance-management/maintenance-window#adding-a-configurable-maintenance-window-for-appsmiths-auto-updates).
 
 ## Troubleshooting
 
-If you see deployment errors, you can roll back to a previous version to fix the issue. For more information, see [Restore Appsmith instance](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance). 
+If you see deployment errors, you can rollback to a previous version to fix the issue. For more information, see [Restore Appsmith instance](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance). 
 
 If you continue to face issues, contact the [support team](mailto:support@appsmith.com).

--- a/website/docs/getting-started/setup/instance-management/update-appsmith.md
+++ b/website/docs/getting-started/setup/instance-management/update-appsmith.md
@@ -14,7 +14,7 @@ Before you start the update process, make sure you complete the below steps:
 
 * Ensure that you have at least 2 GB of free storage space for backup and update tasks.
 * You can create a backup of the Appsmith instance before a manual update. To create a backup, see the [Backup Appsmith Instance](/getting-started/setup/instance-management/appsmithctl#backup-appsmith-instance) section. (_Recommended_)
-* If you are on a version earlier than v1.9.2, first upgrade to the checkpoint version v1.9.2. For more, see [Checkpoint version and upgrade](/getting-started/setup/instance-management#checkpoint-version-and-upgrades).
+* If you are on a version earlier than v1.9.2, first upgrade to version v1.9.2.  See [Checkpoint version and upgrade](/getting-started/setup/instance-management#checkpoint-version-and-upgrades) to upgrade to a checkpoint version.
 
 ## Docker Compose
 The steps below work with any platform that supports Docker. For example, Docker, AWS AMI, or DigitalOcean.

--- a/website/docs/getting-started/setup/instance-management/update-appsmith.md
+++ b/website/docs/getting-started/setup/instance-management/update-appsmith.md
@@ -44,7 +44,7 @@ docker-compose pull && docker-compose rm -fsv appsmith && docker-compose up -d
 Follow the below steps to turn on the auto updates:
 
 :::info
-Before an automatic update, Appsmith creates a backup, which can be used to rollback to a previous version of Appsmith in case the update needs to be undone.
+An automatic update creates a backup before starting the update. You can use this backup to roll back the update in case of any issues.
 :::
 
 1. Go to the root directory of the Appsmith installation and run:

--- a/website/docs/getting-started/setup/instance-management/update-appsmith.md
+++ b/website/docs/getting-started/setup/instance-management/update-appsmith.md
@@ -1,25 +1,27 @@
 ---
-description: Keep your Appsmith installation up-to-date. Follow these simple steps to update the Appsmith installation to the latest version for your platform.
+description: Follow the steps to update Appsmith to the latest version.
 ---
 
 # Update Appsmith
-This page describes the steps for updating Appsmith to the latest version for your installation type.
+This page provides instructions to update Appsmith to the latest version.
 
 ## Prerequisites
-Before you update your Appsmith installation, ensure that you have completed the following steps:
+Ensure that you complete the following steps before starting the update process.
 
-* A minimum of 2 GB of free storage must be available for both the backup and update tasks to run successfully.
-* Create a backup of the Appsmith instance before performing a manual update. For more information about creating a backup, see [Backup Appsmith Instance](/getting-started/setup/instance-management/appsmithctl#backup-appsmith-instance).
-* If you are on a version earlier than v1.9.2, upgrade to version v1.9.2 before upgrading to the latest version. For more information about upgrading to a checkpoint version, see [Checkpoint version and upgrade](/getting-started/setup/instance-management#checkpoint-version-and-upgrades).
+* At least 2 GB of free storage.
+* Create a backup of the Appsmith instance before a manual update. Refer to the [Backup Appsmith Instance](/getting-started/setup/instance-management/appsmithctl#backup-appsmith-instance) section.
+* If you are on a version earlier than v1.9.2, first upgrade to version v1.9.2. Refer to the [Checkpoint version and upgrade](/getting-started/setup/instance-management#checkpoint-version-and-upgrades) section.
 
 ## Docker Compose
-To update Appsmith, follow these steps on Docker Compose or any other platform that uses docker-compose (like AWS AMI or DigitalOcean). You can update Appsmith in one of the following ways:
+Follow the below steps on Docker or platforms that use `docker-compose`. For example, AWS AMI or DigitalOcean.  
+
+You can update Appsmith in one of the following ways:
 
 * [Manual update](#manual-update)
 * [Automatic update](#automatic-update)
 
 ### Manual update
-To update Appsmith manually, go to the root directory of the installation and run the following command:
+Go to the root directory of the installation and run:
 
 ```
 docker-compose pull && docker-compose rm -fsv appsmith && docker-compose up -d
@@ -27,7 +29,7 @@ docker-compose pull && docker-compose rm -fsv appsmith && docker-compose up -d
 
 ### Automatic update
 
-To update Appsmith automatically, you need to turn on the automatic updates. Follow the below steps:
+Follow the below steps to turn on the auto updates:
 
 1. Go to the root directory of the Appsmith installation and run:
 
@@ -42,8 +44,10 @@ To update Appsmith automatically, you need to turn on the automatic updates. Fol
    docker-compose up -d
    ```
 
-The server restart updates the Appsmith to the latest version. You can also choose to schedule automatic updates. For more information, see [Configure a maintenance window for automatic updates](/getting-started/setup/instance-management/maintenance-window#adding-a-configurable-maintenance-window-for-appsmiths-auto-updates).
+The server restart updates the Appsmith to the latest version. You can choose to schedule automatic updates. Refer to [Configure a maintenance window](/getting-started/setup/instance-management/maintenance-window#adding-a-configurable-maintenance-window-for-appsmiths-auto-updates).
 
 ## Troubleshooting
 
-The auto backup feature is also turned on when you turn on automatic updates. This means that Appsmith is first backed up before updating to the latest version. If you see any errors during deployment, you can use the backup version to roll back. For more information, see [the rollback instructions using the `appsmithctl` command](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance). If you continue to experience issues, please raise them on the <a href="#!" onclick="Intercom('show')">chat window</a> available on the documentation.
+When you turn on automatic updates, it turns on the auto backup feature. And creates a backup before an update. You can roll back to a previous version if you see deployment errors. Refer to [the rollback instructions using the `appsmithctl` command](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance). 
+
+If you are still having issues, reach out to the support team on the <a href="#!" onclick="Intercom('show')">chat widget</a>.

--- a/website/docs/getting-started/setup/instance-management/update-appsmith.md
+++ b/website/docs/getting-started/setup/instance-management/update-appsmith.md
@@ -14,7 +14,7 @@ Before you start the update process, make sure you complete the below steps:
 
 * Ensure that you have at least 2 GB of free storage space for backup and update tasks.
 * You can create a backup of the Appsmith instance before a manual update. To create a backup, see the [Backup Appsmith Instance](/getting-started/setup/instance-management/appsmithctl#backup-appsmith-instance) section. (_Recommended_)
-* If you are on a version earlier than v1.9.2, first upgrade to version v1.9.2. To upgrade, see the [Checkpoint version and upgrade](/getting-started/setup/instance-management#checkpoint-version-and-upgrades) section.
+* If you are on a version earlier than v1.9.2, first upgrade to the checkpoint version v1.9.2. For more, see [Checkpoint version and upgrade](/getting-started/setup/instance-management#checkpoint-version-and-upgrades).
 
 ## Docker Compose
 The steps below work with any platform that supports Docker. For example, Docker, AWS AMI, or DigitalOcean.
@@ -44,7 +44,7 @@ docker-compose pull && docker-compose rm -fsv appsmith && docker-compose up -d
 Follow the below steps to turn on the auto updates:
 
 :::info
-An automatic update first creates a backup and then starts the update.
+Before an automatic update, Appsmith creates a backup, which can be used to rollback to a previous version of Appsmith in case the update needs to be undone.
 :::
 
 1. Go to the root directory of the Appsmith installation and run:
@@ -75,10 +75,10 @@ An automatic update first creates a backup and then starts the update.
    docker-compose up -d
    ```
 
-When the server restarts, Appsmith is updated to the latest version. You have the option to schedule automatic updates for your instance. To schedule automatic updates, see [Configure auto-updates](/getting-started/setup/instance-management/maintenance-window#adding-a-configurable-maintenance-window-for-appsmiths-auto-updates).
+When the server restarts, Appsmith is updated to the latest version. This configuration runs an Appsmith instance and a Watchtower instance to keep Appsmith up-to-date automatically. You may also schedule automatic updates for your instance. For more information, see [Configure auto-updates](/getting-started/setup/instance-management/maintenance-window#adding-a-configurable-maintenance-window-for-appsmiths-auto-updates).
 
 ## Troubleshooting
 
-If you see deployment errors, you can roll back to a previous version to fix the issue. To roll back, see the [Restore Appsmith instance](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance). 
+If you see deployment errors, you can rollback to a previous version to fix the issue. For more information, see [Restore Appsmith instance](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance). 
 
 If you continue to face issues, reach out to the [support team](mailto:support@appsmith.com).

--- a/website/docs/getting-started/setup/instance-management/update-appsmith.md
+++ b/website/docs/getting-started/setup/instance-management/update-appsmith.md
@@ -13,8 +13,8 @@ The steps below apply to both the Community and Business editions.
 Before you start the update process, make sure you complete the below steps:
 
 * Ensure that you have at least 2 GB of free storage space for backup and update tasks.
-* You can create a backup of the Appsmith instance before a manual update. To create a backup, see the [Backup Appsmith Instance](/getting-started/setup/instance-management/appsmithctl#backup-appsmith-instance) section. (_Recommended_)
-* If you are on a version earlier than v1.9.2, first upgrade to version v1.9.2.  See [Checkpoint version and upgrade](/getting-started/setup/instance-management#checkpoint-version-and-upgrades) to upgrade to a checkpoint version.
+* You can create a backup of the Appsmith instance before a manual update. To create a backup, see [Backup Appsmith Instance](/getting-started/setup/instance-management/appsmithctl#backup-appsmith-instance) (_Recommended_)
+* If you are on a version earlier than v1.9.2, first upgrade to version v1.9.2.  For more information, see [Checkpoint version and upgrade](/getting-started/setup/instance-management#checkpoint-version-and-upgrades).
 
 ## Docker Compose
 The steps below work with any platform that supports Docker. For example, Docker, AWS AMI, or DigitalOcean.

--- a/website/docs/getting-started/setup/instance-management/update-appsmith.md
+++ b/website/docs/getting-started/setup/instance-management/update-appsmith.md
@@ -10,15 +10,15 @@ Before you update your Appsmith installation, ensure that you have completed the
 
 * A minimum of 2 GB of free storage must be available for both the backup and update tasks to run successfully.
 * Create a backup of the Appsmith instance before performing a manual update. For more information about creating a backup, see [Backup Appsmith Instance](/getting-started/setup/instance-management/appsmithctl#backup-appsmith-instance).
-* If you are on a version earlier than v1.9.2, upgrade to version v1.9.2 before upgrading to the latest version. For more information about upgrading to checkpoint version, see [Checkpoint version and upgrade](/getting-started/setup/instance-management#checkpoint-version-and-upgrades).
+* If you are on a version earlier than v1.9.2, upgrade to version v1.9.2 before upgrading to the latest version. For more information about upgrading to a checkpoint version, see [Checkpoint version and upgrade](/getting-started/setup/instance-management#checkpoint-version-and-upgrades).
 
 ## Docker Compose
-To update Appsmith, follow these steps on Docker Compose or any other platform that uses docker-compose (like AWS AMI or DigitalOcean). You can update Appsmith by one of the following ways:
+To update Appsmith, follow these steps on Docker Compose or any other platform that uses docker-compose (like AWS AMI or DigitalOcean). You can update Appsmith in one of the following ways:
 
-* [Update manually](#update-manually)
+* [Manual update](#manual-update)
 * [Automatic update](#automatic-update)
 
-### Update manually
+### Manual update
 To update Appsmith manually, go to the root directory of the installation and run the following command:
 
 ```
@@ -42,15 +42,8 @@ To update Appsmith automatically, you need to turn on the automatic updates. Fol
    docker-compose up -d
    ```
 
-The server restart updates the Appsmith to the latest version. 
-
-If you face issues:
-* Try to roll back to a previous version, see [Rollback](#rollback) section.
-* Check the troubleshooting guide, see [Deployment Errors](/help-and-support/troubleshooting-guide/deployment-errors)
-
-## Rollback
-The auto backup feature is also turned on when you turn on automatic updates. This means that Appsmith is first backed up before updating to the latest version. You can use the backup version to roll back if you face any issues during the update. For more information, see [the rollback instructions using the `appsmithctl` command](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance). 
+The server restart updates the Appsmith to the latest version. You can also choose to schedule automatic updates. For more information, see [Configure a maintenance window for automatic updates](/getting-started/setup/instance-management/maintenance-window#adding-a-configurable-maintenance-window-for-appsmiths-auto-updates).
 
 ## Troubleshooting
 
-If you see any errors during deployment, refer to [Deployment Errors](/help-and-support/troubleshooting-guide/deployment-errors) troubleshooting guide. This guide provides detailed information on troubleshooting common deployment errors you may encounter.
+The auto backup feature is also turned on when you turn on automatic updates. This means that Appsmith is first backed up before updating to the latest version. If you see any errors during deployment, you can use the backup version to roll back. For more information, see [the rollback instructions using the `appsmithctl` command](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance). If you continue to experience issues, please raise them on the <a href="#!" onclick="Intercom('show')">chat window</a> available on the documentation.

--- a/website/docs/getting-started/setup/instance-management/update-appsmith.md
+++ b/website/docs/getting-started/setup/instance-management/update-appsmith.md
@@ -75,7 +75,7 @@ Before an automatic update, Appsmith creates a backup. You may use this to rollb
    docker-compose up -d
    ```
 
-When the server restarts, Appsmith updates to the latest version. This setup runs an Appsmith instance and a Watchtower instance. The Watchtower checks and updates the instance whenever a new version becomes available. You may also schedule automatic updates for your instance. For more information, see [Configure auto-updates](/getting-started/setup/instance-management/maintenance-window#adding-a-configurable-maintenance-window-for-appsmiths-auto-updates).
+When the server restarts, Appsmith updates to the latest version. This setup runs an Appsmith and a Watchtower container. The Watchtower checks and updates Appsmith whenever a new version becomes available. You may also schedule automatic updates for your instance. For more information, see [Configure auto-updates](/getting-started/setup/instance-management/maintenance-window#adding-a-configurable-maintenance-window-for-appsmiths-auto-updates).
 
 ## Troubleshooting
 

--- a/website/docs/getting-started/setup/instance-management/update-appsmith.md
+++ b/website/docs/getting-started/setup/instance-management/update-appsmith.md
@@ -3,22 +3,33 @@ description: Follow the steps to update Appsmith to the latest version.
 ---
 
 # Update Appsmith
-This page provides instructions to update Appsmith to the latest version.
+This page provides steps to update Appsmith to the latest version.
+
+:::info
+The steps below apply to both the Community and Business editions.
+:::
 
 ## Prerequisites
-Ensure that you complete the following steps before starting the update process.
+Before you start the update process, make sure you complete the below steps:
 
-* For backup and update tasks, you need at least 2 GB of free storage.
-* You need to create a backup of the Appsmith instance before a manual update. To create a backup, see the [Backup Appsmith Instance](/getting-started/setup/instance-management/appsmithctl#backup-appsmith-instance) section.
+* Ensure that you have at least 2 GB of free storage space for backup and update tasks.
+* You can create a backup of the Appsmith instance before a manual update. To create a backup, see the [Backup Appsmith Instance](/getting-started/setup/instance-management/appsmithctl#backup-appsmith-instance) section. (_Recommended_)
 * If you are on a version earlier than v1.9.2, first upgrade to version v1.9.2. To upgrade, see the [Checkpoint version and upgrade](/getting-started/setup/instance-management#checkpoint-version-and-upgrades) section.
 
 ## Docker Compose
-Follow the below steps on Docker or platforms that use `docker-compose`. For example, AWS AMI or DigitalOcean.  
+The below steps work on any platform that uses `docker-compose`. For example, Docker, AWS AMI, or DigitalOcean.
 
-You can update Appsmith in one of the following ways:
+You can update Appsmith in one of the below ways:
 
 * [Manual update](#manual-update)
 * [Automatic update](#automatic-update)
+
+:::info
+If you don't know the installation directory, run:
+```
+docker inspect -f '{{ (index .Mounts 0).Source }}' <APPSMITH_CONTAINER_ID>
+```
+:::
 
 ### Manual update
 Go to the root directory of your installation and run:
@@ -29,7 +40,11 @@ docker-compose pull && docker-compose rm -fsv appsmith && docker-compose up -d
 
 ### Automatic update
 
-When you turn on automatic update, it first creates a backup and then starts the update. Follow the below steps to turn on the auto updates:
+Follow the below steps to turn on the auto updates:
+
+:::info
+An automatic update first creates a backup and then starts the update.
+:::
 
 1. Go to the root directory of the Appsmith installation and run:
 
@@ -37,17 +52,32 @@ When you turn on automatic update, it first creates a backup and then starts the
    docker-compose down
    ```
 
-2. Open the `docker-compose.yml` file and uncomment lines 13-23.
+2. Open the `docker-compose.yml` file and uncomment the below code block:
+   
+   ```yaml
+   #auto_update:
+   #  image: containrrr/watchtower
+   #  volumes:
+   #    - /var/run/docker.sock:/var/run/docker.sock
+   #  # Update check interval in seconds.
+   #  command: --schedule "0 0 * ? * *" --label-enable --cleanup
+   #  restart: unless-stopped
+   #  depends_on:
+   #    - appsmith
+   #  environment:
+   #    - WATCHTOWER_LIFECYCLE_HOOKS=true
+   ```
+
 3. Save the file and run:
 
    ```
    docker-compose up -d
    ```
 
-Restarting the server deploys the latest version of Appsmith. You have the option to schedule automatic updates for your instance. To schedule automatic updates, see [Configure auto-updates](/getting-started/setup/instance-management/maintenance-window#adding-a-configurable-maintenance-window-for-appsmiths-auto-updates).
+When the server restarts, Appsmith is updated to the latest version. You have the option to schedule automatic updates for your instance. To schedule automatic updates, see [Configure auto-updates](/getting-started/setup/instance-management/maintenance-window#adding-a-configurable-maintenance-window-for-appsmiths-auto-updates).
 
 ## Troubleshooting
 
-If you see deployment errors, you can roll back to a previous version to fix the issue. To roll back, see [the rollback instructions using the `appsmithctl` command](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance). 
+If you see deployment errors, you can roll back to a previous version to fix the issue. To roll back, see the [Restore Appsmith instance](/getting-started/setup/instance-management/appsmithctl#restore-appsmith-instance). 
 
-If you continue to face issues, reach out to the support team on the <a href="#!" onclick="Intercom('show')">chat widget</a>.
+If you continue to face issues, reach out to the [support team](mailto:support@appsmith.com).

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8,9 +8,9 @@
       "name": "appsmith-docs",
       "version": "0.0.0",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/plugin-client-redirects": "^2.1.0",
-        "@docusaurus/preset-classic": "2.1.0",
+        "@docusaurus/core": "^2.4.0",
+        "@docusaurus/plugin-client-redirects": "^2.4.0",
+        "@docusaurus/preset-classic": "^2.4.0",
         "@mdx-js/react": "^1.6.22",
         "@twilio-labs/docusaurus-plugin-segment": "^0.1.0",
         "aws-sdk": "^2.1231.0",
@@ -20,7 +20,7 @@
         "react-dom": "^17.0.2"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "2.1.0",
+        "@docusaurus/module-type-aliases": "^2.4.0",
         "glob": "^8.0.3",
         "marked": "^4.2.2"
       },
@@ -29,99 +29,99 @@
       }
     },
     "node_modules/@algolia/autocomplete-core": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.1.tgz",
-      "integrity": "sha512-eiZw+fxMzNQn01S8dA/hcCpoWCOCwcIIEUtHHdzN5TGB3IpzLbuhqFeTfh2OUhhgkE8Uo17+wH+QJ/wYyQmmzg==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.4.tgz",
+      "integrity": "sha512-daoLpQ3ps/VTMRZDEBfU8ixXd+amZcNJ4QSP3IERGyzqnL5Ch8uSRFt/4G8pUvW9c3o6GA4vtVv4I4lmnkdXyg==",
       "dependencies": {
-        "@algolia/autocomplete-shared": "1.7.1"
+        "@algolia/autocomplete-shared": "1.7.4"
       }
     },
     "node_modules/@algolia/autocomplete-preset-algolia": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.1.tgz",
-      "integrity": "sha512-pJwmIxeJCymU1M6cGujnaIYcY3QPOVYZOXhFkWVM7IxKzy272BwCvMFMyc5NpG/QmiObBxjo7myd060OeTNJXg==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.4.tgz",
+      "integrity": "sha512-s37hrvLEIfcmKY8VU9LsAXgm2yfmkdHT3DnA3SgHaY93yjZ2qL57wzb5QweVkYuEBZkT2PIREvRoLXC2sxTbpQ==",
       "dependencies": {
-        "@algolia/autocomplete-shared": "1.7.1"
+        "@algolia/autocomplete-shared": "1.7.4"
       },
       "peerDependencies": {
-        "@algolia/client-search": "^4.9.1",
-        "algoliasearch": "^4.9.1"
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
       }
     },
     "node_modules/@algolia/autocomplete-shared": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.1.tgz",
-      "integrity": "sha512-eTmGVqY3GeyBTT8IWiB2K5EuURAqhnumfktAEoHxfDY2o7vg2rSnO16ZtIG0fMgt3py28Vwgq42/bVEuaQV7pg=="
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.4.tgz",
+      "integrity": "sha512-2VGCk7I9tA9Ge73Km99+Qg87w0wzW4tgUruvWAn/gfey1ZXgmxZtyIRBebk35R1O8TbK77wujVtCnpsGpRy1kg=="
     },
     "node_modules/@algolia/cache-browser-local-storage": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.14.2.tgz",
-      "integrity": "sha512-FRweBkK/ywO+GKYfAWbrepewQsPTIEirhi1BdykX9mxvBPtGNKccYAxvGdDCumU1jL4r3cayio4psfzKMejBlA==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.16.0.tgz",
+      "integrity": "sha512-jVrk0YB3tjOhD5/lhBtYCVCeLjZmVpf2kdi4puApofytf/R0scjWz0GdozlW4HhU+Prxmt/c9ge4QFjtv5OAzQ==",
       "dependencies": {
-        "@algolia/cache-common": "4.14.2"
+        "@algolia/cache-common": "4.16.0"
       }
     },
     "node_modules/@algolia/cache-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.14.2.tgz",
-      "integrity": "sha512-SbvAlG9VqNanCErr44q6lEKD2qoK4XtFNx9Qn8FK26ePCI8I9yU7pYB+eM/cZdS9SzQCRJBbHUumVr4bsQ4uxg=="
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.16.0.tgz",
+      "integrity": "sha512-4iHjkSYQYw46pITrNQgXXhvUmcekI8INz1m+SzmqLX8jexSSy4Ky4zfGhZzhhhLHXUP3+x/PK/c0qPjxEvRwKQ=="
     },
     "node_modules/@algolia/cache-in-memory": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.14.2.tgz",
-      "integrity": "sha512-HrOukWoop9XB/VFojPv1R5SVXowgI56T9pmezd/djh2JnVN/vXswhXV51RKy4nCpqxyHt/aGFSq2qkDvj6KiuQ==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.16.0.tgz",
+      "integrity": "sha512-p7RYykvA6Ip6QENxrh99nOD77otVh1sJRivcgcVpnjoZb5sIN3t33eUY1DpB9QSBizcrW+qk19rNkdnZ43a+PQ==",
       "dependencies": {
-        "@algolia/cache-common": "4.14.2"
+        "@algolia/cache-common": "4.16.0"
       }
     },
     "node_modules/@algolia/client-account": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.14.2.tgz",
-      "integrity": "sha512-WHtriQqGyibbb/Rx71YY43T0cXqyelEU0lB2QMBRXvD2X0iyeGl4qMxocgEIcbHyK7uqE7hKgjT8aBrHqhgc1w==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.16.0.tgz",
+      "integrity": "sha512-eydcfpdIyuWoKgUSz5iZ/L0wE/Wl7958kACkvTHLDNXvK/b8Z1zypoJavh6/km1ZNQmFpeYS2jrmq0kUSFn02w==",
       "dependencies": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/client-search": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/client-common": "4.16.0",
+        "@algolia/client-search": "4.16.0",
+        "@algolia/transporter": "4.16.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.14.2.tgz",
-      "integrity": "sha512-yBvBv2mw+HX5a+aeR0dkvUbFZsiC4FKSnfqk9rrfX+QrlNOKEhCG0tJzjiOggRW4EcNqRmaTULIYvIzQVL2KYQ==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.16.0.tgz",
+      "integrity": "sha512-cONWXH3BfilgdlCofUm492bJRWtpBLVW/hsUlfoFtiX1u05xoBP7qeiDwh9RR+4pSLHLodYkHAf5U4honQ55Qg==",
       "dependencies": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/client-search": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/client-common": "4.16.0",
+        "@algolia/client-search": "4.16.0",
+        "@algolia/requester-common": "4.16.0",
+        "@algolia/transporter": "4.16.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.14.2.tgz",
-      "integrity": "sha512-43o4fslNLcktgtDMVaT5XwlzsDPzlqvqesRi4MjQz2x4/Sxm7zYg5LRYFol1BIhG6EwxKvSUq8HcC/KxJu3J0Q==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.16.0.tgz",
+      "integrity": "sha512-QVdR4019ukBH6f5lFr27W60trRxQF1SfS1qo0IP6gjsKhXhUVJuHxOCA6ArF87jrNkeuHEoRoDU+GlvaecNo8g==",
       "dependencies": {
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/requester-common": "4.16.0",
+        "@algolia/transporter": "4.16.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.14.2.tgz",
-      "integrity": "sha512-ACCoLi0cL8CBZ1W/2juehSltrw2iqsQBnfiu/Rbl9W2yE6o2ZUb97+sqN/jBqYNQBS+o0ekTMKNkQjHHAcEXNw==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.16.0.tgz",
+      "integrity": "sha512-irtLafssDGPuhYqIwxqOxiWlVYvrsBD+EMA1P9VJtkKi3vSNBxiWeQ0f0Tn53cUNdSRNEssfoEH84JL97SV2SQ==",
       "dependencies": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/client-common": "4.16.0",
+        "@algolia/requester-common": "4.16.0",
+        "@algolia/transporter": "4.16.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.14.2.tgz",
-      "integrity": "sha512-L5zScdOmcZ6NGiVbLKTvP02UbxZ0njd5Vq9nJAmPFtjffUSOGEp11BmD2oMJ5QvARgx2XbX4KzTTNS5ECYIMWw==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.16.0.tgz",
+      "integrity": "sha512-xsfrAE1jO/JDh1wFrRz+alVyW+aA6qnkzmbWWWZWEgVF3EaFqzIf9r1l/aDtDdBtNTNhX9H3Lg31+BRtd5izQA==",
       "dependencies": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/client-common": "4.16.0",
+        "@algolia/requester-common": "4.16.0",
+        "@algolia/transporter": "4.16.0"
       }
     },
     "node_modules/@algolia/events": {
@@ -130,47 +130,47 @@
       "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
     },
     "node_modules/@algolia/logger-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.14.2.tgz",
-      "integrity": "sha512-/JGlYvdV++IcMHBnVFsqEisTiOeEr6cUJtpjz8zc0A9c31JrtLm318Njc72p14Pnkw3A/5lHHh+QxpJ6WFTmsA=="
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.16.0.tgz",
+      "integrity": "sha512-U9H8uCzSDuePJmbnjjTX21aPDRU6x74Tdq3dJmdYu2+pISx02UeBJm4kSgc9RW5jcR5j35G9gnjHY9Q3ngWbyQ=="
     },
     "node_modules/@algolia/logger-console": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.14.2.tgz",
-      "integrity": "sha512-8S2PlpdshbkwlLCSAB5f8c91xyc84VM9Ar9EdfE9UmX+NrKNYnWR1maXXVDQQoto07G1Ol/tYFnFVhUZq0xV/g==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.16.0.tgz",
+      "integrity": "sha512-+qymusiM+lPZKrkf0tDjCQA158eEJO2IU+Nr/sJ9TFyI/xkFPjNPzw/Qbc8Iy/xcOXGlc6eMgmyjtVQqAWq6UA==",
       "dependencies": {
-        "@algolia/logger-common": "4.14.2"
+        "@algolia/logger-common": "4.16.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.14.2.tgz",
-      "integrity": "sha512-CEh//xYz/WfxHFh7pcMjQNWgpl4wFB85lUMRyVwaDPibNzQRVcV33YS+63fShFWc2+42YEipFGH2iPzlpszmDw==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.16.0.tgz",
+      "integrity": "sha512-gK+kvs6LHl/PaOJfDuwjkopNbG1djzFLsVBklGBsSU6h6VjFkxIpo6Qq80IK14p9cplYZfhfaL12va6Q9p3KVQ==",
       "dependencies": {
-        "@algolia/requester-common": "4.14.2"
+        "@algolia/requester-common": "4.16.0"
       }
     },
     "node_modules/@algolia/requester-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.14.2.tgz",
-      "integrity": "sha512-73YQsBOKa5fvVV3My7iZHu1sUqmjjfs9TteFWwPwDmnad7T0VTCopttcsM3OjLxZFtBnX61Xxl2T2gmG2O4ehg=="
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.16.0.tgz",
+      "integrity": "sha512-3Zmcs/iMubcm4zqZ3vZG6Zum8t+hMWxGMzo0/uY2BD8o9q5vMxIYI0c4ocdgQjkXcix189WtZNkgjSOBzSbkdw=="
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.14.2.tgz",
-      "integrity": "sha512-oDbb02kd1o5GTEld4pETlPZLY0e+gOSWjWMJHWTgDXbv9rm/o2cF7japO6Vj1ENnrqWvLBmW1OzV9g6FUFhFXg==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.16.0.tgz",
+      "integrity": "sha512-L8JxM2VwZzh8LJ1Zb8TFS6G3icYsCKZsdWW+ahcEs1rGWmyk9SybsOe1MLnjonGBaqPWJkn9NjS7mRdjEmBtKA==",
       "dependencies": {
-        "@algolia/requester-common": "4.14.2"
+        "@algolia/requester-common": "4.16.0"
       }
     },
     "node_modules/@algolia/transporter": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.14.2.tgz",
-      "integrity": "sha512-t89dfQb2T9MFQHidjHcfhh6iGMNwvuKUvojAj+JsrHAGbuSy7yE4BylhLX6R0Q1xYRoC4Vvv+O5qIw/LdnQfsQ==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.16.0.tgz",
+      "integrity": "sha512-H9BVB2EAjT65w7XGBNf5drpsW39x2aSZ942j4boSAAJPPlLmjtj5IpAP7UAtsV8g9Beslonh0bLa1XGmE/P0BA==",
       "dependencies": {
-        "@algolia/cache-common": "4.14.2",
-        "@algolia/logger-common": "4.14.2",
-        "@algolia/requester-common": "4.14.2"
+        "@algolia/cache-common": "4.16.0",
+        "@algolia/logger-common": "4.16.0",
+        "@algolia/requester-common": "4.16.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1890,11 +1890,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.0.tgz",
-      "integrity": "sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
+      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.11"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1968,18 +1968,18 @@
       }
     },
     "node_modules/@docsearch/css": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.2.1.tgz",
-      "integrity": "sha512-gaP6TxxwQC+K8D6TRx5WULUWKrcbzECOPA2KCVMuI+6C7dNiGUk5yXXzVhc5sld79XKYLnO9DRTI4mjXDYkh+g=="
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.3.3.tgz",
+      "integrity": "sha512-6SCwI7P8ao+se1TUsdZ7B4XzL+gqeQZnBc+2EONZlcVa0dVrk0NjETxozFKgMv0eEGH8QzP1fkN+A1rH61l4eg=="
     },
     "node_modules/@docsearch/react": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.2.1.tgz",
-      "integrity": "sha512-EzTQ/y82s14IQC5XVestiK/kFFMe2aagoYFuTAIfIb/e+4FU7kSMKonRtLwsCiLQHmjvNQq+HO+33giJ5YVtaQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.3.3.tgz",
+      "integrity": "sha512-pLa0cxnl+G0FuIDuYlW+EBK6Rw2jwLw9B1RHIeS4N4s2VhsfJ/wzeCi3CWcs5yVfxLd5ZK50t//TMA5e79YT7Q==",
       "dependencies": {
-        "@algolia/autocomplete-core": "1.7.1",
-        "@algolia/autocomplete-preset-algolia": "1.7.1",
-        "@docsearch/css": "3.2.1",
+        "@algolia/autocomplete-core": "1.7.4",
+        "@algolia/autocomplete-preset-algolia": "1.7.4",
+        "@docsearch/css": "3.3.3",
         "algoliasearch": "^4.0.0"
       },
       "peerDependencies": {
@@ -2000,9 +2000,9 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.1.0.tgz",
-      "integrity": "sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.4.0.tgz",
+      "integrity": "sha512-J55/WEoIpRcLf3afO5POHPguVZosKmJEQWKBL+K7TAnfuE7i+Y0NPLlkKtnWCehagGsgTqClfQEexH/UT4kELA==",
       "dependencies": {
         "@babel/core": "^7.18.6",
         "@babel/generator": "^7.18.7",
@@ -2014,13 +2014,13 @@
         "@babel/runtime": "^7.18.6",
         "@babel/runtime-corejs3": "^7.18.6",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
+        "@docusaurus/cssnano-preset": "2.4.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/mdx-loader": "2.4.0",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-common": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
         "@svgr/webpack": "^6.2.1",
         "autoprefixer": "^10.4.7",
@@ -2041,7 +2041,7 @@
         "del": "^6.1.1",
         "detect-port": "^1.3.0",
         "escape-html": "^1.0.3",
-        "eta": "^1.12.3",
+        "eta": "^2.0.0",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.1.0",
         "html-minifier-terser": "^6.1.0",
@@ -2087,10 +2087,21 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
+    "node_modules/@docusaurus/core/node_modules/eta": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/eta/-/eta-2.0.1.tgz",
+      "integrity": "sha512-46E2qDPDm7QA+usjffUWz9KfXsxVZclPOuKsXs4ZWZdI/X1wpDF7AO424pt7fdYohCzWsIkXAhNGXSlwo5naAg==",
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/eta-dev/eta?sponsor=1"
+      }
+    },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.1.0.tgz",
-      "integrity": "sha512-pRLewcgGhOies6pzsUROfmPStDRdFw+FgV5sMtLr5+4Luv2rty5+b/eSIMMetqUsmg3A9r9bcxHk9bKAKvx3zQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.4.0.tgz",
+      "integrity": "sha512-RmdiA3IpsLgZGXRzqnmTbGv43W4OD44PCo+6Q/aYjEM2V57vKCVqNzuafE94jv0z/PjHoXUrjr69SaRymBKYYw==",
       "dependencies": {
         "cssnano-preset-advanced": "^5.3.8",
         "postcss": "^8.4.14",
@@ -2102,9 +2113,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.1.0.tgz",
-      "integrity": "sha512-uuJx2T6hDBg82joFeyobywPjSOIfeq05GfyKGHThVoXuXsu1KAzMDYcjoDxarb9CoHCI/Dor8R2MoL6zII8x1Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.4.0.tgz",
+      "integrity": "sha512-T8+qR4APN+MjcC9yL2Es+xPJ2923S9hpzDmMtdsOcUGLqpCGBbU1vp3AAqDwXtVgFkq+NsEk7sHdVsfLWR/AXw==",
       "dependencies": {
         "chalk": "^4.1.2",
         "tslib": "^2.4.0"
@@ -2114,14 +2125,14 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.1.0.tgz",
-      "integrity": "sha512-i97hi7hbQjsD3/8OSFhLy7dbKGH8ryjEzOfyhQIn2CFBYOY3ko0vMVEf3IY9nD3Ld7amYzsZ8153RPkcnXA+Lg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.4.0.tgz",
+      "integrity": "sha512-GWoH4izZKOmFoC+gbI2/y8deH/xKLvzz/T5BsEexBye8EHQlwsA7FMrVa48N063bJBH4FUOiRRXxk5rq9cC36g==",
       "dependencies": {
         "@babel/parser": "^7.18.8",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
         "@mdx-js/mdx": "^1.6.22",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
@@ -2145,12 +2156,12 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.1.0.tgz",
-      "integrity": "sha512-Z8WZaK5cis3xEtyfOT817u9xgGUauT0PuuVo85ysnFRX8n7qLN1lTPCkC+aCmFm/UcV8h/W5T4NtIsst94UntQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.4.0.tgz",
+      "integrity": "sha512-YEQO2D3UXs72qCn8Cr+RlycSQXVGN9iEUyuHwTuK4/uL/HFomB2FHSU0vSDM23oLd+X/KibQ3Ez6nGjQLqXcHg==",
       "dependencies": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.1.0",
+        "@docusaurus/types": "2.4.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2164,16 +2175,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-client-redirects": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-2.1.0.tgz",
-      "integrity": "sha512-3PhzwHSyZWqBAFPJuLJE3dZVuKWQEj9ReQP85Z3/2hpnQoVNBgAqc+64FIko0FvvK1iluLeasO7NWGyuATngvw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-2.4.0.tgz",
+      "integrity": "sha512-HsS+Dc2ZLWhfpjYJ5LIrOB/XfXZcElcC7o1iA4yIVtiFz+LHhwP863fhqbwSJ1c6tNDOYBH3HwbskHrc/PIn7Q==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
-        "eta": "^1.12.3",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-common": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
+        "eta": "^2.0.0",
         "fs-extra": "^10.1.0",
         "lodash": "^4.17.21",
         "tslib": "^2.4.0"
@@ -2186,18 +2197,29 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
+    "node_modules/@docusaurus/plugin-client-redirects/node_modules/eta": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/eta/-/eta-2.0.1.tgz",
+      "integrity": "sha512-46E2qDPDm7QA+usjffUWz9KfXsxVZclPOuKsXs4ZWZdI/X1wpDF7AO424pt7fdYohCzWsIkXAhNGXSlwo5naAg==",
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/eta-dev/eta?sponsor=1"
+      }
+    },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.1.0.tgz",
-      "integrity": "sha512-xEp6jlu92HMNUmyRBEeJ4mCW1s77aAEQO4Keez94cUY/Ap7G/r0Awa6xSLff7HL0Fjg8KK1bEbDy7q9voIavdg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.4.0.tgz",
+      "integrity": "sha512-YwkAkVUxtxoBAIj/MCb4ohN0SCtHBs4AS75jMhPpf67qf3j+U/4n33cELq7567hwyZ6fMz2GPJcVmctzlGGThQ==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-common": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^10.1.0",
@@ -2217,17 +2239,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.1.0.tgz",
-      "integrity": "sha512-Rup5pqXrXlKGIC4VgwvioIhGWF7E/NNSlxv+JAxRYpik8VKlWsk9ysrdHIlpX+KJUCO9irnY21kQh2814mlp/Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.4.0.tgz",
+      "integrity": "sha512-ic/Z/ZN5Rk/RQo+Io6rUGpToOtNbtPloMR2JcGwC1xT2riMu6zzfSwmBi9tHJgdXH6CB5jG+0dOZZO8QS5tmDg==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/module-type-aliases": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "@types/react-router-config": "^5.0.6",
         "combine-promises": "^1.1.0",
         "fs-extra": "^10.1.0",
@@ -2247,15 +2269,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.1.0.tgz",
-      "integrity": "sha512-SwZdDZRlObHNKXTnFo7W2aF6U5ZqNVI55Nw2GCBryL7oKQSLeI0lsrMlMXdzn+fS7OuBTd3MJBO1T4Zpz0i/+g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.4.0.tgz",
+      "integrity": "sha512-Pk2pOeOxk8MeU3mrTU0XLIgP9NZixbdcJmJ7RUFrZp1Aj42nd0RhIT14BGvXXyqb8yTQlk4DmYGAzqOfBsFyGw==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0",
         "webpack": "^5.73.0"
@@ -2269,13 +2291,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.1.0.tgz",
-      "integrity": "sha512-8wsDq3OIfiy6440KLlp/qT5uk+WRHQXIXklNHEeZcar+Of0TZxCNe2FBpv+bzb/0qcdP45ia5i5WmR5OjN6DPw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.4.0.tgz",
+      "integrity": "sha512-KC56DdYjYT7Txyux71vXHXGYZuP6yYtqwClvYpjKreWIHWus5Zt6VNi23rMZv3/QKhOCrN64zplUbdfQMvddBQ==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
         "fs-extra": "^10.1.0",
         "react-json-view": "^1.21.3",
         "tslib": "^2.4.0"
@@ -2289,13 +2311,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.1.0.tgz",
-      "integrity": "sha512-4cgeqIly/wcFVbbWP03y1QJJBgH8W+Bv6AVbWnsXNOZa1yB3AO6hf3ZdeQH9x20v9T2pREogVgAH0rSoVnNsgg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.4.0.tgz",
+      "integrity": "sha512-uGUzX67DOAIglygdNrmMOvEp8qG03X20jMWadeqVQktS6nADvozpSLGx4J0xbkblhJkUzN21WiilsP9iVP+zkw==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -2307,13 +2329,31 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.1.0.tgz",
-      "integrity": "sha512-/3aDlv2dMoCeiX2e+DTGvvrdTA+v3cKQV3DbmfsF4ENhvc5nKV23nth04Z3Vq0Ci1ui6Sn80TkhGk/tiCMW2AA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.4.0.tgz",
+      "integrity": "sha512-adj/70DANaQs2+TF/nRdMezDXFAV/O/pjAbUgmKBlyOTq5qoMe0Tk4muvQIwWUmiUQxFJe+sKlZGM771ownyOg==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-google-tag-manager": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-2.4.0.tgz",
+      "integrity": "sha512-E66uGcYs4l7yitmp/8kMEVQftFPwV9iC62ORh47Veqzs6ExwnhzBkJmwDnwIysHBF1vlxnzET0Fl2LfL5fRR3A==",
+      "dependencies": {
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -2325,16 +2365,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.1.0.tgz",
-      "integrity": "sha512-2Y6Br8drlrZ/jN9MwMBl0aoi9GAjpfyfMBYpaQZXimbK+e9VjYnujXlvQ4SxtM60ASDgtHIAzfVFBkSR/MwRUw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.4.0.tgz",
+      "integrity": "sha512-pZxh+ygfnI657sN8a/FkYVIAmVv0CGk71QMKqJBOfMmDHNN1FeDeFkBjWP49ejBqpqAhjufkv5UWq3UOu2soCw==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-common": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "fs-extra": "^10.1.0",
         "sitemap": "^7.1.1",
         "tslib": "^2.4.0"
@@ -2348,22 +2388,23 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.1.0.tgz",
-      "integrity": "sha512-NQMnaq974K4BcSMXFSJBQ5itniw6RSyW+VT+6i90kGZzTwiuKZmsp0r9lC6BYAvvVMQUNJQwrETmlu7y2XKW7w==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.4.0.tgz",
+      "integrity": "sha512-/5z5o/9bc6+P5ool2y01PbJhoGddEGsC0ej1MF6mCoazk8A+kW4feoUd68l7Bnv01rCnG3xy7kHUQP97Y0grUA==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/plugin-debug": "2.1.0",
-        "@docusaurus/plugin-google-analytics": "2.1.0",
-        "@docusaurus/plugin-google-gtag": "2.1.0",
-        "@docusaurus/plugin-sitemap": "2.1.0",
-        "@docusaurus/theme-classic": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-search-algolia": "2.1.0",
-        "@docusaurus/types": "2.1.0"
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/plugin-content-blog": "2.4.0",
+        "@docusaurus/plugin-content-docs": "2.4.0",
+        "@docusaurus/plugin-content-pages": "2.4.0",
+        "@docusaurus/plugin-debug": "2.4.0",
+        "@docusaurus/plugin-google-analytics": "2.4.0",
+        "@docusaurus/plugin-google-gtag": "2.4.0",
+        "@docusaurus/plugin-google-tag-manager": "2.4.0",
+        "@docusaurus/plugin-sitemap": "2.4.0",
+        "@docusaurus/theme-classic": "2.4.0",
+        "@docusaurus/theme-common": "2.4.0",
+        "@docusaurus/theme-search-algolia": "2.4.0",
+        "@docusaurus/types": "2.4.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -2386,26 +2427,26 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.1.0.tgz",
-      "integrity": "sha512-xn8ZfNMsf7gaSy9+ClFnUu71o7oKgMo5noYSS1hy3svNifRTkrBp6+MReLDsmIaj3mLf2e7+JCBYKBFbaGzQng==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.4.0.tgz",
+      "integrity": "sha512-GMDX5WU6Z0OC65eQFgl3iNNEbI9IMJz9f6KnOyuMxNUR6q0qVLsKCNopFUDfFNJ55UU50o7P7o21yVhkwpfJ9w==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-translations": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/module-type-aliases": "2.4.0",
+        "@docusaurus/plugin-content-blog": "2.4.0",
+        "@docusaurus/plugin-content-docs": "2.4.0",
+        "@docusaurus/plugin-content-pages": "2.4.0",
+        "@docusaurus/theme-common": "2.4.0",
+        "@docusaurus/theme-translations": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-common": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
         "copy-text-to-clipboard": "^3.0.1",
-        "infima": "0.2.0-alpha.42",
+        "infima": "0.2.0-alpha.43",
         "lodash": "^4.17.21",
         "nprogress": "^0.2.0",
         "postcss": "^8.4.14",
@@ -2425,16 +2466,17 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.1.0.tgz",
-      "integrity": "sha512-vT1otpVPbKux90YpZUnvknsn5zvpLf+AW1W0EDcpE9up4cDrPqfsh0QoxGHFJnobE2/qftsBFC19BneN4BH8Ag==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.4.0.tgz",
+      "integrity": "sha512-IkG/l5f/FLY6cBIxtPmFnxpuPzc5TupuqlOx+XDN+035MdQcAh8wHXXZJAkTeYDeZ3anIUSUIvWa7/nRKoQEfg==",
       "dependencies": {
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/module-type-aliases": "2.4.0",
+        "@docusaurus/plugin-content-blog": "2.4.0",
+        "@docusaurus/plugin-content-docs": "2.4.0",
+        "@docusaurus/plugin-content-pages": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-common": "2.4.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2442,6 +2484,7 @@
         "parse-numeric-range": "^1.3.0",
         "prism-react-renderer": "^1.3.5",
         "tslib": "^2.4.0",
+        "use-sync-external-store": "^1.2.0",
         "utility-types": "^3.10.0"
       },
       "engines": {
@@ -2453,22 +2496,22 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.1.0.tgz",
-      "integrity": "sha512-rNBvi35VvENhucslEeVPOtbAzBdZY/9j55gdsweGV5bYoAXy4mHB6zTGjealcB4pJ6lJY4a5g75fXXMOlUqPfg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.4.0.tgz",
+      "integrity": "sha512-pPCJSCL1Qt4pu/Z0uxBAuke0yEBbxh0s4fOvimna7TEcBLPq0x06/K78AaABXrTVQM6S0vdocFl9EoNgU17hqA==",
       "dependencies": {
         "@docsearch/react": "^3.1.1",
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-translations": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/plugin-content-docs": "2.4.0",
+        "@docusaurus/theme-common": "2.4.0",
+        "@docusaurus/theme-translations": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "algoliasearch": "^4.13.1",
         "algoliasearch-helper": "^3.10.0",
         "clsx": "^1.2.1",
-        "eta": "^1.12.3",
+        "eta": "^2.0.0",
         "fs-extra": "^10.1.0",
         "lodash": "^4.17.21",
         "tslib": "^2.4.0",
@@ -2482,10 +2525,21 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
+    "node_modules/@docusaurus/theme-search-algolia/node_modules/eta": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/eta/-/eta-2.0.1.tgz",
+      "integrity": "sha512-46E2qDPDm7QA+usjffUWz9KfXsxVZclPOuKsXs4ZWZdI/X1wpDF7AO424pt7fdYohCzWsIkXAhNGXSlwo5naAg==",
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/eta-dev/eta?sponsor=1"
+      }
+    },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.1.0.tgz",
-      "integrity": "sha512-07n2akf2nqWvtJeMy3A+7oSGMuu5F673AovXVwY0aGAux1afzGCiqIFlYW3EP0CujvDJAEFSQi/Tetfh+95JNg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.4.0.tgz",
+      "integrity": "sha512-kEoITnPXzDPUMBHk3+fzEzbopxLD3fR5sDoayNH0vXkpUukA88/aDL1bqkhxWZHA3LOfJ3f0vJbOwmnXW5v85Q==",
       "dependencies": {
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0"
@@ -2495,9 +2549,9 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.1.0.tgz",
-      "integrity": "sha512-BS1ebpJZnGG6esKqsjtEC9U9qSaPylPwlO7cQ1GaIE7J/kMZI3FITnNn0otXXu7c7ZTqhb6+8dOrG6fZn6fqzQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.4.0.tgz",
+      "integrity": "sha512-xaBXr+KIPDkIaef06c+i2HeTqVNixB7yFut5fBXPGI2f1rrmEV2vLMznNGsFwvZ5XmA3Quuefd4OGRkdo97Dhw==",
       "dependencies": {
         "@types/history": "^4.7.11",
         "@types/react": "*",
@@ -2514,12 +2568,13 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.1.0.tgz",
-      "integrity": "sha512-fPvrfmAuC54n8MjZuG4IysaMdmvN5A/qr7iFLbSGSyDrsbP4fnui6KdZZIa/YOLIPLec8vjZ8RIITJqF18mx4A==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.4.0.tgz",
+      "integrity": "sha512-89hLYkvtRX92j+C+ERYTuSUK6nF9bGM32QThcHPg2EDDHVw6FzYQXmX6/p+pU5SDyyx5nBlE4qXR92RxCAOqfg==",
       "dependencies": {
-        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/logger": "2.4.0",
         "@svgr/webpack": "^6.2.1",
+        "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.1.0",
         "github-slugger": "^1.4.0",
@@ -2547,9 +2602,9 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.1.0.tgz",
-      "integrity": "sha512-F2vgmt4yRFgRQR2vyEFGTWeyAdmgKbtmu3sjHObF0tjjx/pN0Iw/c6eCopaH34E6tc9nO0nvp01pwW+/86d1fg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.4.0.tgz",
+      "integrity": "sha512-zIMf10xuKxddYfLg5cS19x44zud/E9I7lj3+0bv8UIs0aahpErfNrGhijEfJpAfikhQ8tL3m35nH3hJ3sOG82A==",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -2566,12 +2621,12 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.1.0.tgz",
-      "integrity": "sha512-AMJzWYKL3b7FLltKtDXNLO9Y649V2BXvrnRdnW2AA+PpBnYV78zKLSCz135cuWwRj1ajNtP4onbXdlnyvCijGQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.4.0.tgz",
+      "integrity": "sha512-IrBsBbbAp6y7mZdJx4S4pIA7dUyWSA0GNosPk6ZJ0fX3uYIEQgcQSGIgTeSC+8xPEx3c16o03en1jSDpgQgz/w==",
       "dependencies": {
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
         "joi": "^17.6.0",
         "js-yaml": "^4.1.0",
         "tslib": "^2.4.0"
@@ -3947,30 +4002,30 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.14.2.tgz",
-      "integrity": "sha512-ngbEQonGEmf8dyEh5f+uOIihv4176dgbuOZspiuhmTTBRBuzWu3KCGHre6uHj5YyuC7pNvQGzB6ZNJyZi0z+Sg==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.16.0.tgz",
+      "integrity": "sha512-HAjKJ6bBblaXqO4dYygF4qx251GuJ6zCZt+qbJ+kU7sOC+yc84pawEjVpJByh+cGP2APFCsao2Giz50cDlKNPA==",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.14.2",
-        "@algolia/cache-common": "4.14.2",
-        "@algolia/cache-in-memory": "4.14.2",
-        "@algolia/client-account": "4.14.2",
-        "@algolia/client-analytics": "4.14.2",
-        "@algolia/client-common": "4.14.2",
-        "@algolia/client-personalization": "4.14.2",
-        "@algolia/client-search": "4.14.2",
-        "@algolia/logger-common": "4.14.2",
-        "@algolia/logger-console": "4.14.2",
-        "@algolia/requester-browser-xhr": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/requester-node-http": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/cache-browser-local-storage": "4.16.0",
+        "@algolia/cache-common": "4.16.0",
+        "@algolia/cache-in-memory": "4.16.0",
+        "@algolia/client-account": "4.16.0",
+        "@algolia/client-analytics": "4.16.0",
+        "@algolia/client-common": "4.16.0",
+        "@algolia/client-personalization": "4.16.0",
+        "@algolia/client-search": "4.16.0",
+        "@algolia/logger-common": "4.16.0",
+        "@algolia/logger-console": "4.16.0",
+        "@algolia/requester-browser-xhr": "4.16.0",
+        "@algolia/requester-common": "4.16.0",
+        "@algolia/requester-node-http": "4.16.0",
+        "@algolia/transporter": "4.16.0"
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.11.1.tgz",
-      "integrity": "sha512-mvsPN3eK4E0bZG0/WlWJjeqe/bUD2KOEVOl0GyL/TGXn6wcpZU8NOuztGHCUKXkyg5gq6YzUakVTmnmSSO5Yiw==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.12.0.tgz",
+      "integrity": "sha512-/j1U3PEwdan0n6P/QqSnSpNSLC5+cEMvyljd5CnmNmUjDlGrys+vFEOwjVEnqELIiAGMHEA/Nl3CiKVFBUYqyQ==",
       "dependencies": {
         "@algolia/events": "^4.0.1"
       },
@@ -5027,9 +5082,9 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
     "node_modules/copy-text-to-clipboard": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.0.1.tgz",
-      "integrity": "sha512-rvVsHrpFcL4F2P8ihsoLdFHmd404+CMg71S756oRSeQgqk51U3kicGdnvfkrxva0xXH92SjGS62B0XIJsbh+9Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.1.0.tgz",
+      "integrity": "sha512-PFM6BnjLnOON/lB3ta/Jg7Ywsv+l9kQGD4TWDCSlRBGmqnnTM5MrDkhAFgw+8HZt0wW6Q2BBE4cmy9sq+s9Qng==",
       "engines": {
         "node": ">=12"
       },
@@ -6450,9 +6505,9 @@
       }
     },
     "node_modules/flux": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/flux/-/flux-4.0.3.tgz",
-      "integrity": "sha512-yKAbrp7JhZhj6uiT1FTuVMlIAT1J4jqEyBpFApi1kxpGZCvacMVc/t1pMQyotqHhAgvoE3bNvAykhCo2CLjnYw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/flux/-/flux-4.0.4.tgz",
+      "integrity": "sha512-NCj3XlayA2UsapRpM7va6wU1+9rE5FIL7qoMcmxWHRzbp0yujihMBm9BBHZ1MDIk5h5o2Bl6eGiCe8rYELAmYw==",
       "dependencies": {
         "fbemitter": "^3.0.0",
         "fbjs": "^3.0.1"
@@ -7285,9 +7340,9 @@
       }
     },
     "node_modules/htmlparser2": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
-      "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -7297,9 +7352,9 @@
       ],
       "dependencies": {
         "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
+        "domhandler": "^5.0.3",
         "domutils": "^3.0.1",
-        "entities": "^4.3.0"
+        "entities": "^4.4.0"
       }
     },
     "node_modules/http-cache-semantics": {
@@ -7485,9 +7540,9 @@
       }
     },
     "node_modules/infima": {
-      "version": "0.2.0-alpha.42",
-      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.42.tgz",
-      "integrity": "sha512-ift8OXNbQQwtbIt6z16KnSWP7uJ/SysSMFI4F87MNRTicypfl4Pv3E2OGVv6N3nSZFJvA8imYulCBS64iyHYww==",
+      "version": "0.2.0-alpha.43",
+      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.43.tgz",
+      "integrity": "sha512-2uw57LvUqW0rK/SWYnd/2rRfxNA5DDNOh33jxF7fy46VWoNhGxiUQyVZHbBMjQ33mQem0cjdDVwgWVAmlRfgyQ==",
       "engines": {
         "node": ">=12"
       }
@@ -9069,9 +9124,9 @@
       "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ=="
     },
     "node_modules/parse5": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.1.tgz",
-      "integrity": "sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
       "dependencies": {
         "entities": "^4.4.0"
       },
@@ -10312,11 +10367,11 @@
       }
     },
     "node_modules/react-textarea-autosize": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.4.tgz",
-      "integrity": "sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.1.tgz",
+      "integrity": "sha512-aD2C+qK6QypknC+lCMzteOdIjoMbNlgSFmJjCV+DrfTPwp59i/it9mMNf2HDzvRjQgKAyBDPyLJhcrzElf2U4Q==",
       "dependencies": {
-        "@babel/runtime": "^7.10.2",
+        "@babel/runtime": "^7.20.13",
         "use-composed-ref": "^1.3.0",
         "use-latest": "^1.2.1"
       },
@@ -10395,9 +10450,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.0",
@@ -12147,9 +12202,9 @@
       }
     },
     "node_modules/ua-parser-js": {
-      "version": "0.7.33",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
-      "integrity": "sha512-s8ax/CeZdK9R/56Sui0WM6y9OFREJarMRHqLB2EwkovemBxNQ+Bqu8GAsUnVcXKgphb++ghr/B2BZx4mahujPw==",
+      "version": "0.7.34",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.34.tgz",
+      "integrity": "sha512-cJMeh/eOILyGu0ejgTKB95yKT3zOenSe9UGE3vj6WfiOwgGYnmATUsnDixMFvdU+rNMvWih83hrUP8VwhF9yXQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -12648,6 +12703,14 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util": {
@@ -13434,95 +13497,95 @@
   },
   "dependencies": {
     "@algolia/autocomplete-core": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.1.tgz",
-      "integrity": "sha512-eiZw+fxMzNQn01S8dA/hcCpoWCOCwcIIEUtHHdzN5TGB3IpzLbuhqFeTfh2OUhhgkE8Uo17+wH+QJ/wYyQmmzg==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.4.tgz",
+      "integrity": "sha512-daoLpQ3ps/VTMRZDEBfU8ixXd+amZcNJ4QSP3IERGyzqnL5Ch8uSRFt/4G8pUvW9c3o6GA4vtVv4I4lmnkdXyg==",
       "requires": {
-        "@algolia/autocomplete-shared": "1.7.1"
+        "@algolia/autocomplete-shared": "1.7.4"
       }
     },
     "@algolia/autocomplete-preset-algolia": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.1.tgz",
-      "integrity": "sha512-pJwmIxeJCymU1M6cGujnaIYcY3QPOVYZOXhFkWVM7IxKzy272BwCvMFMyc5NpG/QmiObBxjo7myd060OeTNJXg==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.4.tgz",
+      "integrity": "sha512-s37hrvLEIfcmKY8VU9LsAXgm2yfmkdHT3DnA3SgHaY93yjZ2qL57wzb5QweVkYuEBZkT2PIREvRoLXC2sxTbpQ==",
       "requires": {
-        "@algolia/autocomplete-shared": "1.7.1"
+        "@algolia/autocomplete-shared": "1.7.4"
       }
     },
     "@algolia/autocomplete-shared": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.1.tgz",
-      "integrity": "sha512-eTmGVqY3GeyBTT8IWiB2K5EuURAqhnumfktAEoHxfDY2o7vg2rSnO16ZtIG0fMgt3py28Vwgq42/bVEuaQV7pg=="
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.4.tgz",
+      "integrity": "sha512-2VGCk7I9tA9Ge73Km99+Qg87w0wzW4tgUruvWAn/gfey1ZXgmxZtyIRBebk35R1O8TbK77wujVtCnpsGpRy1kg=="
     },
     "@algolia/cache-browser-local-storage": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.14.2.tgz",
-      "integrity": "sha512-FRweBkK/ywO+GKYfAWbrepewQsPTIEirhi1BdykX9mxvBPtGNKccYAxvGdDCumU1jL4r3cayio4psfzKMejBlA==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.16.0.tgz",
+      "integrity": "sha512-jVrk0YB3tjOhD5/lhBtYCVCeLjZmVpf2kdi4puApofytf/R0scjWz0GdozlW4HhU+Prxmt/c9ge4QFjtv5OAzQ==",
       "requires": {
-        "@algolia/cache-common": "4.14.2"
+        "@algolia/cache-common": "4.16.0"
       }
     },
     "@algolia/cache-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.14.2.tgz",
-      "integrity": "sha512-SbvAlG9VqNanCErr44q6lEKD2qoK4XtFNx9Qn8FK26ePCI8I9yU7pYB+eM/cZdS9SzQCRJBbHUumVr4bsQ4uxg=="
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.16.0.tgz",
+      "integrity": "sha512-4iHjkSYQYw46pITrNQgXXhvUmcekI8INz1m+SzmqLX8jexSSy4Ky4zfGhZzhhhLHXUP3+x/PK/c0qPjxEvRwKQ=="
     },
     "@algolia/cache-in-memory": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.14.2.tgz",
-      "integrity": "sha512-HrOukWoop9XB/VFojPv1R5SVXowgI56T9pmezd/djh2JnVN/vXswhXV51RKy4nCpqxyHt/aGFSq2qkDvj6KiuQ==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.16.0.tgz",
+      "integrity": "sha512-p7RYykvA6Ip6QENxrh99nOD77otVh1sJRivcgcVpnjoZb5sIN3t33eUY1DpB9QSBizcrW+qk19rNkdnZ43a+PQ==",
       "requires": {
-        "@algolia/cache-common": "4.14.2"
+        "@algolia/cache-common": "4.16.0"
       }
     },
     "@algolia/client-account": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.14.2.tgz",
-      "integrity": "sha512-WHtriQqGyibbb/Rx71YY43T0cXqyelEU0lB2QMBRXvD2X0iyeGl4qMxocgEIcbHyK7uqE7hKgjT8aBrHqhgc1w==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.16.0.tgz",
+      "integrity": "sha512-eydcfpdIyuWoKgUSz5iZ/L0wE/Wl7958kACkvTHLDNXvK/b8Z1zypoJavh6/km1ZNQmFpeYS2jrmq0kUSFn02w==",
       "requires": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/client-search": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/client-common": "4.16.0",
+        "@algolia/client-search": "4.16.0",
+        "@algolia/transporter": "4.16.0"
       }
     },
     "@algolia/client-analytics": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.14.2.tgz",
-      "integrity": "sha512-yBvBv2mw+HX5a+aeR0dkvUbFZsiC4FKSnfqk9rrfX+QrlNOKEhCG0tJzjiOggRW4EcNqRmaTULIYvIzQVL2KYQ==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.16.0.tgz",
+      "integrity": "sha512-cONWXH3BfilgdlCofUm492bJRWtpBLVW/hsUlfoFtiX1u05xoBP7qeiDwh9RR+4pSLHLodYkHAf5U4honQ55Qg==",
       "requires": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/client-search": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/client-common": "4.16.0",
+        "@algolia/client-search": "4.16.0",
+        "@algolia/requester-common": "4.16.0",
+        "@algolia/transporter": "4.16.0"
       }
     },
     "@algolia/client-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.14.2.tgz",
-      "integrity": "sha512-43o4fslNLcktgtDMVaT5XwlzsDPzlqvqesRi4MjQz2x4/Sxm7zYg5LRYFol1BIhG6EwxKvSUq8HcC/KxJu3J0Q==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.16.0.tgz",
+      "integrity": "sha512-QVdR4019ukBH6f5lFr27W60trRxQF1SfS1qo0IP6gjsKhXhUVJuHxOCA6ArF87jrNkeuHEoRoDU+GlvaecNo8g==",
       "requires": {
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/requester-common": "4.16.0",
+        "@algolia/transporter": "4.16.0"
       }
     },
     "@algolia/client-personalization": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.14.2.tgz",
-      "integrity": "sha512-ACCoLi0cL8CBZ1W/2juehSltrw2iqsQBnfiu/Rbl9W2yE6o2ZUb97+sqN/jBqYNQBS+o0ekTMKNkQjHHAcEXNw==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.16.0.tgz",
+      "integrity": "sha512-irtLafssDGPuhYqIwxqOxiWlVYvrsBD+EMA1P9VJtkKi3vSNBxiWeQ0f0Tn53cUNdSRNEssfoEH84JL97SV2SQ==",
       "requires": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/client-common": "4.16.0",
+        "@algolia/requester-common": "4.16.0",
+        "@algolia/transporter": "4.16.0"
       }
     },
     "@algolia/client-search": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.14.2.tgz",
-      "integrity": "sha512-L5zScdOmcZ6NGiVbLKTvP02UbxZ0njd5Vq9nJAmPFtjffUSOGEp11BmD2oMJ5QvARgx2XbX4KzTTNS5ECYIMWw==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.16.0.tgz",
+      "integrity": "sha512-xsfrAE1jO/JDh1wFrRz+alVyW+aA6qnkzmbWWWZWEgVF3EaFqzIf9r1l/aDtDdBtNTNhX9H3Lg31+BRtd5izQA==",
       "requires": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/client-common": "4.16.0",
+        "@algolia/requester-common": "4.16.0",
+        "@algolia/transporter": "4.16.0"
       }
     },
     "@algolia/events": {
@@ -13531,47 +13594,47 @@
       "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
     },
     "@algolia/logger-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.14.2.tgz",
-      "integrity": "sha512-/JGlYvdV++IcMHBnVFsqEisTiOeEr6cUJtpjz8zc0A9c31JrtLm318Njc72p14Pnkw3A/5lHHh+QxpJ6WFTmsA=="
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.16.0.tgz",
+      "integrity": "sha512-U9H8uCzSDuePJmbnjjTX21aPDRU6x74Tdq3dJmdYu2+pISx02UeBJm4kSgc9RW5jcR5j35G9gnjHY9Q3ngWbyQ=="
     },
     "@algolia/logger-console": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.14.2.tgz",
-      "integrity": "sha512-8S2PlpdshbkwlLCSAB5f8c91xyc84VM9Ar9EdfE9UmX+NrKNYnWR1maXXVDQQoto07G1Ol/tYFnFVhUZq0xV/g==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.16.0.tgz",
+      "integrity": "sha512-+qymusiM+lPZKrkf0tDjCQA158eEJO2IU+Nr/sJ9TFyI/xkFPjNPzw/Qbc8Iy/xcOXGlc6eMgmyjtVQqAWq6UA==",
       "requires": {
-        "@algolia/logger-common": "4.14.2"
+        "@algolia/logger-common": "4.16.0"
       }
     },
     "@algolia/requester-browser-xhr": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.14.2.tgz",
-      "integrity": "sha512-CEh//xYz/WfxHFh7pcMjQNWgpl4wFB85lUMRyVwaDPibNzQRVcV33YS+63fShFWc2+42YEipFGH2iPzlpszmDw==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.16.0.tgz",
+      "integrity": "sha512-gK+kvs6LHl/PaOJfDuwjkopNbG1djzFLsVBklGBsSU6h6VjFkxIpo6Qq80IK14p9cplYZfhfaL12va6Q9p3KVQ==",
       "requires": {
-        "@algolia/requester-common": "4.14.2"
+        "@algolia/requester-common": "4.16.0"
       }
     },
     "@algolia/requester-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.14.2.tgz",
-      "integrity": "sha512-73YQsBOKa5fvVV3My7iZHu1sUqmjjfs9TteFWwPwDmnad7T0VTCopttcsM3OjLxZFtBnX61Xxl2T2gmG2O4ehg=="
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.16.0.tgz",
+      "integrity": "sha512-3Zmcs/iMubcm4zqZ3vZG6Zum8t+hMWxGMzo0/uY2BD8o9q5vMxIYI0c4ocdgQjkXcix189WtZNkgjSOBzSbkdw=="
     },
     "@algolia/requester-node-http": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.14.2.tgz",
-      "integrity": "sha512-oDbb02kd1o5GTEld4pETlPZLY0e+gOSWjWMJHWTgDXbv9rm/o2cF7japO6Vj1ENnrqWvLBmW1OzV9g6FUFhFXg==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.16.0.tgz",
+      "integrity": "sha512-L8JxM2VwZzh8LJ1Zb8TFS6G3icYsCKZsdWW+ahcEs1rGWmyk9SybsOe1MLnjonGBaqPWJkn9NjS7mRdjEmBtKA==",
       "requires": {
-        "@algolia/requester-common": "4.14.2"
+        "@algolia/requester-common": "4.16.0"
       }
     },
     "@algolia/transporter": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.14.2.tgz",
-      "integrity": "sha512-t89dfQb2T9MFQHidjHcfhh6iGMNwvuKUvojAj+JsrHAGbuSy7yE4BylhLX6R0Q1xYRoC4Vvv+O5qIw/LdnQfsQ==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.16.0.tgz",
+      "integrity": "sha512-H9BVB2EAjT65w7XGBNf5drpsW39x2aSZ942j4boSAAJPPlLmjtj5IpAP7UAtsV8g9Beslonh0bLa1XGmE/P0BA==",
       "requires": {
-        "@algolia/cache-common": "4.14.2",
-        "@algolia/logger-common": "4.14.2",
-        "@algolia/requester-common": "4.14.2"
+        "@algolia/cache-common": "4.16.0",
+        "@algolia/logger-common": "4.16.0",
+        "@algolia/requester-common": "4.16.0"
       }
     },
     "@ampproject/remapping": {
@@ -14731,11 +14794,11 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.0.tgz",
-      "integrity": "sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
+      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
       "requires": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.11"
       }
     },
     "@babel/runtime-corejs3": {
@@ -14791,25 +14854,25 @@
       "optional": true
     },
     "@docsearch/css": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.2.1.tgz",
-      "integrity": "sha512-gaP6TxxwQC+K8D6TRx5WULUWKrcbzECOPA2KCVMuI+6C7dNiGUk5yXXzVhc5sld79XKYLnO9DRTI4mjXDYkh+g=="
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.3.3.tgz",
+      "integrity": "sha512-6SCwI7P8ao+se1TUsdZ7B4XzL+gqeQZnBc+2EONZlcVa0dVrk0NjETxozFKgMv0eEGH8QzP1fkN+A1rH61l4eg=="
     },
     "@docsearch/react": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.2.1.tgz",
-      "integrity": "sha512-EzTQ/y82s14IQC5XVestiK/kFFMe2aagoYFuTAIfIb/e+4FU7kSMKonRtLwsCiLQHmjvNQq+HO+33giJ5YVtaQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.3.3.tgz",
+      "integrity": "sha512-pLa0cxnl+G0FuIDuYlW+EBK6Rw2jwLw9B1RHIeS4N4s2VhsfJ/wzeCi3CWcs5yVfxLd5ZK50t//TMA5e79YT7Q==",
       "requires": {
-        "@algolia/autocomplete-core": "1.7.1",
-        "@algolia/autocomplete-preset-algolia": "1.7.1",
-        "@docsearch/css": "3.2.1",
+        "@algolia/autocomplete-core": "1.7.4",
+        "@algolia/autocomplete-preset-algolia": "1.7.4",
+        "@docsearch/css": "3.3.3",
         "algoliasearch": "^4.0.0"
       }
     },
     "@docusaurus/core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.1.0.tgz",
-      "integrity": "sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.4.0.tgz",
+      "integrity": "sha512-J55/WEoIpRcLf3afO5POHPguVZosKmJEQWKBL+K7TAnfuE7i+Y0NPLlkKtnWCehagGsgTqClfQEexH/UT4kELA==",
       "requires": {
         "@babel/core": "^7.18.6",
         "@babel/generator": "^7.18.7",
@@ -14821,13 +14884,13 @@
         "@babel/runtime": "^7.18.6",
         "@babel/runtime-corejs3": "^7.18.6",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
+        "@docusaurus/cssnano-preset": "2.4.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/mdx-loader": "2.4.0",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-common": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
         "@svgr/webpack": "^6.2.1",
         "autoprefixer": "^10.4.7",
@@ -14848,7 +14911,7 @@
         "del": "^6.1.1",
         "detect-port": "^1.3.0",
         "escape-html": "^1.0.3",
-        "eta": "^1.12.3",
+        "eta": "^2.0.0",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.1.0",
         "html-minifier-terser": "^6.1.0",
@@ -14882,12 +14945,19 @@
         "webpack-dev-server": "^4.9.3",
         "webpack-merge": "^5.8.0",
         "webpackbar": "^5.0.2"
+      },
+      "dependencies": {
+        "eta": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/eta/-/eta-2.0.1.tgz",
+          "integrity": "sha512-46E2qDPDm7QA+usjffUWz9KfXsxVZclPOuKsXs4ZWZdI/X1wpDF7AO424pt7fdYohCzWsIkXAhNGXSlwo5naAg=="
+        }
       }
     },
     "@docusaurus/cssnano-preset": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.1.0.tgz",
-      "integrity": "sha512-pRLewcgGhOies6pzsUROfmPStDRdFw+FgV5sMtLr5+4Luv2rty5+b/eSIMMetqUsmg3A9r9bcxHk9bKAKvx3zQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.4.0.tgz",
+      "integrity": "sha512-RmdiA3IpsLgZGXRzqnmTbGv43W4OD44PCo+6Q/aYjEM2V57vKCVqNzuafE94jv0z/PjHoXUrjr69SaRymBKYYw==",
       "requires": {
         "cssnano-preset-advanced": "^5.3.8",
         "postcss": "^8.4.14",
@@ -14896,23 +14966,23 @@
       }
     },
     "@docusaurus/logger": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.1.0.tgz",
-      "integrity": "sha512-uuJx2T6hDBg82joFeyobywPjSOIfeq05GfyKGHThVoXuXsu1KAzMDYcjoDxarb9CoHCI/Dor8R2MoL6zII8x1Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.4.0.tgz",
+      "integrity": "sha512-T8+qR4APN+MjcC9yL2Es+xPJ2923S9hpzDmMtdsOcUGLqpCGBbU1vp3AAqDwXtVgFkq+NsEk7sHdVsfLWR/AXw==",
       "requires": {
         "chalk": "^4.1.2",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/mdx-loader": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.1.0.tgz",
-      "integrity": "sha512-i97hi7hbQjsD3/8OSFhLy7dbKGH8ryjEzOfyhQIn2CFBYOY3ko0vMVEf3IY9nD3Ld7amYzsZ8153RPkcnXA+Lg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.4.0.tgz",
+      "integrity": "sha512-GWoH4izZKOmFoC+gbI2/y8deH/xKLvzz/T5BsEexBye8EHQlwsA7FMrVa48N063bJBH4FUOiRRXxk5rq9cC36g==",
       "requires": {
         "@babel/parser": "^7.18.8",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
         "@mdx-js/mdx": "^1.6.22",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
@@ -14929,12 +14999,12 @@
       }
     },
     "@docusaurus/module-type-aliases": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.1.0.tgz",
-      "integrity": "sha512-Z8WZaK5cis3xEtyfOT817u9xgGUauT0PuuVo85ysnFRX8n7qLN1lTPCkC+aCmFm/UcV8h/W5T4NtIsst94UntQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.4.0.tgz",
+      "integrity": "sha512-YEQO2D3UXs72qCn8Cr+RlycSQXVGN9iEUyuHwTuK4/uL/HFomB2FHSU0vSDM23oLd+X/KibQ3Ez6nGjQLqXcHg==",
       "requires": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.1.0",
+        "@docusaurus/types": "2.4.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -14944,33 +15014,40 @@
       }
     },
     "@docusaurus/plugin-client-redirects": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-2.1.0.tgz",
-      "integrity": "sha512-3PhzwHSyZWqBAFPJuLJE3dZVuKWQEj9ReQP85Z3/2hpnQoVNBgAqc+64FIko0FvvK1iluLeasO7NWGyuATngvw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-2.4.0.tgz",
+      "integrity": "sha512-HsS+Dc2ZLWhfpjYJ5LIrOB/XfXZcElcC7o1iA4yIVtiFz+LHhwP863fhqbwSJ1c6tNDOYBH3HwbskHrc/PIn7Q==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
-        "eta": "^1.12.3",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-common": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
+        "eta": "^2.0.0",
         "fs-extra": "^10.1.0",
         "lodash": "^4.17.21",
         "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "eta": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/eta/-/eta-2.0.1.tgz",
+          "integrity": "sha512-46E2qDPDm7QA+usjffUWz9KfXsxVZclPOuKsXs4ZWZdI/X1wpDF7AO424pt7fdYohCzWsIkXAhNGXSlwo5naAg=="
+        }
       }
     },
     "@docusaurus/plugin-content-blog": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.1.0.tgz",
-      "integrity": "sha512-xEp6jlu92HMNUmyRBEeJ4mCW1s77aAEQO4Keez94cUY/Ap7G/r0Awa6xSLff7HL0Fjg8KK1bEbDy7q9voIavdg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.4.0.tgz",
+      "integrity": "sha512-YwkAkVUxtxoBAIj/MCb4ohN0SCtHBs4AS75jMhPpf67qf3j+U/4n33cELq7567hwyZ6fMz2GPJcVmctzlGGThQ==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-common": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^10.1.0",
@@ -14983,17 +15060,17 @@
       }
     },
     "@docusaurus/plugin-content-docs": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.1.0.tgz",
-      "integrity": "sha512-Rup5pqXrXlKGIC4VgwvioIhGWF7E/NNSlxv+JAxRYpik8VKlWsk9ysrdHIlpX+KJUCO9irnY21kQh2814mlp/Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.4.0.tgz",
+      "integrity": "sha512-ic/Z/ZN5Rk/RQo+Io6rUGpToOtNbtPloMR2JcGwC1xT2riMu6zzfSwmBi9tHJgdXH6CB5jG+0dOZZO8QS5tmDg==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/module-type-aliases": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "@types/react-router-config": "^5.0.6",
         "combine-promises": "^1.1.0",
         "fs-extra": "^10.1.0",
@@ -15006,88 +15083,100 @@
       }
     },
     "@docusaurus/plugin-content-pages": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.1.0.tgz",
-      "integrity": "sha512-SwZdDZRlObHNKXTnFo7W2aF6U5ZqNVI55Nw2GCBryL7oKQSLeI0lsrMlMXdzn+fS7OuBTd3MJBO1T4Zpz0i/+g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.4.0.tgz",
+      "integrity": "sha512-Pk2pOeOxk8MeU3mrTU0XLIgP9NZixbdcJmJ7RUFrZp1Aj42nd0RhIT14BGvXXyqb8yTQlk4DmYGAzqOfBsFyGw==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0",
         "webpack": "^5.73.0"
       }
     },
     "@docusaurus/plugin-debug": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.1.0.tgz",
-      "integrity": "sha512-8wsDq3OIfiy6440KLlp/qT5uk+WRHQXIXklNHEeZcar+Of0TZxCNe2FBpv+bzb/0qcdP45ia5i5WmR5OjN6DPw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.4.0.tgz",
+      "integrity": "sha512-KC56DdYjYT7Txyux71vXHXGYZuP6yYtqwClvYpjKreWIHWus5Zt6VNi23rMZv3/QKhOCrN64zplUbdfQMvddBQ==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
         "fs-extra": "^10.1.0",
         "react-json-view": "^1.21.3",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/plugin-google-analytics": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.1.0.tgz",
-      "integrity": "sha512-4cgeqIly/wcFVbbWP03y1QJJBgH8W+Bv6AVbWnsXNOZa1yB3AO6hf3ZdeQH9x20v9T2pREogVgAH0rSoVnNsgg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.4.0.tgz",
+      "integrity": "sha512-uGUzX67DOAIglygdNrmMOvEp8qG03X20jMWadeqVQktS6nADvozpSLGx4J0xbkblhJkUzN21WiilsP9iVP+zkw==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/plugin-google-gtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.1.0.tgz",
-      "integrity": "sha512-/3aDlv2dMoCeiX2e+DTGvvrdTA+v3cKQV3DbmfsF4ENhvc5nKV23nth04Z3Vq0Ci1ui6Sn80TkhGk/tiCMW2AA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.4.0.tgz",
+      "integrity": "sha512-adj/70DANaQs2+TF/nRdMezDXFAV/O/pjAbUgmKBlyOTq5qoMe0Tk4muvQIwWUmiUQxFJe+sKlZGM771ownyOg==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@docusaurus/plugin-google-tag-manager": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-2.4.0.tgz",
+      "integrity": "sha512-E66uGcYs4l7yitmp/8kMEVQftFPwV9iC62ORh47Veqzs6ExwnhzBkJmwDnwIysHBF1vlxnzET0Fl2LfL5fRR3A==",
+      "requires": {
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/plugin-sitemap": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.1.0.tgz",
-      "integrity": "sha512-2Y6Br8drlrZ/jN9MwMBl0aoi9GAjpfyfMBYpaQZXimbK+e9VjYnujXlvQ4SxtM60ASDgtHIAzfVFBkSR/MwRUw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.4.0.tgz",
+      "integrity": "sha512-pZxh+ygfnI657sN8a/FkYVIAmVv0CGk71QMKqJBOfMmDHNN1FeDeFkBjWP49ejBqpqAhjufkv5UWq3UOu2soCw==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-common": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "fs-extra": "^10.1.0",
         "sitemap": "^7.1.1",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/preset-classic": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.1.0.tgz",
-      "integrity": "sha512-NQMnaq974K4BcSMXFSJBQ5itniw6RSyW+VT+6i90kGZzTwiuKZmsp0r9lC6BYAvvVMQUNJQwrETmlu7y2XKW7w==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.4.0.tgz",
+      "integrity": "sha512-/5z5o/9bc6+P5ool2y01PbJhoGddEGsC0ej1MF6mCoazk8A+kW4feoUd68l7Bnv01rCnG3xy7kHUQP97Y0grUA==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/plugin-debug": "2.1.0",
-        "@docusaurus/plugin-google-analytics": "2.1.0",
-        "@docusaurus/plugin-google-gtag": "2.1.0",
-        "@docusaurus/plugin-sitemap": "2.1.0",
-        "@docusaurus/theme-classic": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-search-algolia": "2.1.0",
-        "@docusaurus/types": "2.1.0"
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/plugin-content-blog": "2.4.0",
+        "@docusaurus/plugin-content-docs": "2.4.0",
+        "@docusaurus/plugin-content-pages": "2.4.0",
+        "@docusaurus/plugin-debug": "2.4.0",
+        "@docusaurus/plugin-google-analytics": "2.4.0",
+        "@docusaurus/plugin-google-gtag": "2.4.0",
+        "@docusaurus/plugin-google-tag-manager": "2.4.0",
+        "@docusaurus/plugin-sitemap": "2.4.0",
+        "@docusaurus/theme-classic": "2.4.0",
+        "@docusaurus/theme-common": "2.4.0",
+        "@docusaurus/theme-search-algolia": "2.4.0",
+        "@docusaurus/types": "2.4.0"
       }
     },
     "@docusaurus/react-loadable": {
@@ -15100,26 +15189,26 @@
       }
     },
     "@docusaurus/theme-classic": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.1.0.tgz",
-      "integrity": "sha512-xn8ZfNMsf7gaSy9+ClFnUu71o7oKgMo5noYSS1hy3svNifRTkrBp6+MReLDsmIaj3mLf2e7+JCBYKBFbaGzQng==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.4.0.tgz",
+      "integrity": "sha512-GMDX5WU6Z0OC65eQFgl3iNNEbI9IMJz9f6KnOyuMxNUR6q0qVLsKCNopFUDfFNJ55UU50o7P7o21yVhkwpfJ9w==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-translations": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/module-type-aliases": "2.4.0",
+        "@docusaurus/plugin-content-blog": "2.4.0",
+        "@docusaurus/plugin-content-docs": "2.4.0",
+        "@docusaurus/plugin-content-pages": "2.4.0",
+        "@docusaurus/theme-common": "2.4.0",
+        "@docusaurus/theme-translations": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-common": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
         "copy-text-to-clipboard": "^3.0.1",
-        "infima": "0.2.0-alpha.42",
+        "infima": "0.2.0-alpha.43",
         "lodash": "^4.17.21",
         "nprogress": "^0.2.0",
         "postcss": "^8.4.14",
@@ -15132,16 +15221,17 @@
       }
     },
     "@docusaurus/theme-common": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.1.0.tgz",
-      "integrity": "sha512-vT1otpVPbKux90YpZUnvknsn5zvpLf+AW1W0EDcpE9up4cDrPqfsh0QoxGHFJnobE2/qftsBFC19BneN4BH8Ag==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.4.0.tgz",
+      "integrity": "sha512-IkG/l5f/FLY6cBIxtPmFnxpuPzc5TupuqlOx+XDN+035MdQcAh8wHXXZJAkTeYDeZ3anIUSUIvWa7/nRKoQEfg==",
       "requires": {
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/module-type-aliases": "2.4.0",
+        "@docusaurus/plugin-content-blog": "2.4.0",
+        "@docusaurus/plugin-content-docs": "2.4.0",
+        "@docusaurus/plugin-content-pages": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-common": "2.4.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -15149,45 +15239,53 @@
         "parse-numeric-range": "^1.3.0",
         "prism-react-renderer": "^1.3.5",
         "tslib": "^2.4.0",
+        "use-sync-external-store": "^1.2.0",
         "utility-types": "^3.10.0"
       }
     },
     "@docusaurus/theme-search-algolia": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.1.0.tgz",
-      "integrity": "sha512-rNBvi35VvENhucslEeVPOtbAzBdZY/9j55gdsweGV5bYoAXy4mHB6zTGjealcB4pJ6lJY4a5g75fXXMOlUqPfg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.4.0.tgz",
+      "integrity": "sha512-pPCJSCL1Qt4pu/Z0uxBAuke0yEBbxh0s4fOvimna7TEcBLPq0x06/K78AaABXrTVQM6S0vdocFl9EoNgU17hqA==",
       "requires": {
         "@docsearch/react": "^3.1.1",
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-translations": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/plugin-content-docs": "2.4.0",
+        "@docusaurus/theme-common": "2.4.0",
+        "@docusaurus/theme-translations": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "algoliasearch": "^4.13.1",
         "algoliasearch-helper": "^3.10.0",
         "clsx": "^1.2.1",
-        "eta": "^1.12.3",
+        "eta": "^2.0.0",
         "fs-extra": "^10.1.0",
         "lodash": "^4.17.21",
         "tslib": "^2.4.0",
         "utility-types": "^3.10.0"
+      },
+      "dependencies": {
+        "eta": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/eta/-/eta-2.0.1.tgz",
+          "integrity": "sha512-46E2qDPDm7QA+usjffUWz9KfXsxVZclPOuKsXs4ZWZdI/X1wpDF7AO424pt7fdYohCzWsIkXAhNGXSlwo5naAg=="
+        }
       }
     },
     "@docusaurus/theme-translations": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.1.0.tgz",
-      "integrity": "sha512-07n2akf2nqWvtJeMy3A+7oSGMuu5F673AovXVwY0aGAux1afzGCiqIFlYW3EP0CujvDJAEFSQi/Tetfh+95JNg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.4.0.tgz",
+      "integrity": "sha512-kEoITnPXzDPUMBHk3+fzEzbopxLD3fR5sDoayNH0vXkpUukA88/aDL1bqkhxWZHA3LOfJ3f0vJbOwmnXW5v85Q==",
       "requires": {
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/types": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.1.0.tgz",
-      "integrity": "sha512-BS1ebpJZnGG6esKqsjtEC9U9qSaPylPwlO7cQ1GaIE7J/kMZI3FITnNn0otXXu7c7ZTqhb6+8dOrG6fZn6fqzQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.4.0.tgz",
+      "integrity": "sha512-xaBXr+KIPDkIaef06c+i2HeTqVNixB7yFut5fBXPGI2f1rrmEV2vLMznNGsFwvZ5XmA3Quuefd4OGRkdo97Dhw==",
       "requires": {
         "@types/history": "^4.7.11",
         "@types/react": "*",
@@ -15200,12 +15298,13 @@
       }
     },
     "@docusaurus/utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.1.0.tgz",
-      "integrity": "sha512-fPvrfmAuC54n8MjZuG4IysaMdmvN5A/qr7iFLbSGSyDrsbP4fnui6KdZZIa/YOLIPLec8vjZ8RIITJqF18mx4A==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.4.0.tgz",
+      "integrity": "sha512-89hLYkvtRX92j+C+ERYTuSUK6nF9bGM32QThcHPg2EDDHVw6FzYQXmX6/p+pU5SDyyx5nBlE4qXR92RxCAOqfg==",
       "requires": {
-        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/logger": "2.4.0",
         "@svgr/webpack": "^6.2.1",
+        "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.1.0",
         "github-slugger": "^1.4.0",
@@ -15222,20 +15321,20 @@
       }
     },
     "@docusaurus/utils-common": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.1.0.tgz",
-      "integrity": "sha512-F2vgmt4yRFgRQR2vyEFGTWeyAdmgKbtmu3sjHObF0tjjx/pN0Iw/c6eCopaH34E6tc9nO0nvp01pwW+/86d1fg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.4.0.tgz",
+      "integrity": "sha512-zIMf10xuKxddYfLg5cS19x44zud/E9I7lj3+0bv8UIs0aahpErfNrGhijEfJpAfikhQ8tL3m35nH3hJ3sOG82A==",
       "requires": {
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/utils-validation": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.1.0.tgz",
-      "integrity": "sha512-AMJzWYKL3b7FLltKtDXNLO9Y649V2BXvrnRdnW2AA+PpBnYV78zKLSCz135cuWwRj1ajNtP4onbXdlnyvCijGQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.4.0.tgz",
+      "integrity": "sha512-IrBsBbbAp6y7mZdJx4S4pIA7dUyWSA0GNosPk6ZJ0fX3uYIEQgcQSGIgTeSC+8xPEx3c16o03en1jSDpgQgz/w==",
       "requires": {
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
         "joi": "^17.6.0",
         "js-yaml": "^4.1.0",
         "tslib": "^2.4.0"
@@ -16335,30 +16434,30 @@
       "requires": {}
     },
     "algoliasearch": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.14.2.tgz",
-      "integrity": "sha512-ngbEQonGEmf8dyEh5f+uOIihv4176dgbuOZspiuhmTTBRBuzWu3KCGHre6uHj5YyuC7pNvQGzB6ZNJyZi0z+Sg==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.16.0.tgz",
+      "integrity": "sha512-HAjKJ6bBblaXqO4dYygF4qx251GuJ6zCZt+qbJ+kU7sOC+yc84pawEjVpJByh+cGP2APFCsao2Giz50cDlKNPA==",
       "requires": {
-        "@algolia/cache-browser-local-storage": "4.14.2",
-        "@algolia/cache-common": "4.14.2",
-        "@algolia/cache-in-memory": "4.14.2",
-        "@algolia/client-account": "4.14.2",
-        "@algolia/client-analytics": "4.14.2",
-        "@algolia/client-common": "4.14.2",
-        "@algolia/client-personalization": "4.14.2",
-        "@algolia/client-search": "4.14.2",
-        "@algolia/logger-common": "4.14.2",
-        "@algolia/logger-console": "4.14.2",
-        "@algolia/requester-browser-xhr": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/requester-node-http": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/cache-browser-local-storage": "4.16.0",
+        "@algolia/cache-common": "4.16.0",
+        "@algolia/cache-in-memory": "4.16.0",
+        "@algolia/client-account": "4.16.0",
+        "@algolia/client-analytics": "4.16.0",
+        "@algolia/client-common": "4.16.0",
+        "@algolia/client-personalization": "4.16.0",
+        "@algolia/client-search": "4.16.0",
+        "@algolia/logger-common": "4.16.0",
+        "@algolia/logger-console": "4.16.0",
+        "@algolia/requester-browser-xhr": "4.16.0",
+        "@algolia/requester-common": "4.16.0",
+        "@algolia/requester-node-http": "4.16.0",
+        "@algolia/transporter": "4.16.0"
       }
     },
     "algoliasearch-helper": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.11.1.tgz",
-      "integrity": "sha512-mvsPN3eK4E0bZG0/WlWJjeqe/bUD2KOEVOl0GyL/TGXn6wcpZU8NOuztGHCUKXkyg5gq6YzUakVTmnmSSO5Yiw==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.12.0.tgz",
+      "integrity": "sha512-/j1U3PEwdan0n6P/QqSnSpNSLC5+cEMvyljd5CnmNmUjDlGrys+vFEOwjVEnqELIiAGMHEA/Nl3CiKVFBUYqyQ==",
       "requires": {
         "@algolia/events": "^4.0.1"
       }
@@ -17129,9 +17228,9 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
     "copy-text-to-clipboard": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.0.1.tgz",
-      "integrity": "sha512-rvVsHrpFcL4F2P8ihsoLdFHmd404+CMg71S756oRSeQgqk51U3kicGdnvfkrxva0xXH92SjGS62B0XIJsbh+9Q=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.1.0.tgz",
+      "integrity": "sha512-PFM6BnjLnOON/lB3ta/Jg7Ywsv+l9kQGD4TWDCSlRBGmqnnTM5MrDkhAFgw+8HZt0wW6Q2BBE4cmy9sq+s9Qng=="
     },
     "copy-webpack-plugin": {
       "version": "11.0.0",
@@ -18146,9 +18245,9 @@
       }
     },
     "flux": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/flux/-/flux-4.0.3.tgz",
-      "integrity": "sha512-yKAbrp7JhZhj6uiT1FTuVMlIAT1J4jqEyBpFApi1kxpGZCvacMVc/t1pMQyotqHhAgvoE3bNvAykhCo2CLjnYw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/flux/-/flux-4.0.4.tgz",
+      "integrity": "sha512-NCj3XlayA2UsapRpM7va6wU1+9rE5FIL7qoMcmxWHRzbp0yujihMBm9BBHZ1MDIk5h5o2Bl6eGiCe8rYELAmYw==",
       "requires": {
         "fbemitter": "^3.0.0",
         "fbjs": "^3.0.1"
@@ -18756,14 +18855,14 @@
       }
     },
     "htmlparser2": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
-      "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
       "requires": {
         "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
+        "domhandler": "^5.0.3",
         "domutils": "^3.0.1",
-        "entities": "^4.3.0"
+        "entities": "^4.4.0"
       }
     },
     "http-cache-semantics": {
@@ -18889,9 +18988,9 @@
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
     },
     "infima": {
-      "version": "0.2.0-alpha.42",
-      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.42.tgz",
-      "integrity": "sha512-ift8OXNbQQwtbIt6z16KnSWP7uJ/SysSMFI4F87MNRTicypfl4Pv3E2OGVv6N3nSZFJvA8imYulCBS64iyHYww=="
+      "version": "0.2.0-alpha.43",
+      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.43.tgz",
+      "integrity": "sha512-2uw57LvUqW0rK/SWYnd/2rRfxNA5DDNOh33jxF7fy46VWoNhGxiUQyVZHbBMjQ33mQem0cjdDVwgWVAmlRfgyQ=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -19984,9 +20083,9 @@
       "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ=="
     },
     "parse5": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.1.tgz",
-      "integrity": "sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
       "requires": {
         "entities": "^4.4.0"
       }
@@ -20828,11 +20927,11 @@
       }
     },
     "react-textarea-autosize": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.4.tgz",
-      "integrity": "sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.1.tgz",
+      "integrity": "sha512-aD2C+qK6QypknC+lCMzteOdIjoMbNlgSFmJjCV+DrfTPwp59i/it9mMNf2HDzvRjQgKAyBDPyLJhcrzElf2U4Q==",
       "requires": {
-        "@babel/runtime": "^7.10.2",
+        "@babel/runtime": "^7.20.13",
         "use-composed-ref": "^1.3.0",
         "use-latest": "^1.2.1"
       }
@@ -20890,9 +20989,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "regenerator-transform": {
       "version": "0.15.0",
@@ -22201,9 +22300,9 @@
       "peer": true
     },
     "ua-parser-js": {
-      "version": "0.7.33",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
-      "integrity": "sha512-s8ax/CeZdK9R/56Sui0WM6y9OFREJarMRHqLB2EwkovemBxNQ+Bqu8GAsUnVcXKgphb++ghr/B2BZx4mahujPw=="
+      "version": "0.7.34",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.34.tgz",
+      "integrity": "sha512-cJMeh/eOILyGu0ejgTKB95yKT3zOenSe9UGE3vj6WfiOwgGYnmATUsnDixMFvdU+rNMvWih83hrUP8VwhF9yXQ=="
     },
     "unbox-primitive": {
       "version": "1.0.2",
@@ -22526,6 +22625,12 @@
       "requires": {
         "use-isomorphic-layout-effect": "^1.1.1"
       }
+    },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
     },
     "util": {
       "version": "0.12.4",

--- a/website/package.json
+++ b/website/package.json
@@ -14,9 +14,9 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "2.1.0",
-    "@docusaurus/plugin-client-redirects": "^2.1.0",
-    "@docusaurus/preset-classic": "2.1.0",
+    "@docusaurus/core": "^2.4.0",
+    "@docusaurus/plugin-client-redirects": "^2.4.0",
+    "@docusaurus/preset-classic": "^2.4.0",
     "@mdx-js/react": "^1.6.22",
     "@twilio-labs/docusaurus-plugin-segment": "^0.1.0",
     "aws-sdk": "^2.1231.0",
@@ -26,7 +26,7 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "2.1.0",
+    "@docusaurus/module-type-aliases": "^2.4.0",
     "glob": "^8.0.3",
     "marked": "^4.2.2"
   },

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -166,6 +166,7 @@ const sidebars = {
                 'getting-started/setup/instance-management/supervisor',
                 'getting-started/setup/instance-management/appsmithctl',
                 'getting-started/setup/instance-management/maintenance-window',
+                'getting-started/setup/instance-management/update-appsmith',
               ],
             },
             {

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -165,8 +165,8 @@ const sidebars = {
               items: [
                 'getting-started/setup/instance-management/supervisor',
                 'getting-started/setup/instance-management/appsmithctl',
-                'getting-started/setup/instance-management/maintenance-window',
                 'getting-started/setup/instance-management/update-appsmith',
+                'getting-started/setup/instance-management/maintenance-window',
               ],
             },
             {


### PR DESCRIPTION
- Updates to Docker Installation Page
   - Installation instructions for Docker Compose
- Added a new doc for Updating Appsmith
   - The doc is added under Instance Management
   - The doc instructs users to update Appsmith to the latest version
   - Further reading removed - as users already have Appsmith instance up and running and configured as per their needs. This page only instructs them to update to the latest version.
- Restart containers section removed - as this is obsolete