### PR TITLE
fix: removing old widget videos

### DIFF
--- a/website/docs/reference/widgets/audio-recorder.md
+++ b/website/docs/reference/widgets/audio-recorder.md
@@ -2,8 +2,6 @@
 
 This page provides information on how to use the Audio Recorder widget to record audio using your microphone. The recorded audio is saved in WAV format.
 
-<VideoEmbed host="youtube" videoId="fMovD6hfHQU" title="Using the Audio Recorder widget" caption="Using the Audio Recorder widget"/>
-
 
 ## Upload audio to S3
 

--- a/website/docs/reference/widgets/checkbox-group.md
+++ b/website/docs/reference/widgets/checkbox-group.md
@@ -5,8 +5,6 @@ description: Learn how to use the Checkbox Group widget for selecting multiple i
 
 This page provides instructions on using the Checkbox Group widget to allow users to select multiple items from a predefined set of choices. 
 
-<VideoEmbed host="youtube" videoId="-7cvZ2yCgtE" title="Using the Checkbox Group Widget" caption="Using the Checkbox Group Widget"/>
-
 
 
 

--- a/website/docs/reference/widgets/datepicker.md
+++ b/website/docs/reference/widgets/datepicker.md
@@ -2,9 +2,6 @@
 
 This page explains how to use the Datepicker widget to display or capture date/time information. It enables to filter the data based on a date range, format dates and performs date validations. 
 
-<VideoEmbed host="youtube" videoId="MFflGf3K324" title="Using the Datepicker widget" caption="Using the Datepicker widget"/>
-
-
 
 ## Update date
 

--- a/website/docs/reference/widgets/divider.md
+++ b/website/docs/reference/widgets/divider.md
@@ -2,7 +2,6 @@
 
 The Divider widget is used to visually separate or compartmentalise different parts of your application.
 
-<VideoEmbed host="youtube" videoId="rTJtDOusWmM" title="How to use Divider Widget" caption="How to use Divider Widget"/>
 
 ## Properties
 

--- a/website/docs/reference/widgets/filepicker.md
+++ b/website/docs/reference/widgets/filepicker.md
@@ -2,8 +2,6 @@
 
 This document explains how to use a datapicker widget to capture date and time input from users.
 
-<VideoEmbed host="youtube" videoId="Sl0zN2CSJaY" title="Filepicker widget and its properties" caption="Filepicker widget and its properties"/>
-
 
 ##  Upload files
 

--- a/website/docs/reference/widgets/icon-button.md
+++ b/website/docs/reference/widgets/icon-button.md
@@ -2,7 +2,6 @@
 
 Icon button widget is just an icon, along with all other button properties.
 
-![](/img/icon-button.gif)
 
 ## Properties
 

--- a/website/docs/reference/widgets/iframe.md
+++ b/website/docs/reference/widgets/iframe.md
@@ -3,8 +3,6 @@
 
 This page explains how to use the Iframe widget to embed third-party applications and websites into your Appsmith application.
 
