### PR TITLE
fix: Update Oracle docs snippets

### DIFF
--- a/website/docs/reference/datasources/querying-oracle.md
+++ b/website/docs/reference/datasources/querying-oracle.md
@@ -58,7 +58,7 @@ For Oracle SQL syntax, see the official documentation [**Oracle SQL Language Ref
 ### Fetch data
 
 ```sql
-SELECT * FROM users OFFSET {{ UsersTable.pageOffset }} ROWS FETCH NEXT {{ UsersTable.pageSize }} ROWS ONLY ;
+SELECT * FROM users OFFSET {{ UsersTable.pageOffset }} ROWS FETCH NEXT {{ UsersTable.pageSize }} ROWS ONLY;
 ```
 
 In the above example, `UsersTable` is the name of the Table widget used to display the data using [**server-side pagination**](/reference/widgets/table#server-side-pagination) to control how much data is queried at once.
@@ -82,8 +82,8 @@ In the above example,  `NameInput`,  `GenderDropdown`,  and `EmailInput` are t
 
 ```sql
 UPDATE users
-  SET email = '{{EmailInput.text}}'
-  WHERE id = {{ UserTable.selectedRow.id}};
+  SET email = {{ EmailInput.text }}
+  WHERE id = {{ UsersTable.selectedRow.id }};
 ```
 
 In the above example, `EmailInput` is the name of the Input widget used to capture the email entered by the user. `UsersTable` is the Table widget where the user selects the row to update the user's email.
@@ -91,7 +91,7 @@ In the above example, `EmailInput` is the name of the Input widget used to captu
 ### Delete data
 
 ```sql
-DELETE FROM users WHERE id = {{tableUsers.selectedRow.id}};
+DELETE FROM users WHERE id = {{ UsersTable.selectedRow.id }};
 ```
 
 In the above example, `UsersTable` is the name of the Table widget where the user selects the row for deletion.


### PR DESCRIPTION
Review feedback:
* Removes quotations from snippets in Oracle docs

## Checklist
I have:
- [x] run the content through Grammarly
- [x] linked to sample apps when relevant
- [x] added the meta description for each page in the PR
- [x] minimized the callouts and added only when necessary
- [x] added the `queryString` parameter to the Tabs (if used)
- [x] masked PII in images. For example, login credentials, account details, and more
- [x] added images only when necessary
- [x] deleted the images that are no longer used for the updated pages in the PR
- [x] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [x] used the `<figure/>` tag instead of a markdown representation for images
- [x] added the `<figcaption/>` tag to add a caption to the image
- [x] added the `alt` attribute in the `<img/>` tag
- [x] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [x] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.