### PR TITLE
fix: Elasticsearch rehaul review

### DIFF
--- a/website/docs/reference/datasources/querying-elasticsearch.md
+++ b/website/docs/reference/datasources/querying-elasticsearch.md
@@ -67,13 +67,13 @@ For details on building more complex queries, see the [Elasticsearch Document AP
 
 Queries run on top of indexed documents can be configured using the `GET` method. 
 
+**Path:**
 ```json
-// Path
 /users/_search
 ```
 
+**Body:**
 ```javascript
-// Body
 {
   "query": {
     "match": {
@@ -89,13 +89,13 @@ The example above searches the `users` index for a `name` matching your user inp
 
 You can create a single new document using the `POST` method, with a JSON body that represents the document values; an `id` is automatically generated.
 
+**Path:**
 ```json
-// Path
 /users/_doc/
 ```
 
+**Body:**
 ```javascript
-//Body
 {
     "name": {{ NewUserForm.data.Name }},
     "email": {{ NewUserForm.data.Email }},
@@ -103,48 +103,26 @@ You can create a single new document using the `POST` method, with a JSON body t
 }
 ```
 
-Above, user input is collected with a Form widget called `NewUserForm`.
-
-#### Create multiple documents
-
-To create a batch of documents at once, use the `POST` method with the `/_bulk` endpoint:
-
-```json
-// Path
-/_bulk/
-```
-
-In the body, add a line of metadata followed by a line of record data:
-
-```javascript
-//Body
-{"index": {"_index": "users"}}
-{"name":"Reyna", "email":"sunil@example.com", "gender":"female"}
-{"index": {"_index": "users"}}
-{"name":"Aly", "email":"aly@example.com", "gender":"female"}
-{"index": {"_index": "users"}}
-{"name":"Sunil", "email":"sunil@example.com", "gender":"male"}
-```
+Above, user input is collected with a [Form widget](/reference/widgets/form) called `NewUserForm`.
 
 ### Update a document
 
 A single document can be updated using its `id` within an index using a `POST` request. 
 
+**Path:**
 ```javascript
-// Path
 /users/_update/{{ UsersTable.selectedRow.id }}
 ```
 
+**Body:**
 ```javascript
-// Body
+// using a JSON Form widget to collect input
 {
-  "doc": {
-    "name": {{ UpdateUserForm.data.Name }}
-  }
+  "doc": UpdateUserForm.formData
 }
 ```
 
-Above, the record with its `id` is selected from a Table widget called `UsersTable` and updated with input from a Form widget.
+Above, the record with its `id` is selected from a Table widget called `UsersTable` and updated with input from a [JSON Form](/reference/widgets/json-form) widget.
 
 This performs a partial update, where the properties you supply are added to the document; you don't need to add ones that have not changed.
 
@@ -152,8 +130,8 @@ This performs a partial update, where the properties you supply are added to the
 
 A single document can be deleted using its `id` within an index using the `DELETE` method.
 
+**Path:**
 ```javascript
-// Path
 /users/_doc/{{ UsersTable.selectedRow.id }}
 ```
 


### PR DESCRIPTION
Incorporates review feedback:
* Added labels for **Path** and **Body** fields for clarity
* Removed "Create Multiple" subheading
* Updated "Update" heading snippet to be more flexible

## Checklist
I have:
- [x] run the content through Grammarly
- [x] linked to sample apps when relevant
- [x] added the meta description for each page in the PR
- [x] minimized the callouts and added only when necessary
- [x] added the `queryString` parameter to the Tabs (if used)
- [x] masked PII in images. For example, login credentials, account details, and more
- [x] added images only when necessary
- [x] deleted the images that are no longer used for the updated pages in the PR
- [x] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [x] used the `<figure/>` tag instead of a markdown representation for images
- [x] added the `<figcaption/>` tag to add a caption to the image
- [x] added the `alt` attribute in the `<img/>` tag
- [x] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [x] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.