### PR TITLE
fix: change group names

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -535,7 +535,7 @@ const sidebars = {
       //Advanced Concepts Start
       type: 'category',
       collapsed: false,
-      label: 'App and User Management',
+      label: 'Manage Apps and Users',
       items: [
         'advanced-concepts/embed-appsmith-into-existing-application',
         'advanced-concepts/custom-authentication',

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -535,13 +535,19 @@ const sidebars = {
       //Advanced Concepts Start
       type: 'category',
       collapsed: false,
-      label: 'Advanced Concepts',
+      label: 'App and User Management',
       items: [
-        'advanced-concepts/custom-authentication',
-        'advanced-concepts/sharing-data-across-pages',
         'advanced-concepts/embed-appsmith-into-existing-application',
-        'advanced-concepts/audit-logs',
-        'advanced-concepts/branding',
+        'advanced-concepts/custom-authentication',
+        'advanced-concepts/invite-users',
+        {
+          type: 'category',
+          label: 'Granular Access Control',
+          link: {type: 'doc', id:  'advanced-concepts/granular-access-control/README',},
+          items: [
+              'advanced-concepts/granular-access-control/roles', 
+          ]
+        },
         {
           type: 'category',
           label: 'Version Control with Git',
@@ -567,31 +573,17 @@ const sidebars = {
             'advanced-concepts/version-control-with-git/environments-with-git',            
           ],
         },
-        'advanced-concepts/invite-users',
-        {
-          type: 'category',
-          label: 'Granular Access Control',
-          link: {type: 'doc', id:  'advanced-concepts/granular-access-control/README',},
-          items: [
-              'advanced-concepts/granular-access-control/roles', 
-          ]
-        },
-        {
-          type: 'category',
-          label: 'More',
-          link: { type: 'doc', id: 'advanced-concepts/more/README' },
-          items: [
-            'advanced-concepts/more/backup-restore',
-            'advanced-concepts/more/keyboard-shortcuts',
-          ],
-        },
+        'advanced-concepts/sharing-data-across-pages',
+        'advanced-concepts/more/backup-restore',
+        'advanced-concepts/audit-logs',
+        'advanced-concepts/branding',
       ],
     }, //Advanced Concepts end
     {
       //Learning and Resources start
       type: 'category',
       collapsed: false,
-      label: 'Learning & Resources',
+      label: 'Resources',
       items: [
         'learning-and-resources/sample-apps',
         {

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -2963,6 +2963,10 @@
     {
       "source": "/learning-and-resources/tutorials",
       "destination": "/getting-started/tutorials"
+    },
+    {
+      "source": "/advanced-concepts/more",
+      "destination": "/advanced-concepts/more/backup-restore"
     }
   ]
 }


### PR DESCRIPTION
- Updated the name of the **Advanced Concepts** and **Learning and Resources** section (Have not changed slugs)
- Removed the **More** category
- Rearranged the order of pages in Advanced Concepts
- Temporarily hiding the Keyboard shortcuts page (will be added in another section where we have content for UI)



## Checklist
I have:
- [ ] run the content through Grammarly
- [ ] linked to sample apps when relevant
- [ ] added the meta description for each page in the PR
- [ ] minimized the callouts and added only when necessary
- [ ] added the `queryString` parameter to the Tabs (if used)
- [ ] masked PII in images. For example, login credentials, account details, and more
- [ ] added images only when necessary
- [ ] deleted the images that are no longer used for the updated pages in the PR
- [ ] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [ ] used the `<figure/>` tag instead of a markdown representation for images
- [ ] added the `<figcaption/>` tag to add a caption to the image
- [ ] added the `alt` attribute in the `<img/>` tag
- [x] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [ ] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.