### PR TITLE
fix: k8s tools `kubectl` docs link

### DIFF
--- a/website/docs/getting-started/setup/installation-guides/kubernetes/README.mdx
+++ b/website/docs/getting-started/setup/installation-guides/kubernetes/README.mdx
@@ -13,7 +13,7 @@ Before you install Appsmith, ensure the following are installed:
 
 1. Helm Package Manager - This is a package manager for Kubernetes clusters. It allows you to install and manage applications on Kubernetes clusters. To install Helm, follow the instructions for your platform from the official [Helm documentation](https://helm.sh/docs/intro/install/).
 
-2. `kubectl` - This is the command-line interface to manage resources on Kubernetes clusters. To install `kubectl`, follow the instructions for your platform from the official [Kubernetes documentation](https://kubernetes.io/vi/docs/tasks/tools/install-kubectl/).
+2. `kubectl` - This is the command-line interface to manage resources on Kubernetes clusters. To install `kubectl`, follow the instructions for your platform from the official [Kubernetes documentation](https://kubernetes.io/docs/tasks/tools/#kubectl).
 
 ### Configure Kubernetes cluster
 Follow one of the available guidelines below to configure the Kubernetes cluster.

--- a/website/docs/getting-started/setup/installation-guides/kubernetes/migrate-k8s.md
+++ b/website/docs/getting-started/setup/installation-guides/kubernetes/migrate-k8s.md
@@ -47,7 +47,7 @@ job.batch/imago-27473940   1/1           16s        12m
 
 Before you start the migration process, ensure that the below prerequisites are met.
 
-1. Install `kubectl` - `kubectl` is the command-line interface for Kubernetes. It allows you to run commands against Kubernetes clusters to manage applications and other resources. To install kubectl, follow the instructions for your platform from the official [Kubernetes documentation](https://kubernetes.io/vi/docs/tasks/tools/install-kubectl/).
+1. Install `kubectl` - `kubectl` is the command-line interface for Kubernetes. It allows you to run commands against Kubernetes clusters to manage applications and other resources. To install kubectl, follow the instructions for your platform from the official [Kubernetes documentation](https://kubernetes.io/docs/tasks/tools/#kubectl).
 2. Once `kubectl` is installed, configure it to connect to your cluster. Follow one of the available guides below for your platform:
      * Minikube: [Setup Kubectl](https://minikube.sigs.k8s.io/docs/handbook/kubectl/)
      * Google Cloud Kubernetes: [Configuring cluster access for kubectl](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl)


### PR DESCRIPTION
## Changes
- Change the link for `kubectl` install docs to point to the English version of the docs. Previously pointed to the Vietnamese docs.