### PR TITLE
fix: Query Settings Rehaul

### DIFF
--- a/.github/styles/Vocab/technical/accept.txt
+++ b/.github/styles/Vocab/technical/accept.txt
@@ -111,7 +111,6 @@ check
 OAuth
 MongoDB
 URI
-disabled
 Disabled
 Host
 unencrypted
@@ -119,7 +118,6 @@ javascript
 MySQL
 SSL
 SQL
-disable
 callbackFunction
 setInterval
 clearInterval
@@ -392,7 +390,6 @@ onCheckChange
 isChecked
 isDisabled
 default state
-disable
 JSON Form
 selectedValues
 Allow Currency Change

--- a/website/docs/connect-data/reference/query-settings.md
+++ b/website/docs/connect-data/reference/query-settings.md
@@ -6,32 +6,39 @@ You can find the following settings in the **Settings** tab of the query editor 
 
 <dl>
   <dt><b>Encode query params</b></dt>
-  <dd>Toggles converting the special characters in parameters into their UTF equivalents. It also encodes the form body when the <b>Content-Type</b> header is set to <code>FORM_URLENCODED</code>. Available for API queries.
+  <dd>Toggles whether Appsmith converts parameters' special characters into their <a href="https://en.wikipedia.org/wiki/URL_encoding">URL-encoded</a> equivalents. It also encodes the form body when the <b>Content-Type</b> header is set to <code>FORM_URLENCODED</code>. This setting is available for API queries.
   </dd><br />
 
   <dt><b>Use Prepared Statements</b></dt>
-  <dd>Toggles using pre-compiled and parameterized SQL statements to construct and execute database queries. Usually, this improves the efficiency and security of your SQL queries. To learn more, see <a href="/connect-data/concepts/how-to-use-prepared-statements">Prepared Statements</a>. Available for database queries.
+  <dd>Toggles whether Appsmith uses pre-compiled and parameterized SQL statements to construct and execute database queries. This method improves the security of your SQL queries. This setting is turned on by default, and available only for SQL database queries. For more details, see <a href="/connect-data/concepts/how-to-use-prepared-statements">Prepared Statements</a>.
   </dd><br />
 
   <dt><b>Query timeout</b></dt>
-  <dd>Sets the time duration in milliseconds that the Appsmith server waits for the query to finish before it closes the connection. If your query takes longer than this duration, Appsmith throws a timeout error. This setting defaults to 10000 ms with a maximum of 60000 ms. Available for all query types.
+  <dd>Sets the time duration in milliseconds that the Appsmith server waits for the query to finish before it closes the connection. If your query takes longer than this duration, Appsmith throws a <a href="/help-and-support/troubleshooting-guide/action-errors#timeout-error">timeout error</a>. This setting defaults to 10000 ms with a maximum of 60000 ms.
   </dd><br />
 
-  <dt><b>Request confirmation before running query/API</b></dt>
-  <dd>When enabled, Appsmith asks the user for permission to run the query before each execution. Available for all query types.
+  <dt><b>Request confirmation before running query</b></dt>
+  <dd>When turned on, Appsmith asks the user for permission to run the query before each execution.
   </dd><br />
 
-  <dt><b>Run query/API on page load</b></dt>
-  <dd>When enabled, this query is executed every time the page loads or refreshes. This is automatically enabled when you bind the query's data to be displayed in a widget, though you can choose to disable it. Available for all query types.
+  <dt><b>Request confirmation before running API</b></dt>
+  <dd>When turned on, Appsmith asks the user for permission to run the query before each execution.
+  </dd><br />
+
+  <dt><b>Run API on page load</b></dt>
+  <dd>When turned on, your query is executed every time the page loads or refreshes. This is automatically turned on when you bind the query's data to be displayed in a widget, though you can choose to turn it off.
+  </dd><br />
+
+  <dt><b>Run query on page load</b></dt>
+  <dd>When turned on, your query is executed every time the page loads or refreshes. This is automatically turned on when you bind the query's data to be displayed in a widget, though you can choose to turn it off.
   </dd><br />
 
   <dt><b>Smart JSON substitution</b></dt>
