### PR TITLE
fix: use `className` in `<Message />`

### DIFF
--- a/website/src/components/Message.js
+++ b/website/src/components/Message.js
@@ -11,11 +11,11 @@ import React from "react";
  * @returns a html component
  */
 export default function Message(props) {
-    const {messageContainerClassName, caption, captionClassName, messageContent, messageContentClassName} = props;
+    const { messageContainerClassName, caption, captionClassName, messageContent, messageContentClassName } = props;
     return (
-        <div className={messageContainerClassName}> 
-            <div class={captionClassName}>{caption}</div>
-            <div class={messageContentClassName}> {messageContent}</div>
+        <div className={messageContainerClassName}>
+            <div className={captionClassName}>{caption}</div>
+            <div className={messageContentClassName}> {messageContent}</div>
         </div>
     );
 };


### PR DESCRIPTION
## Changes
- Use `className` instead of `class` for CSS in `<Message />` component because only `className` is valid JSX.
- This fixes the error shown in the console.

## Note
- We don't see any difference in the rendered component now because no css is currently passed through this.