### PR TITLE
fix: GAC and invite users

### DIFF
--- a/website/docs/advanced-concepts/granular-access-control/README.md
+++ b/website/docs/advanced-concepts/granular-access-control/README.md
@@ -2,7 +2,7 @@
 
 Granular Access Control (GAC) enables you to specify which users or groups have access to different system components and what actions they can perform within that access. In Appsmith, you can use roles to define access to different parts of your Appsmith instance, such as workspaces, apps, pages, and datasources, and then assign these roles to individual users or groups of users.
 :::info
-Granular Access Control (GAC) is available only in the [business edition](https://www.appsmith.com/pricing) for self-hosted instances.
+Granular Access Control (GAC) is available only in the [business edition](https://www.appsmith.com/pricing).
 :::
 
 Granular Access Control can be implemented in Appsmith using the following elements:

--- a/website/docs/advanced-concepts/granular-access-control/roles.md
+++ b/website/docs/advanced-concepts/granular-access-control/roles.md
@@ -1,11 +1,12 @@
 # Roles
 Roles in Appsmith are collections of permissions that enable users or groups to access certain operations on resources. Rather than giving individual permissions to users or groups, roles allow users to manage multiple permissions.
 
-## Default roles
+## Instance roles
 
-Appmith provides three [built-in](/advanced-concepts/invite-users#built-in-roles) roles for the application and workspace - **Administrator**, **Developer**, and **App Viewer**. Additonally, there are two instance-level roles - **Default Role for all Users** and **Instance Administrator**. 
+In addition to the [default](/advanced-concepts/invite-users#built-in-roles) roles for applications and workspace, Appmith provides two instance-level roles - **Default Role for all Users** and **Instance Administrator**.
 
-- **Default Role For All Users**: This role is responsible for setting the base level of access provided to all users within an instance. This role is editable, and Instance Administrators can customize it and assign default permissions to new users joining the instance. By adjusting the permissions in this role, they can ensure that new users have an appropriate level of access.
+- **Default Role For All Users**: This role applies to all users and can be used to assign a default set of permissions in an instance. It is editable and does not come with any predefined permissions, and Instance Administrators can customize it and assign default permissions to new users joining the instance. By adjusting the permissions in this role, they can ensure that new users have an appropriate level of access.
+
 - **Instance Administrator**: This role provides a user with permission to modify settings at the instance level from the Admin settings. This includes changing the general settings of the instance, such as authentication, email, custom branding, access to view audit logs and granular access control actions. It's important to note that this role has significant control over the instance, so it should only be assigned to trusted users who need these capabilities.
 
 ## Custom roles
@@ -17,8 +18,7 @@ With custom roles, you can provide fine-grained access control by configuring mu
   <figcaption align = "center"><i>Add a custom role</i></figcaption>
 </figure>
 
-
-To create or edit a role, you need to set up the permissions based on your requirements. The permissions are grouped into four categories, which helps users manage and access the necessary permissions easily. The four categories are:
+The permissions are grouped into four categories, which helps users manage and access the necessary permissions easily:
 
 - [Application Resources](#application-resources)
 - [Datasource and Queries](#datasource-and-queries)

--- a/website/docs/advanced-concepts/invite-users.md
+++ b/website/docs/advanced-concepts/invite-users.md
@@ -3,7 +3,7 @@
 
 Appsmith allows you to share your application with the end user or with a team member for collaboration. There are multiple ways to share your application in Appsmith. You can either share your workspace or share a specific application.
 
-## Built-in roles
+## Default roles
 
 In Appsmith, there are built-in roles that you can assign to a user for accessing the applications: 
 
@@ -42,12 +42,10 @@ The table below shows the permissions available for each role when you share a w
 |**Developer**      | Create applications, pages and queries inside the workspace|Edit any application, page and query inside the workspace|View any application, page and query inside the workspace |Delete any application, page and query inside the workspace|	-             |Invite other users to the workspace |	-             |
 |**App Viewer**     |	-             |-             |View any application, page & query inside the workspace.|-|           -     |Invite other users to the workspace only as **App Viewer** |	-|
 
-
-
 ## Share application
 
 :::info
-Sharing a specific application is only available in the [business edition](https://www.appsmith.com/pricing) for self-hosted instances.
+Sharing a specific application is only available in the [business edition](https://www.appsmith.com/pricing).
 :::
 
 If you want the user to just have access to a specific application in a workspace, follow the steps below:
@@ -61,7 +59,6 @@ If you want the user to just have access to a specific application in a workspac
   <figcaption align = "center"><i>Inviting a user to an application</i></figcaption>
 </figure>
 
-
 ### Default roles for application
 
 The table below shows the permissions available for each role when you share an application:
@@ -71,8 +68,7 @@ The table below shows the permissions available for each role when you share an 
 |**Developer**      | Create pages, datasources and queries inside the app|Edit pages, datasources and queries inside the app|View the app, its pages, datasources and queries. |Delete the app, its pages, datasources and queries|-|Invite other users with an equivalent or a lower role |	-       |
 |**App Viewer**     |	-              |     -          |View the app and execute actions (Cannot see queries,datasources)|-|           -     |Invite users only as **App Viewer** |	-|
 
-
-### Make application public
+## Make application public
 
 You can make your applications public and share them with users who are not part of your workspace. These external users do not need to log in to Appsmith to access the shared applications.
 
@@ -81,6 +77,10 @@ To make an application public, you can click on the **Share** button within the 
 :::info
 Only users with Administrator roles for a workspace can make applications public.
 :::
+
+## Further reading
+
+- [Granular Access Control](/advanced-concepts/granular-access-control)
 
 ## Further reading
 

--- a/website/docs/advanced-concepts/invite-users.md
+++ b/website/docs/advanced-concepts/invite-users.md
@@ -81,7 +81,3 @@ Only users with Administrator roles for a workspace can make applications public
 ## Further reading
 
 - [Granular Access Control](/advanced-concepts/granular-access-control)
-
-## Further reading
-
-- [Granular Access Control](/advanced-concepts/granular-access-control)


### PR DESCRIPTION
**Invite Users**

- Changed built-in roles to default roles
- Make applications public is now H2
- updated business edition callout

**GAC** 

- updated business edition callout

**Roles**

- Changed the heading from default roles to instance roles
- Updated information for Default roles for all users
- Made the permission categories explanation simpler
