### PR TITLE
fix: Prepared Statements Rehaul

### DIFF
--- a/.github/styles/Vocab/technical/accept.txt
+++ b/.github/styles/Vocab/technical/accept.txt
@@ -433,3 +433,4 @@ idToken
 groups
 roles
 store
+Prepared Statements

--- a/.github/styles/Vocab/technical/accept.txt
+++ b/.github/styles/Vocab/technical/accept.txt
@@ -433,4 +433,3 @@ idToken
 groups
 roles
 store
-Prepared Statements

--- a/website/docs/connect-data/concepts/how-to-use-prepared-statements.md
+++ b/website/docs/connect-data/concepts/how-to-use-prepared-statements.md
@@ -5,15 +5,12 @@ description: Learn about how Prepared Statements are used in Appsmith.
 
 # Prepared Statements
 
-This page describes what Prepared Statements are, how they are used in your SQL database queries, and the situations where you may need to turn them off.
+This page describes Prepared Statements, how they're used in your SQL database queries, and the situations where you may need to turn them off.
 
-<!-- TODO: this hr/ below necessary? -->
-
----
 
 ## What are Prepared Statements
 
-A [Prepared Statement](https://en.wikipedia.org/wiki/Prepared\_statement) is a feature provided by a Database Management System (DBMS) to execute a SQL statement with parameterized data bindings. When a SQL statement is written, the dynamic parts of the statement (the input data that may be different upon each execution of the query) are abstracted into parameters. When you execute your query, the data you provide is substituted into the pre-compiled statement along with any necessary quotation marks.
+A [Prepared Statement](https://en.wikipedia.org/wiki/Prepared\_statement) is a feature provided by a Database Management System (DBMS) to execute a SQL statement with parameterized data bindings. When a SQL statement is written, the dynamic parts of the statement (the input data that may differ upon each execution of the query) are abstracted into parameters. When you execute your query, the data you provide is substituted into the pre-compiled statement along with any necessary quotation marks.
 
 In the example below, the first statement represents something that you may write in your query: it selects columns from a certain table with a `WHERE` clause to filter based on some criteria, which in this case is the text from **Table1**'s search bar.
 
@@ -35,17 +32,17 @@ When your query is eventually executed, the dynamic data (in this case, the tabl
 
 Here is a simplified look at the lifecycle of a Prepared Statement in Appsmith:
 
-1. **Preparing:** Your SQL statement is sent as a template to the database server. In this template,
+1. **Preparing:** Your SQL statement is sent to the database server as a template.
 
 1. **Processing:** The database server parses the statement for validity and substitutes dynamic values with `{?}`; these are the parameters. Then the resulting template is optimized, compiled, and cached without being executed. At that point, it's ready to be executed whenever you supply the parameters from your query.
 
-1. **Executing:** Once the parameters are recieved, the database binds the parameter values to the template statement and executes it.
+1. **Executing:** Once the parameters are received, the database binds the parameter values to the template statement and executes it.
 
 The template is retained, and the statement can be executed repeatedly and efficiently each time you run your query.
 
-## Benefits of using Prepared Statements
+## Benefits of Prepared Statements
 
-By separating the SQL commands and the parameter data, the database server is able to perform its operations exactly as intended without the risk of malicious users adding their own SQL code into your query (a common attack known as [SQL injection](https://en.wikipedia.org/wiki/SQL\_injection)). When the statement is executed, the user's input is evaluated as a piece of data rather than an extension of your SQL code.
+By separating the SQL commands and the parameter data, the database server can perform its operations exactly as intended without the risk of malicious users adding their own SQL code into your query (a common attack known as [SQL injection](https://en.wikipedia.org/wiki/SQL\_injection)). When the statement is executed, the user's input is evaluated as a piece of data rather than an extension of your SQL code.
 
 As a simple example, imagine a user that sends the input `100; DROP TABLE users;` to your query that's expecting a user's `id`:
 
@@ -68,7 +65,7 @@ Depending on the structure and needs of your SQL query, it's not always possible
 
 ### Dynamic table name
 
-In order for the DBMS to process your SQL template and decide on the appropriate algorithm to use, it needs certain information up front, such as the name of the table you're querying. When your query doesn't specify which table it needs, the DBMS isn't able to process the query as a Prepared Statement.
+For the DBMS to process your SQL template and decide on the appropriate search algorithm, it needs certain information up-front, such as the name of the table you're querying. When your query doesn't specify which table it needs, the DBMS can't process the query as a Prepared Statement.
 
 A query with a dynamic table name looks like this:
 
@@ -76,7 +73,7 @@ A query with a dynamic table name looks like this:
 SELECT * FROM {{TableNamePicker.selectedOptionValue}};
 ```
 
-This query reads the table name from a [Select widget](/reference/widgets/text.md) called **TableNamePicker**, whose selected value is determined only when the query is run. In this situation, Prepared Statements need to be turned off in the [query settings](/connect-data/reference/query-settings).
+This query reads the table name from a [Select widget](/reference/widgets/text.md) called **TableNamePicker**, whose selected value is only determined when the query runs. In this situation, Prepared Statements must be turned off in the [query settings](/connect-data/reference/query-settings).
 
 ### Dynamic queries
 
@@ -88,11 +85,11 @@ As an extreme example, imagine an app with an Input widget **UserQueryInput** wh
 {{ UserQueryInput.text }}
 ```
 
-In a case like this, the DBMS has nothing to pre-compile, since the entire query is only determined as the query is being executed. Here, Prepared Statements should be turned off.
+In such a case, the DBMS has nothing to pre-compile since the entire query is only determined as the query is being executed. Here, your should turn off Prepared Statements.
 
 ### Dynamic clauses
 
-This also extends to queries which have clauses that are included based on conditional code. Since the underlying structure of the query is not known in advance, it won't be acceptable as a Prepared Statement. For example, the following would require that Prepared Statements are turned off:
+The DBMS also can't pre-compile queries with clauses that are included based on conditional code. Since the underlying structure of the query is not known in advance, it won't be acceptable as a Prepared Statement. For example, the following would require that Prepared Statements are turned off:
 
 ```sql
 SELECT * FROM users WHERE name = {{ NameInput.text }}
@@ -111,9 +108,9 @@ There may also be situations in which the structure of a query's `WHERE` clause 
 SELECT * FROM users WHERE {{ NameInput.text ? "name = " + NameInput.text : "1=1" }}
 ```
 
-Above, the conditional code in the `WHERE` clause checks whether an Input widget **NameInput** has a value from the user on its `text` property. If it does, the `WHERE` clause is used to filter by that name. If not, the `WHERE` clause returns all records; for every record, 1 is equal to 1.
+Above, the conditional code in the `WHERE` clause checks whether an Input widget **NameInput** has a value from the user on its `text` property. If it does, the `WHERE` clause filters by that name. If not, the `WHERE` clause returns all records; for every record, 1 is equal to 1.
 
-Since the structure of the `WHERE` clause is not determined up front, it can't be pre-compiled. Just like the table name, the DBMS needs to know which column is being used in the `WHERE` clause so that it can pre-compile the statement. Since the above statement doesn't provide this static information, Prepared Statements must be turned off.
+Since the structure of the `WHERE` clause is not determined up-front, it can't be pre-compiled. Just like the table name, the DBMS needs to know which column is being used in the `WHERE` clause so that it can pre-compile the statement. Since the above statement doesn't provide this static information, Prepared Statements must be turned off.
 
 This limitation also applies to the following query where the column is not static:
 
@@ -121,18 +118,18 @@ This limitation also applies to the following query where the column is not stat
 SELECT * FROM users WHERE {{ ColumnInput.text }} = '{{ ValueInput.text }}';
 ```
 
-Notice that `{{ ValueInput.text }}` is surrounded by quotes: since the column is not static and Prepared Statements must be turned off, you'll need to manually include the quotations around your values. 
+Notice that `{{ ValueInput.text }}` is surrounded by quotes. Since the column is not static and Prepared Statements must be turned off, you'll need to manually include the quotations around your values. 
 
 ## Edge cases
 
 Below, you can find edge cases that may apply if you are experiencing issues:
 
-* Commented code in your queries shouldn't contain any data bindings; all bindings, even commented ones, are parameterized by the DBMS and are used in the statement. To avoid this issue, remove the mustache `{{ }}` brackets around data bindings whenever you are commenting them out.
+* Commented code in your queries shouldn't contain any data bindings; all bindings, even commented ones, are parameterized by the DBMS and are used in the statement. To avoid this issue, remove the mustache `{{ }}` brackets around data bindings whenever you comment them out.
 
 * If you're using a dynamic array to supply a SQL `IN` clause and using [PostgreSQL](/connect-data/reference/querying-postgres.md), then you can use `= ANY`. However, MySQL doesn't support this syntax and requires that you turn off Prepared Statements.
 
 ## Summary
 
-Prepared Statements are very useful for increasing the security of your queries by protecting against SQL-injection attacks. With this setting enabled, malicious SQL sent by attackers is interpreted as an unharmful literal string, rather than actual SQL code.
+Prepared Statements are handy for increasing the security of your queries by protecting against SQL injection attacks. With this setting enabled, malicious SQL sent by attackers is interpreted as an unharmful literal string rather than actual SQL code.
 
-However, when the structure of your query isn't static and provided up front, you may need to turn this setting off. When your SQL statement is built according to conditional logic or doesn't specify which table and column it's querying, the database server is unable to pre-compile your statement and the query won't work.
+However, when the structure of your query isn't static and provided up-front, you may need to turn this setting off. When your SQL statement is built according to conditional logic or doesn't specify which table and column it's querying, the database server can't pre-compile your statement, and the query won't work.

--- a/website/docs/connect-data/concepts/how-to-use-prepared-statements.md
+++ b/website/docs/connect-data/concepts/how-to-use-prepared-statements.md
@@ -5,49 +5,53 @@ description: Learn about how Prepared Statements are used in Appsmith.
 
 # Prepared Statements
 
-This page describes Prepared Statements, how they're used in your SQL database queries, and the situations where you may need to turn them off.
+This page explains prepared statements, why they're used in your SQL database queries, and the situations where you may need to turn them off.
 
 
-## What are Prepared Statements
+## Overview
 
-A [Prepared Statement](https://en.wikipedia.org/wiki/Prepared\_statement) is a feature provided by a Database Management System (DBMS) to execute a SQL statement with parameterized data bindings. When a SQL statement is written, the dynamic parts of the statement (the input data that may differ upon each execution of the query) are abstracted into parameters. When you execute your query, the data you provide is substituted into the pre-compiled statement along with any necessary quotation marks.
+A prepared statement is a feature provided by a Database Management System (DBMS) to execute a SQL statement with parameterized data bindings. When a SQL statement is written, the dynamic parts of the statement (the input data that may differ upon each execution of the query) are abstracted into parameters. When you execute your query, the data you provide is substituted into the pre-compiled statement along with any necessary quotation marks.
 
-In the example below, the first statement represents something that you may write in your query: it selects columns from a certain table with a `WHERE` clause to filter based on some criteria, which in this case is the text from **Table1**'s search bar.
+In the example below, the first statement represents something that you may write in your query: it selects the `name` column from a certain table by using a `WHERE` clause to filter based on some criteria, which in this case is user input from the search box of a table widget `Table1`.
 
 ```sql
 -- regular SQL query
 SELECT * FROM users WHERE name = {{ Table1.searchText }};
 ```
 
-When Prepared Statements are turned on, your SQL statement is pre-compiled on the DB server into something like the following snippet, where the dynamic data is replaced by a placeholder:
+When prepared statements are turned on, your SQL statement is pre-compiled on the database server into something like the following snippet, where the dynamic data is replaced by a placeholder:
 
 ```sql
--- a Prepared Statement where the dynamic data is abstracted away
-SELECT * FROM users WHERE name = {?}
+-- a prepared statement where the dynamic data is abstracted away
+SELECT * FROM users WHERE name = ?
 ```
 
-When your query is eventually executed, the dynamic data (in this case, the table's search bar text) is sent to the DB server and substituted into the statement in place of the `{?}`.
+When your query is eventually executed, the dynamic data (in this case, the table's search bar text) is sent to the database server and substituted into the statement in place of the `?`.
 
-### Prepared Statements lifecycle
+:::info
+The **Use Prepared Statement** query setting is available for Postgres, MySQL, MsSQL, and Oracle queries.
+:::
 
-Here is a simplified look at the lifecycle of a Prepared Statement in Appsmith:
+### Prepared statements workflow
 
-1. **Preparing:** Your SQL statement is sent to the database server as a template.
+Here is a simplified look at the flow of a prepared statement in Appsmith:
 
-1. **Processing:** The database server parses the statement for validity and substitutes dynamic values with `{?}`; these are the parameters. Then the resulting template is optimized, compiled, and cached without being executed. At that point, it's ready to be executed whenever you supply the parameters from your query.
+1. **Prepare:** The SQL statement is sent to the database server as a template.
 
-1. **Executing:** Once the parameters are received, the database binds the parameter values to the template statement and executes it.
+1. **Process:** The database server parses the statement for validity and substitutes dynamic values with `?`; these are the parameters. Then the resulting template is optimized, compiled, and cached without being executed. At that point, it's ready to be executed whenever you supply the parameters from your query.
 
-The template is retained, and the statement can be executed repeatedly and efficiently each time you run your query.
+1. **Execute:** Once the parameters are received, the database binds the parameter values to the template statement and executes it.
 
-## Benefits of Prepared Statements
+The template is retained, and the statement can be executed repeatedly and efficiently each time you run the query.
 
-By separating the SQL commands and the parameter data, the database server can perform its operations exactly as intended without the risk of malicious users adding their own SQL code into your query (a common attack known as [SQL injection](https://en.wikipedia.org/wiki/SQL\_injection)). When the statement is executed, the user's input is evaluated as a piece of data rather than an extension of your SQL code.
+## Benefits
 
-As a simple example, imagine a user that sends the input `100; DROP TABLE users;` to your query that's expecting a user's `id`:
+By separating the SQL commands and the parameter data, the database server can perform its operations exactly as intended without the risk of malicious users adding their own SQL code into the query (a common attack known as [SQL injection](https://en.wikipedia.org/wiki/SQL\_injection)). When the statement is executed, the user's input is evaluated as a piece of data rather than an extension of your SQL code.
+
+As a simple example, imagine a user that sends the input `100; DROP TABLE users;` to a query that's expecting a user's `id`:
 
 ```sql
--- without Prepared Statements
+-- without prepared statements
 SELECT * from users WHERE id = 100; DROP TABLE users;
 ```
 
@@ -59,37 +63,37 @@ SELECT * FROM users WHERE id = "100; DROP TABLE users;";
 
 With the parameterized input, the query would return nothing after it's unable to find a user with an `id` equal to the literal `100; DROP TABLE users;`.
 
-## Limitations of Prepared Statements
+## Limitations
 
-Depending on the structure and needs of your SQL query, it's not always possible to use Prepared Statements. The sections below explain the situations where you'll need to turn them off.
+Depending on the structure and needs of your SQL query, it's not always possible to use prepared statements. The sections below explain the situations where you'll need to turn them off.
 
 ### Dynamic table name
 
-For the DBMS to process your SQL template and decide on the appropriate search algorithm, it needs certain information up-front, such as the name of the table you're querying. When your query doesn't specify which table it needs, the DBMS can't process the query as a Prepared Statement.
+For the DBMS to process your SQL template and decide on the appropriate search algorithm, it needs certain information up-front, such as the name of the table you're querying. When your query doesn't specify which table it needs, the DBMS can't process the query as a prepared statement.
 
 A query with a dynamic table name looks like this:
 
 ```sql
-SELECT * FROM {{TableNamePicker.selectedOptionValue}};
+SELECT * FROM {{ TableNamePicker.selectedOptionValue }};
 ```
 
-This query reads the table name from a [Select widget](/reference/widgets/text.md) called **TableNamePicker**, whose selected value is only determined when the query runs. In this situation, Prepared Statements must be turned off in the [query settings](/connect-data/reference/query-settings).
+This query reads the table name from a Select widget called `TableNamePicker`, whose selected value is only determined when the query runs. In this situation, prepared statements must be turned off in the [query settings](/connect-data/reference/query-settings).
 
 ### Dynamic queries
 
 In some cases, the structure of your query's SQL statement might be determined by conditional code from your app.
 
-As an extreme example, imagine an app with an Input widget **UserQueryInput** where the user is supposed to write their own SQL. The query body would look like:
+As an example, imagine an app with an Input widget `UserQueryInput` where the user is supposed to write their own SQL. The query body would look like:
 
 ```sql
 {{ UserQueryInput.text }}
 ```
 
-In such a case, the DBMS has nothing to pre-compile since the entire query is only determined as the query is being executed. Here, your should turn off Prepared Statements.
+In such a case, the DBMS has nothing to pre-compile since the entire query is only determined as the query is being executed. Here, your should turn off prepared statements.
 
 ### Dynamic clauses
 
-The DBMS also can't pre-compile queries with clauses that are included based on conditional code. Since the underlying structure of the query is not known in advance, it won't be acceptable as a Prepared Statement. For example, the following would require that Prepared Statements are turned off:
+The DBMS also can't pre-compile queries with clauses that are included based on conditional code. Since the underlying structure of the query is not known in advance, it won't be acceptable as a Prepared Statement. For example, the following would require that prepared statements are turned off:
 
 ```sql
 SELECT * FROM users WHERE name = {{ NameInput.text }}
@@ -108,9 +112,9 @@ There may also be situations in which the structure of a query's `WHERE` clause 
 SELECT * FROM users WHERE {{ NameInput.text ? "name = " + NameInput.text : "1=1" }}
 ```
 
-Above, the conditional code in the `WHERE` clause checks whether an Input widget **NameInput** has a value from the user on its `text` property. If it does, the `WHERE` clause filters by that name. If not, the `WHERE` clause returns all records; for every record, 1 is equal to 1.
+Above, the conditional code in the `WHERE` clause checks whether an Input widget `NameInput` has a value from the user on its `text` property. If it does, the `WHERE` clause filters by that name. If not, the `WHERE` clause returns all records; for every record, 1 is equal to 1.
 
-Since the structure of the `WHERE` clause is not determined up-front, it can't be pre-compiled. Just like the table name, the DBMS needs to know which column is being used in the `WHERE` clause so that it can pre-compile the statement. Since the above statement doesn't provide this static information, Prepared Statements must be turned off.
+Since the structure of the `WHERE` clause is not determined up-front, it can't be pre-compiled. Just like the table name, the DBMS needs to know which column is being used in the `WHERE` clause so that it can pre-compile the statement. Since the above statement doesn't provide this static information, prepared statements must be turned off.
 
 This limitation also applies to the following query where the column is not static:
 
@@ -118,7 +122,7 @@ This limitation also applies to the following query where the column is not stat
 SELECT * FROM users WHERE {{ ColumnInput.text }} = '{{ ValueInput.text }}';
 ```
 
-Notice that `{{ ValueInput.text }}` is surrounded by quotes. Since the column is not static and Prepared Statements must be turned off, you'll need to manually include the quotations around your values. 
+Notice that `{{ ValueInput.text }}` is surrounded by quotes. Since the column is not static and prepared statements must be turned off, you'll need to manually include the quotations around your values. 
 
 ## Edge cases
 
@@ -126,10 +130,10 @@ Below, you can find edge cases that may apply if you are experiencing issues:
 
 * Commented code in your queries shouldn't contain any data bindings; all bindings, even commented ones, are parameterized by the DBMS and are used in the statement. To avoid this issue, remove the mustache `{{ }}` brackets around data bindings whenever you comment them out.
 
-* If you're using a dynamic array to supply a SQL `IN` clause and using [PostgreSQL](/connect-data/reference/querying-postgres.md), then you can use `= ANY`. However, MySQL doesn't support this syntax and requires that you turn off Prepared Statements.
+* If you're using a dynamic array to supply a SQL `IN` clause and using PostgreSQL, then you can use `= ANY`. However, MySQL doesn't support this syntax and requires that you turn off prepared statements.
 
 ## Summary
 
-Prepared Statements are handy for increasing the security of your queries by protecting against SQL injection attacks. With this setting enabled, malicious SQL sent by attackers is interpreted as an unharmful literal string rather than actual SQL code.
+Prepared statements are handy for increasing the security of your queries by protecting against SQL injection attacks. With this setting enabled, malicious SQL sent by attackers is interpreted as an unharmful literal string rather than actual SQL code.
 
 However, when the structure of your query isn't static and provided up-front, you may need to turn this setting off. When your SQL statement is built according to conditional logic or doesn't specify which table and column it's querying, the database server can't pre-compile your statement, and the query won't work.

--- a/website/docs/connect-data/concepts/how-to-use-prepared-statements.md
+++ b/website/docs/connect-data/concepts/how-to-use-prepared-statements.md
@@ -10,7 +10,9 @@ This page explains prepared statements, why they're used in your SQL database qu
 
 ## Overview
 
-A prepared statement is a feature provided by a Database Management System (DBMS) to execute a SQL statement with parameterized data bindings. When a SQL statement is written, the dynamic parts of the statement (the input data that may differ upon each execution of the query) are abstracted into parameters. When you execute your query, the data you provide is substituted into the pre-compiled statement along with any necessary quotation marks.
+A prepared statement is a feature provided by a Database Management System (DBMS) to execute a SQL statement with parameterized data bindings. This process improves the security of your app by making your queries significantly more resistant to SQL-injection attacks.
+
+When a SQL statement is written, the dynamic parts of the statement (the input data that may differ upon each execution of the query) are abstracted into parameters. When you execute your query, the data you provide is substituted into the pre-compiled statement along with any necessary quotation marks.
 
 In the example below, the first statement represents something that you may write in your query: it selects the `name` column from a certain table by using a `WHERE` clause to filter based on some criteria, which in this case is user input from the search box of a table widget `Table1`.
 
@@ -44,7 +46,7 @@ Here is a simplified look at the flow of a prepared statement in Appsmith:
 
 The template is retained, and the statement can be executed repeatedly and efficiently each time you run the query.
 
-## Benefits
+## Security
 
 By separating the SQL commands and the parameter data, the database server can perform its operations exactly as intended without the risk of malicious users adding their own SQL code into the query (a common attack known as [SQL injection](https://en.wikipedia.org/wiki/SQL\_injection)). When the statement is executed, the user's input is evaluated as a piece of data rather than an extension of your SQL code.
 
@@ -122,15 +124,17 @@ This limitation also applies to the following query where the column is not stat
 SELECT * FROM users WHERE {{ ColumnInput.text }} = '{{ ValueInput.text }}';
 ```
 
-Notice that `{{ ValueInput.text }}` is surrounded by quotes. Since the column is not static and prepared statements must be turned off, you'll need to manually include the quotations around your values. 
+Notice that `{{ ValueInput.text }}` is surrounded by quotes. Since the column is not static and prepared statements must be turned off, you'll need to manually include the quotations around your values.
 
-## Edge cases
+#### Dynamic array with IN clause
 
-Below, you can find edge cases that may apply if you are experiencing issues:
+Prepared statements are not usable when you're binding dynamic arrays into SQL `IN` clauses. However, if you're querying a PostgreSQL datasource, you can replace the `IN` clause with an equivalent clause using the `= ANY` syntax.
 
-* Commented code in your queries shouldn't contain any data bindings; all bindings, even commented ones, are parameterized by the DBMS and are used in the statement. To avoid this issue, remove the mustache `{{ }}` brackets around data bindings whenever you comment them out.
+MySQL datasources don't support this syntax though, so prepared statements should be turned off for the query to succeed.
 
-* If you're using a dynamic array to supply a SQL `IN` clause and using PostgreSQL, then you can use `= ANY`. However, MySQL doesn't support this syntax and requires that you turn off prepared statements.
+### Commented bindings
+
+Commented code in your queries shouldn't contain any data bindings; all bindings, even commented ones, are parameterized by the DBMS and are used in the statement. To avoid this issue, remove the mustache `{{ }}` brackets around data bindings whenever you comment them out.
 
 ## Summary
 

--- a/website/docs/connect-data/concepts/how-to-use-prepared-statements.md
+++ b/website/docs/connect-data/concepts/how-to-use-prepared-statements.md
@@ -99,7 +99,7 @@ The DBMS also can't pre-compile queries with clauses that are included based on 
 SELECT * FROM users WHERE name = {{ NameInput.text }}
 {{
     IncludeAddressCheckbox.isChecked?
-        "INNER JOIN teams ON users.teamID=team.teamID" :
+        "INNER JOIN teams ON users.teamID = teams.teamID" :
         ""
 }};
 ```


### PR DESCRIPTION
Rehaul of Prepared Statements concept page in Connect Data section.

### 1st Review Changes
* intro: use "explain" not "describe"
* lowercase "Prepared Statements"
* intro: how they're used -> why they're used
* Benefits and Limitations headings, rm "Prepared Statements"
* What are prepared statements heading -> "Overview"
* rm link to prepared statements wikipedia. add link elsewhere if a doc contains more info, else omit
* Check whether DBMS should be referred to as RDBMS -- _(found that DBMS should suffice)_
* Table1.searchText sentence reshuffling
* {?} change to ?
* lifecycle -> workflow
* remove "ing" from the lifecycle verbs
* "preparing" part: "The query" not "Your query"
* DB server -> database server
* don't link to widgets
* rm "extreme"
* widget names in code not bold

### 2nd Review Changes
* Added line to highlight security benefit at the top of "Overview"
* Changed "Benefits" heading to "Security"
* "Edge Cases" section turned into subheads of "Limitations"

## Checklist
I have:
- [x] run the content through Grammarly
- [x] linked to sample apps when relevant
- [x] added the meta description for each page in the PR
- [x] minimized the callouts and added only when necessary
- [x] added the `queryString` parameter to the Tabs (if used)
- [x] masked PII in images. For example, login credentials, account details, and more
- [x] added images only when necessary
- [x] deleted the images that are no longer used for the updated pages in the PR
- [x] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [x] used the `<figure/>` tag instead of a markdown representation for images
- [x] added the `<figcaption/>` tag to add a caption to the image
- [x] added the `alt` attribute in the `<img/>` tag
- [x] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [x] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.