### PR TITLE
Fix: old tutorial redirects

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -2959,6 +2959,10 @@
     {
       "source": "/getting-started/start-building",
       "destination": "/getting-started/tutorials/start-building"
+    },
+    {
+      "source": "/learning-and-resources/tutorials",
+      "destination": "/getting-started/tutorials"
     }
   ]
 }

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -2955,6 +2955,10 @@
     {
       "source": "/core-concepts/data-access-and-binding/querying-a-database/query-settings",
       "destination": "/connect-data/reference/query-settings"
+    },
+    {
+      "source": "/getting-started/start-building",
+      "destination": "/getting-started/tutorials/start-building"
     }
   ]
 }


### PR DESCRIPTION
## Checklist
I have:
- [ ] run the content through Grammarly
- [ ] linked to sample apps when relevant
- [ ] added the meta description for each page in the PR
- [ ] minimized the callouts and added only when necessary
- [ ] added the `queryString` parameter to the Tabs (if used)
- [ ] masked PII in images. For example, login credentials, account details, and more
- [ ] added images only when necessary
- [ ] deleted the images that are no longer used for the updated pages in the PR
- [ ] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [ ] used the `<figure/>` tag instead of a markdown representation for images
- [ ] added the `<figcaption/>` tag to add a caption to the image
- [ ] added the `alt` attribute in the `<img/>` tag
- [ ] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [ ] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.