### PR TITLE
fix: added redirect rule for Connect to Local Datasource

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -327,6 +327,10 @@
       "destination": "/learning-and-resources/how-to-guides/how-to-use-prepared-statements"
     },
     {
+      "source": "/advanced-concepts/more/how-to-work-with-local-apis-on-appsmith",
+      "destination": "/learning-and-resources/how-to-guides/how-to-work-with-local-apis-on-appsmith"
+    },
+    {
       "source": "/sample-apps",
       "destination": "/learning-and-resources/sample-apps"
     },


### PR DESCRIPTION
The old location of the "Connect to Local Datasource" how-to guide results in a 404. PR adds a redirect rule to its proper location.

## Checklist
I have:
- [x] run the content through Grammarly
- [x] linked to sample apps when relevant
- [x] added the meta description for each page in the PR
- [x] minimized the callouts and added only when necessary
- [x] added the `queryString` parameter to the Tabs (if used)
- [x] masked PII in images. For example, login credentials, account details, and more
- [x] added images only when necessary
- [x] deleted the images that are no longer used for the updated pages in the PR
- [x] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [x] used the `<figure/>` tag instead of a markdown representation for images
- [x] added the `<figcaption/>` tag to add a caption to the image
- [x] added the `alt` attribute in the `<img/>` tag
- [x] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [x] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.