### PR TITLE
fix: added production condition to segment script

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -21,7 +21,7 @@ const config = {
     locales: ['en'],
   },
   plugins: [
-    [
+    process.env.VERCEL_ENV === "production" && [
       '@twilio-labs/docusaurus-plugin-segment',
       {
         writeKey: 'tjqTIkJzeqSTB1SUookBTdWhZEoR031c',


### PR DESCRIPTION
Added a condition to the segment plugin to make sure the its only fired in the Vercel production environment.

Using the available system variable from Vercel - https://vercel.com/docs/concepts/projects/environment-variables/system-environment-variables

Addresses https://github.com/appsmithorg/appsmith-docs/issues/1187