### PR TITLE
fix: add callout to mention env variable takes precedence over Admin settings

### DIFF
--- a/website/docs/getting-started/setup/instance-configuration/README.mdx
+++ b/website/docs/getting-started/setup/instance-configuration/README.mdx
@@ -26,6 +26,9 @@ If you don’t see the “Admin Settings” option on the left sidebar, you’re
   <figcaption align = "center"><i>Access admin settings on the left panel under workspaces</i></figcaption>
 </figure>
 
+:::info
+When configuring an Appsmith instance, it's important to note that if you choose to set configurations using [environment variables](#environment-variables), those values take precedence over any values set in the Admin Settings.
+:::
 
 ### Add super admins
 Users who are granted super admin privileges are authorized to access and make changes to instance & platform settings. If you are a super admin and want to grant super admin privileges to other users, add their email addresses in the **Admin Email** field on the **General** settings page so they can access and modify instance settings as shown below:

--- a/website/docs/getting-started/setup/instance-configuration/README.mdx
+++ b/website/docs/getting-started/setup/instance-configuration/README.mdx
@@ -27,7 +27,7 @@ If you don’t see the “Admin Settings” option on the left sidebar, you’re
 </figure>
 
 :::info
-When configuring an Appsmith instance, it's important to note that if you choose to set configurations using [environment variables](#environment-variables), those values take precedence over any values set in the Admin Settings.
+If you have set values using [environment variables](#environment-variables) for your instance, those values take precedence over values specified in the Admin Settings UI.
 :::
 
 ### Add super admins

--- a/website/docs/getting-started/setup/instance-configuration/authentication/github-login.md
+++ b/website/docs/getting-started/setup/instance-configuration/authentication/github-login.md
@@ -41,6 +41,10 @@ Click **Admin Settings > Authentication > Enable**(GitHub). Add the `Client ID` 
 
 ![](/img/as_github_auth_config.png)
 
+:::info
+If you have set values using [environment variables](#environment-variables) for your instance, those values take precedence over values specified in the Admin Settings UI.
+:::
+
 ### Environment variables
 
 Update the values for the following keys in the instance configuration file, for example, in the `docker.env` file for Docker installation (`<PROJECT_ROOT>/stacks/configuration/`) and in the `values.yaml` file for Kubernetes:

--- a/website/docs/getting-started/setup/instance-configuration/authentication/google-login.md
+++ b/website/docs/getting-started/setup/instance-configuration/authentication/google-login.md
@@ -50,6 +50,10 @@ You can add the Client ID, Client Secret and allowed domains from [Admin Setting
 
 ![](/img/as_google_auth_config.png)
 
+:::info
+If you have set values using [environment variables](#environment-variables) for your instance, those values take precedence over values specified in the Admin Settings UI.
+:::
+
 ### Environment variables
 
 Update the values for the following keys in the instance configuration file, for example, in the `docker.env` file for Docker installation (`<PROJECT_ROOT>/stacks/configuration/`) and in the `values.yaml` file for Kubernetes:

--- a/website/docs/getting-started/setup/instance-configuration/custom-domain/README.md
+++ b/website/docs/getting-started/setup/instance-configuration/custom-domain/README.md
@@ -41,6 +41,10 @@ You can use [Admin Settings](/getting-started/setup/instance-configuration#admin
 
 When you restart Appsmith, it generates an SSL certificate for your custom domain. You can now use your custom domain mapped to port 443 via HTTPS to access Appsmith in your browser.
 
+:::info
+If you have set values using [environment variables](#environment-variables) for your instance, those values take precedence over values specified in the Admin Settings UI.
+:::
+
 ### Environment variables
 Appsmith is deployed on a Docker container. To generate an SSL certificate, add the custom domain to the environment variable `APPSMITH_CUSTOM_DOMAIN` in a `docker.env` file. Follow the steps below:
 

--- a/website/docs/getting-started/setup/instance-configuration/custom-mongodb-redis.md
+++ b/website/docs/getting-started/setup/instance-configuration/custom-mongodb-redis.md
@@ -31,6 +31,10 @@ You can use [Admin Settings](/getting-started/setup/instance-configuration#admin
   <figcaption align = "center"><i>Setup an external MongoDB using Admin settings</i></figcaption>
 </figure>
 
+:::info
+If you have set values using [environment variables](#environment-variables) for your instance, those values take precedence over values specified in the Admin Settings UI.
+:::
+
 #### Environment variable
 To connect to an external MongoDB server, update the environment variable `APPSMITH_MONGODB_URI`. For example, if you want to connect to [MongoDB Cloud](https://www.mongodb.com/cloud), set the value as shown below:
 

--- a/website/docs/getting-started/setup/instance-configuration/email/README.md
+++ b/website/docs/getting-started/setup/instance-configuration/email/README.md
@@ -45,6 +45,10 @@ Be sure to double-check your configuration if you find that you're able to send 
 
 ## Configure using admin settings
 
+:::info
+If you have set values using [environment variables](#environment-variables) for your instance, those values take precedence over values specified in the Admin Settings UI.
+:::
+
 You can configure the email for your self-hosted instance using the [Admin Settings](/getting-started/setup/instance-configuration) page. Follow the below steps:
 
 * Navigate to **profile** >> **Admin Settings** >> Select **Email.**

--- a/website/docs/getting-started/setup/instance-configuration/email/README.md
+++ b/website/docs/getting-started/setup/instance-configuration/email/README.md
@@ -21,7 +21,7 @@ Appsmith allows you to configure email using environment variables or the [admin
 
 <VideoEmbed host="youtube" videoId="NOAofPbmJWw" title="" caption="" /> 
 
-## Configure using environment variables
+## Environment variables
 
 Appsmith requires the following environment variables to be configured:
 
@@ -43,7 +43,7 @@ Be sure to double-check your configuration if you find that you're able to send 
 
 [Restart the Appsmith instance](../) once the environment variables are configured.
 
-## Configure using admin settings
+## Admin settings
 
 :::info
 If you have set values using [environment variables](#environment-variables) for your instance, those values take precedence over values specified in the Admin Settings UI.


### PR DESCRIPTION
## Checklist
I have:
- [ ] run the content through Grammarly
- [ ] linked to sample apps when relevant
- [ ] added the meta description for each page in the PR
- [ ] minimized the callouts and added only when necessary
- [ ] added the `queryString` parameter to the Tabs (if used)
- [ ] masked PII in images. For example, login credentials, account details, and more
- [ ] added images only when necessary
- [ ] deleted the images that are no longer used for the updated pages in the PR
- [ ] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [ ] used the `<figure/>` tag instead of a markdown representation for images
- [ ] added the `<figcaption/>` tag to add a caption to the image
- [ ] added the `alt` attribute in the `<img/>` tag
- [ ] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [ ] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.