### PR TITLE
fix: Added css to hide next and previous buttons

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -420,3 +420,7 @@ ul.circle > li:before {
   letter-spacing: -4em;
   margin-top: 1.5em;
 }
+
+.pagination-nav {
+  display: none !important;
+}


### PR DESCRIPTION
fixes - #939

@danciaclara - As we have hidden the buttons, the users don't know where to navigate other than the sidebar for the pages where there is no **Further reading** section. IMO, we should mandate the **Further reading** section for every page. Thoughts?