### PR TITLE
fix: custom chart

### DIFF
--- a/website/docs/reference/widgets/chart.mdx
+++ b/website/docs/reference/widgets/chart.mdx
@@ -170,51 +170,11 @@ In the **Custom Fusion Chart** property, you need to specify "type" for chart ty
 }
 ```
 
-#### Type
+* **Type :** The type is used to define the chart type recognized by the FusionCharts. FusionCharts provides an extensive range of chart variants, with almost 100+ options to choose from. 
 
-The type is used to define the chart type recognized by the FusionCharts. FusionCharts provides an extensive range of chart variants, with almost 100+ options to choose from. You can refer to the official [FusionCharts documentation](https://www.fusioncharts.com/dev/chart-guide/list-of-charts/) documentation to learn more about these charts.
+* **Datasource :** The datasource defines the customization options and data points necessary for creating a chart. It consists of attributes such as chart and data, which may vary depending on the chart type.
 
-```json
-//example
-"type": "column2d"
-```
-This creates a 2D column chart. The value of the `type` property is case-sensitive.
-
-#### Datasource
-
-The datasource defines the customization options and the data points to create a chart. It includes two attributes: **chart** and **data**.
-
-* **Chart**:
-
-The `chart` attribute is an object that can be used to customize the overall appearance of the chart. It includes options such as the chart `title`, `x-axis` and `y-axis labels`, chart `width` and `height`, and more. Here are some most commonly used properties of the `chart` object:
-
-```json
-//example
- "chart": {
-      "caption": "Monthly Revenue for the year 2021",  //Sets the main title of the chart.
-      "xAxisName": "Month",  // Sets the label for the x-axis.
-      "yAxisName": "Revenue",  // Sets the label for the y-axis.
-      "theme": "fusion"  //Sets the color scheme for the chart.
-    },..
-```
-* **Data**: 
-
-The "data" attribute represents the data in an array format with key-value pairs like `[{“label”: “string value”, “value”: “string value”}]`. It's where you specify the actual data that you want to display in the chart.
-
-Here is an example of how to set the "data" array in the "dataSource" property:
-
-```json
- "data": [
-      {
-        "label": "Jan",
-        "value": 42000
-      },
-      {
-        "label": "Feb",
-        "value": 810000
-      },..
-```
-
+Each chart type has different configurations and options. To learn more about these charts and their specific configurations, you can refer to the official [FusionCharts documentation](https://www.fusioncharts.com/dev/chart-guide/list-of-charts/). 
 
 #### Examples
 Here are some examples of custom charts that you can use as a reference to create your own customized charts.

--- a/website/docs/reference/widgets/chart.mdx
+++ b/website/docs/reference/widgets/chart.mdx
@@ -174,7 +174,7 @@ In the **Custom Fusion Chart** property, you need to specify "type" for chart ty
 
 * **Datasource :** The datasource defines the customization options and data points necessary for creating a chart. It consists of attributes such as chart and data, which may vary depending on the chart type.
 
-Each chart type has different configurations and options. To learn more about these charts and their specific configurations, you can refer to the official [FusionCharts documentation](https://www.fusioncharts.com/dev/chart-guide/list-of-charts/). 
+Each chart type has different configurations and options. To learn more about these charts and their specific configurations, you can refer to the official [FusionCharts documentation](https://www.fusioncharts.com/dev/chart-guide/list-of-charts/). Copy the relevant code examples provided in the documentation and paste them into your project for easy implementation.
 
 #### Examples
 Here are some examples of custom charts that you can use as a reference to create your own customized charts.


### PR DESCRIPTION
Review comments:
"The type, datasource, and chart attribute bit are confusing. Keep it simple
The custom chart needs 2 properties
Type
Datasource
2. Go to the [fusion chart docs](https://www.fusioncharts.com/dev/chart-attributes/area2d) and copy the type from the javascript alias on top and the datasource from the code at the bottom (use an image to highlight these 2 on the page) and paste it in the custom chart field.
3. Each type has a different configuration for chart and data. You can refer the fusion chart docs for the configuration options"

## Checklist
I have:
- [x] run the content through Grammarly
- [x] linked to sample apps when relevant
- [x] added the meta description for each page in the PR
- [x] minimized the callouts and added only when necessary
- [x] added the `queryString` parameter to the Tabs (if used)
- [x] masked PII in images. For example, login credentials, account details, and more
- [x] added images only when necessary
- [x] deleted the images that are no longer used for the updated pages in the PR
- [x] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [x] used the `<figure/>` tag instead of a markdown representation for images
- [x] added the `<figcaption/>` tag to add a caption to the image
- [x] added the `alt` attribute in the `<img/>` tag
- [x] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [x] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.