-  <dd>When enabled, the query intelligently adds or removes quotation marks from your JavaScript data as necessary to correctly cast them into JSON. Some tasks, such as sending raw binary data in an API query, may require this setting to be disabled. Available for API queries.
+  <dd>JavaScript objects and JSON objects are formatted similarly, however they have different rules for where quotation marks are required. When this setting is turned on, Appsmith intelligently adds or removes quotation marks from your JavaScript data as necessary to correctly cast them into JSON. This setting is turned on by default, however it may need to be turned off for some tasks such as sending raw binary data to an API. This setting is available for API queries. For a video guide on using this feature, see <a href="https://www.youtube.com/watch?v=-Z3y-pdNhXc">How to Use Smart JSON Substitution</a>.
   </dd>
-  <dd><VideoEmbed host="youtube" videoId="-Z3y-pdNhXc" title="How to use smart JSON substitution" caption="How to use smart JSON substitution"/></dd><br />
 
   <dt><b>Smart BSON substitution</b></dt>
-  <dd>When enabled, the query intelligently adds or removes quotation marks from your JavaScript data as necessary to correctly cast them into BSON. Available for <a href="/connect-data/reference/querying-mongodb">MongoDB</a> queries.
+  <dd>JavaScript objects and Binary JSON (BSON) objects are formatted similarly, however they have different rules for where quotation marks are required. When turned on, the query intelligently adds or removes quotation marks from your JavaScript data as necessary to correctly cast them into BSON. This setting is turned on by default, and available only for <a href="/connect-data/reference/querying-mongodb">MongoDB</a> queries.
   </dd>
 
 </dl>

--- a/website/docs/connect-data/reference/query-settings.md
+++ b/website/docs/connect-data/reference/query-settings.md
@@ -1,26 +1,37 @@
 # Query Settings
 
-In the Appsmith Query Editor, you can specify the following settings in the **Settings** tab for an API or a DB query:
+This page is a reference guide that provides a description of all the settings available for configuring your queries.
 
-|Setting   | Availability  | Description  |
-|----------|---------------|--------------|
-| Run on page load  | API and DB query  | It allows you to configure whether the query should load every time the page loads. By default, it's turned on for queries that display data on a widget. You can explicitly change this setting to suit your logic.   |
-| Request confirmation  | API and DB query  | It enables you to set up a confirmation pop-up before a query is run. It protects against users accidentally running destructive operations.  |
-| Query timeout  | API and DB query  | The time till which Appsmith server waits for the query to execute before closing the connection. By default, it's set to 10000 ms. If your query takes longer than this to return results, Appsmith throws a timeout error. The maximum duration before a query times out is 6000 ms.  |
-| Prepared statements | DB query | Execute a statement with dynamic data bindings repeatedly and efficiently |
-| Encode query params  | API  | Encode query params convert the special characters in params to their UTF equivalents. You can also encode the form body when the Content-Type header is set to `FORM_URLENCODED`. |
-| Smart JSON substitution  | API   | Dynamically perform type conversions on field values in a request body  |
+You can find the following settings in the **Settings** tab of the query editor for an API or database query:
 
-## Prepared statements
+<dl>
+  <dt><b>Encode query params</b></dt>
+  <dd>Toggles converting the special characters in parameters into their UTF equivalents. It also encodes the form body when the <b>Content-Type</b> header is set to <code>FORM_URLENCODED</code>. Available for API queries.
+  </dd><br />
 
-A Prepared Statement is a feature provided by SQL databases to execute the same statement with dynamic data bindings securely. Appsmith supports using prepared statements by converting the user query into a parameterized query by replacing the bindings. That means the query created on the Appsmith has bindings for reading the widget values selected by users. By default, the prepared statement is **enabled** for all queries. To know more about Prepared statements in Appsmith, please check [How to Use Prepared Statements?](/connect-data/concepts/how-to-use-prepared-statements)
+  <dt><b>Use Prepared Statements</b></dt>
+  <dd>Toggles using pre-compiled and parameterized SQL statements to construct and execute database queries. Usually, this improves the efficiency and security of your SQL queries. To learn more, see <a href="/connect-data/concepts/how-to-use-prepared-statements">Prepared Statements</a>. Available for database queries.
+  </dd><br />
 
