### PR TITLE
fix: Added mention of Debug mode

### DIFF
--- a/website/docs/core-concepts/data-access-and-binding/querying-a-database.md
+++ b/website/docs/core-concepts/data-access-and-binding/querying-a-database.md
@@ -55,9 +55,13 @@ Queries fetch data in an array of objects where each object is a row, and each k
 
 When a query fails, Appsmith commonly shows a notification stating: `<query_name> action returned an error response `.
 
-
 To see the error message returned by the datasource in response to your query, look for the failed query in the [debugger](/help-and-support/troubleshooting-guide/#using-the-linter-and-debugger), or access it in code with `<query_name>.data`.
 
+### Debug mode
+
+By default in view mode, you can't see any error messages raised by Appsmith. This is to ensure that your app viewers don’t get to see ugly errors that they would otherwise have little context about. 
+
+If you want to see errors in the view mode as well as in edit mode, you can append `?debug=true` to your app's URL and reload the page. You can also always see the errors logged in the browser console.
 
 ## Use queries in applications
 

--- a/website/docs/core-concepts/data-access-and-binding/querying-a-database.md
+++ b/website/docs/core-concepts/data-access-and-binding/querying-a-database.md
@@ -59,9 +59,9 @@ To see the error message returned by the datasource in response to your query, l
 
 ### Debug mode
 
-By default in view mode, you can't see any error messages raised by Appsmith. This is to ensure that your app viewers don’t get to see ugly errors that they would otherwise have little context about. 
+By default, in the *View* Mode, you can't see any error messages raised by Appsmith. This ensures your app viewers don’t see error messages they would have minimal context about. 
 
-If you want to see errors in the view mode as well as in edit mode, you can append `?debug=true` to your app's URL and reload the page. You can also always see the errors logged in the browser console.
+If you want to see errors in the *View* and in the *Edit* mode, you can append `?debug=true` to your app's URL and reload the page. You can also always see the errors logged in the browser console.
 
 ## Use queries in applications
 


### PR DESCRIPTION
Adds a little subheading that describes how to continue seeing App errors while in view mode.

## Checklist
I have:
- [x] run the content through Grammarly
- [x] linked to sample apps when relevant
- [x] added the meta description for each page in the PR
- [x] minimized the callouts and added only when necessary
- [x] added the `queryString` parameter to the Tabs (if used)
- [x] masked PII in images. For example, login credentials, account details, and more
- [x] added images only when necessary
- [x] deleted the images that are no longer used for the updated pages in the PR
- [x] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [x] used the `<figure/>` tag instead of a markdown representation for images
- [x] added the `<figcaption/>` tag to add a caption to the image
- [x] added the `alt` attribute in the `<img/>` tag
- [x] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [x] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.