-<VideoEmbed host="youtube" videoId="4jXTyxUhnP0" title="Using the Iframe widget" caption="Using the Iframe widget"/>
-
 :::info
 The Iframe widget is safe from XSS attacks from v1.8.6 onwards. If you have a self-hosted Appsmith and are on an older version, see [Sandboxing Iframe widgets](/product/security#sandboxing-iframe-widgets) to enable this.
 :::

--- a/website/docs/reference/widgets/image.md
+++ b/website/docs/reference/widgets/image.md
@@ -2,9 +2,6 @@
 
 You can add images in the form of URLs or base64 strings. The Image widget supports popular formats such as JPG, PNG, SVG, WebP and GIF.
 
-
-<VideoEmbed host="youtube" videoId="jdDcydQ8Ho0" title="How to use the Image Widget" caption="How to use the Image Widget"/>
-
 ## Display static images 
 
 You can specify the image source using the **Image property** to display an image. The Image property can accept a **URL**, a **data URI**, or a **base64** encoded image data as its input. For example, you can add this URL in the image property:

--- a/website/docs/reference/widgets/list.md
+++ b/website/docs/reference/widgets/list.md
@@ -2,7 +2,6 @@
 
 The List widget provides a way to iterate over a structured dataset (array of objects) and display the data in sections that repeat vertically without writing any code. Each list item can contain other widgets to display data or capture user input.
 
-<VideoEmbed host="youtube" videoId="0ePiZlWmp7Q" title="How to use List Widget" caption="How to use List Widget"/>
 
 ##  List components
 

--- a/website/docs/reference/widgets/maps.md
+++ b/website/docs/reference/widgets/maps.md
@@ -6,8 +6,6 @@ This page explains how to use the Map widget(powered by Google Maps API) to disp
 If you want to use the Map widget on your self-hosted instance, it's essential to have Google Maps configured on your instance. For more information, see [Configuring Google Maps](/getting-started/setup/instance-configuration/google-maps).
 :::
 
-<VideoEmbed host="youtube" videoId="xCTiPNlBKLU" title="Using the Map Widget" caption="Using the Map Widget"/>
-
 
 ## Display location
 

--- a/website/docs/reference/widgets/menu-button.md
+++ b/website/docs/reference/widgets/menu-button.md
@@ -2,7 +2,6 @@
 
 The Menu Button widget is a customizable dropdown menu that allows you to add a list of options for users to select from. It's a powerful tool for creating navigation menus, dropdown lists, and options for users to choose from.
 
-<VideoEmbed host="youtube" videoId="tDMAOxZTmxY" title="How to use Menu Button Widget" caption="How to use Menu Button Widget"/>
 
 ## Usage
 

--- a/website/docs/reference/widgets/modal.md
+++ b/website/docs/reference/widgets/modal.md
@@ -3,9 +3,6 @@
 
 This page explains how to use the Modal widget to create a dialog in your app for displaying various types of content, such as alerts, confirmation pop-ups, forms, and more. It acts as a container used to group and handle related user inputs , and can be opened using actions such as setting a Button widget's onClick event. 
 
-<VideoEmbed host="youtube" videoId="s8cHVkhj3ec" title="Using the Modal widget" caption="Using the Modal widget"/>
-
-
 
 
 ## Update data with Modal

--- a/website/docs/reference/widgets/multi-tree-select.md
+++ b/website/docs/reference/widgets/multi-tree-select.md
@@ -2,7 +2,6 @@
 
 The multi-tree-select widget captures the user input from a specified list of permitted options, and these options can have child options within them. It captures multiple choices.
 
-<VideoEmbed host="youtube" videoId="XaaFY0grXjE" title="How to use Multi-tree-select Widget" caption="How to use Multi-tree-select Widget"/>
 
 ### Displaying Data
 

--- a/website/docs/reference/widgets/multiselect.md
+++ b/website/docs/reference/widgets/multiselect.md
@@ -4,8 +4,6 @@ This page explains how to use a Multiselect widget to allow users to select mult
 
 
 
-<VideoEmbed host="youtube" videoId="oH7Y-vSMIgM" title="Using Multiselect" caption="Using Multiselect"/>
-
 ## Display static options 
 
 To display static options in a Multiselect widget, you can use the **Options** property.

--- a/website/docs/reference/widgets/rating.md
+++ b/website/docs/reference/widgets/rating.md
@@ -1,10 +1,6 @@
 # Rating
 
-The Rating widget is used to perform a quick rating operation on something.
-
-<VideoEmbed host="youtube" videoId="ssm7TYCQtfo" title="How to use Rating Widget" caption="How to use Rating Widget"/>
-
-Use the Rate component to rate any sort of information from the connected data source. It's customizable and features rich.
+The Rating widget is used to perform a quick rating operation on something. Use the Rate component to rate any sort of information from the connected data source. It's customizable and features rich.
 
 ## Properties
 

--- a/website/docs/reference/widgets/rich-text-editor.md
+++ b/website/docs/reference/widgets/rich-text-editor.md
@@ -5,7 +5,6 @@ description: Learn how to use the Rich Text Editor widget for capturing and form
 
 This page provides information on using the Rich Text Editor, which allows you to capture rich text input from users. 
 
-<VideoEmbed host="youtube" videoId="_KrxFScQJys" title="Using Rich Text Editor Widget" caption="Using Rich Text Editor Widget"/>
 
 ## Content properties
 

--- a/website/docs/reference/widgets/stat-box.md
+++ b/website/docs/reference/widgets/stat-box.md
@@ -2,7 +2,6 @@
 
 A Stat Box widget shows and highlights essential statistics related to the application. The widget comes pre-built with a default layout which can change as per application requirements
 
-<VideoEmbed host="youtube" videoId="fcWH9Qpa-DQ" title="How to use Stat Box Widget" caption="How to use Stat Box Widget"/>
 
 ### Stats Box widget
 

--- a/website/docs/reference/widgets/switch.md
+++ b/website/docs/reference/widgets/switch.md
@@ -2,7 +2,6 @@
 
 The Switch is a simple UI widget you can use when you want users to make a binary choice.
 
-<VideoEmbed host="youtube" videoId="5kNWJ9mtlOw" title="How to use Switch Widget" caption="How to use Switch Widget"/>
 
 ## Properties
 

--- a/website/docs/reference/widgets/tabs.md
+++ b/website/docs/reference/widgets/tabs.md
@@ -3,8 +3,6 @@
 This page explains how the Tabs widget can be used to group related content and enable users to switch between different sets of information within a single container.
 
 
-<VideoEmbed host="youtube" videoId="NLe0To_fB7E" title="Using the Tabs Widget" caption="Using the Tabs Widget"/>
-
 
 ## Create multi-step form
 

--- a/website/docs/reference/widgets/tree-select.md
+++ b/website/docs/reference/widgets/tree-select.md
@@ -3,9 +3,6 @@
 This page explains how to use the Treeselect widget to allow users to select a single option from a hierarchical list.
 
 
-<VideoEmbed host="youtube" videoId="vSqpSssJdws" title="Using Treeselect Widget" caption="Using Treeselect Widget"/>
-
-
 
 ## Display static options
 

--- a/website/docs/reference/widgets/video.md
+++ b/website/docs/reference/widgets/video.md
@@ -2,7 +2,6 @@
 
 A widget for playing a variety of URLs, including file paths, YouTube, Facebook, Twitch, SoundCloud, Streamable, Vimeo, Wistia, Mixcloud, and DailyMotion.
 
-<VideoEmbed host="youtube" videoId="KvIWaTOmZPo" title="How to use Video Widget" caption="How to use Video Widget"/>
 
 ## Properties
 


### PR DESCRIPTION
## Checklist
I have:
- [ ] run the content through Grammarly
- [ ] linked to sample apps when relevant
- [ ] added the meta description for each page in the PR
- [ ] minimized the callouts and added only when necessary
- [ ] added the `queryString` parameter to the Tabs (if used)
- [ ] masked PII in images. For example, login credentials, account details, and more
- [ ] added images only when necessary
- [ ] deleted the images that are no longer used for the updated pages in the PR
- [ ] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [ ] used the `<figure/>` tag instead of a markdown representation for images
- [ ] added the `<figcaption/>` tag to add a caption to the image
- [ ] added the `alt` attribute in the `<img/>` tag
- [ ] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [ ] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.