-## Smart JSON substitution
+  <dt><b>Query timeout</b></dt>
+  <dd>Sets the time duration in milliseconds that the Appsmith server waits for the query to finish before it closes the connection. . If your query takes longer than this duration, Appsmith throws a timeout error. This setting defaults to 10000 ms with a maximum of 60000 ms. Available for all query types.
+  </dd><br />
 
-The smart JSON substitution allows Appsmith to dynamically perform type conversions on field values in a request body. The video below illustrates how to use this feature:
+  <dt><b>Request confirmation before running query/API</b></dt>
+  <dd>When enabled, Appsmith asks the user for permission to run the query before each execution. Available for all query types.
+  </dd><br />
 
-<VideoEmbed host="youtube" videoId="-Z3y-pdNhXc" title="How to use smart JSON substitution" caption="How to use smart JSON substitution"/>
+  <dt><b>Run query/API on page load</b></dt>
+  <dd>When enabled, this query is executed every time the page loads or refreshes. This is automatically enabled when you bind the query's data to be displayed in a widget, though you can choose to disable it. Available for all query types.
+  </dd><br />
 
-:::info
-Do you need help? Check out the [API response troubleshooting guide](/help-and-support/troubleshooting-guide/query-errors) or reach out on[ Discord](https://discord.com/invite/rBTTVJp) to get support or ask questions on the [community forum](https://community.appsmith.com/).
-:::
+  <dt><b>Smart JSON substitution</b></dt>
+  <dd>When enabled, the query intelligently adds or removes quotation marks from your JavaScript data as necessary to correctly cast them into JSON. Some tasks such as sending raw binary data in an API query may require this setting to be disabled. Available for API queries.
+  </dd>
+  <dd><VideoEmbed host="youtube" videoId="-Z3y-pdNhXc" title="How to use smart JSON substitution" caption="How to use smart JSON substitution"/></dd><br />
+
+  <dt><b>Smart BSON substitution</b></dt>
+  <dd>When enabled, the query intelligently adds or removes quotation marks from your JavaScript data as necessary to correctly cast them into BSON. Available for <a href="/connect-data/reference/querying-mongodb">MongoDB</a> queries.
+  </dd>
+
+</dl>

--- a/website/docs/connect-data/reference/query-settings.md
+++ b/website/docs/connect-data/reference/query-settings.md
@@ -10,7 +10,7 @@ You can find the following settings in the **Settings** tab of the query editor 
   </dd><br />
 
   <dt><b>Use Prepared Statements</b></dt>
-  <dd>Toggles whether Appsmith uses pre-compiled and parameterized SQL statements to construct and execute database queries. This method improves the security of your SQL queries. This setting is turned on by default, and available only for SQL database queries. For more details, see <a href="/connect-data/concepts/how-to-use-prepared-statements">Prepared Statements</a>.
+  <dd>Toggles whether Appsmith uses pre-compiled and parameterized SQL statements to construct and execute database queries. This method improves the security of your SQL queries. This setting is turned on by default, and available for SQL database queries. For more details, see <a href="/connect-data/concepts/how-to-use-prepared-statements">Prepared Statements</a>.
   </dd><br />
 
   <dt><b>Query timeout</b></dt>
@@ -35,10 +35,10 @@ You can find the following settings in the **Settings** tab of the query editor 
 
   <dt><b>Smart JSON substitution</b></dt>
   <dd>JavaScript objects and JSON objects are formatted similarly, however they have different rules for where quotation marks are required. When this setting is turned on, Appsmith intelligently adds or removes quotation marks from your JavaScript data as necessary to correctly cast them into JSON. This setting is turned on by default, however it may need to be turned off for some tasks such as sending raw binary data to an API. This setting is available for API queries. For a video guide on using this feature, see <a href="https://www.youtube.com/watch?v=-Z3y-pdNhXc">How to Use Smart JSON Substitution</a>.
-  </dd>
+  </dd><br />
 
   <dt><b>Smart BSON substitution</b></dt>
-  <dd>JavaScript objects and Binary JSON (BSON) objects are formatted similarly, however they have different rules for where quotation marks are required. When turned on, the query intelligently adds or removes quotation marks from your JavaScript data as necessary to correctly cast them into BSON. This setting is turned on by default, and available only for <a href="/connect-data/reference/querying-mongodb">MongoDB</a> queries.
+  <dd>JavaScript objects and Binary JSON (BSON) objects are formatted similarly, however they have different rules for where quotation marks are required. When turned on, the query intelligently adds or removes quotation marks from your JavaScript data as necessary to correctly cast them into BSON. This setting is turned on by default, and available for <a href="/connect-data/reference/querying-mongodb">MongoDB</a> queries.
   </dd>
 
 </dl>

--- a/website/docs/connect-data/reference/query-settings.md
+++ b/website/docs/connect-data/reference/query-settings.md
@@ -14,7 +14,7 @@ You can find the following settings in the **Settings** tab of the query editor 
   </dd><br />
 
   <dt><b>Query timeout</b></dt>
-  <dd>Sets the time duration in milliseconds that the Appsmith server waits for the query to finish before it closes the connection. . If your query takes longer than this duration, Appsmith throws a timeout error. This setting defaults to 10000 ms with a maximum of 60000 ms. Available for all query types.
+  <dd>Sets the time duration in milliseconds that the Appsmith server waits for the query to finish before it closes the connection. If your query takes longer than this duration, Appsmith throws a timeout error. This setting defaults to 10000 ms with a maximum of 60000 ms. Available for all query types.
   </dd><br />
 
   <dt><b>Request confirmation before running query/API</b></dt>
@@ -26,7 +26,7 @@ You can find the following settings in the **Settings** tab of the query editor 
   </dd><br />
 
   <dt><b>Smart JSON substitution</b></dt>
-  <dd>When enabled, the query intelligently adds or removes quotation marks from your JavaScript data as necessary to correctly cast them into JSON. Some tasks such as sending raw binary data in an API query may require this setting to be disabled. Available for API queries.
+  <dd>When enabled, the query intelligently adds or removes quotation marks from your JavaScript data as necessary to correctly cast them into JSON. Some tasks, such as sending raw binary data in an API query, may require this setting to be disabled. Available for API queries.
   </dd>
   <dd><VideoEmbed host="youtube" videoId="-Z3y-pdNhXc" title="How to use smart JSON substitution" caption="How to use smart JSON substitution"/></dd><br />
 


### PR DESCRIPTION
Rehaul of Query Settings page in Reference section of Connect Data.

Resolves #1428 

### Review feedback
* rm video, link instead "to see how to use smart json substitution, see..."
* separate settings with "query/API"
* link for "UTF equivalents"
* "Available for API queries" into sentence form
* prepared statements: available for SQL databases
* prepared statements: fix unclear "toggles using"
* prep statements: "For more details, see ..."
* prep state: move "available on" to penultimate sentence
* check for timeout error link
* don't mention "avail for all query types"
* "setting to be >turned off<"
* rm disabled from accepted terms
* fix "enabled" also
* smart json/bson substitution: more detail on why it's useful
* mention when a setting is on by default

## Checklist
I have:
- [x] run the content through Grammarly
- [x] linked to sample apps when relevant
- [x] added the meta description for each page in the PR
- [x] minimized the callouts and added only when necessary
- [x] added the `queryString` parameter to the Tabs (if used)
- [x] masked PII in images. For example, login credentials, account details, and more
- [x] added images only when necessary
- [x] deleted the images that are no longer used for the updated pages in the PR
- [x] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [x] used the `<figure/>` tag instead of a markdown representation for images
- [x] added the `<figcaption/>` tag to add a caption to the image
- [x] added the `alt` attribute in the `<img/>` tag
- [x] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [x] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.