### PR TITLE
chore: add self-hosted instance reference for configurations

### DIFF
--- a/website/docs/getting-started/setup/instance-configuration/authentication/github-login.md
+++ b/website/docs/getting-started/setup/instance-configuration/authentication/github-login.md
@@ -9,6 +9,11 @@ sidebar_position: 2
 
 Appsmith allows you to integrate with GitHub OAuth, enabling end users to sign in to the Appsmith account using their GitHub authentication credentials.
 
+## Prerequisites
+
+1. A self-hosted Appsmith instance. See the [installation guides](/getting-started/setup/installation-guides) for installing Appsmith.
+2. A [GitHub](https://github.com/login) account.
+
 ## Register OAuth app on GitHub
 
 To enable GitHub Sign in, log in to your [GitHub Account](https://github.com) and follow the steps below:

--- a/website/docs/getting-started/setup/instance-configuration/authentication/google-login.md
+++ b/website/docs/getting-started/setup/instance-configuration/authentication/google-login.md
@@ -9,6 +9,11 @@ sidebar_position: 1
 
 Appsmith provides a way to integrate with Google OAuth 2.0, enabling end users to sign in to the Appsmith account using their Google authentication credentials.
 
+## Prerequisites
+
+1. A self-hosted Appsmith instance. See the [installation guides](/getting-started/setup/installation-guides) for installing Appsmith.
+2. A [Google Workspace](https://workspace.google.com/intl/en_in/) account.
+
 ## Configure Google API console
 
 To enable Google Sign-in, go to the [Google API console](https://console.cloud.google.com/apis) to get the authorization credentials that identify Appsmith to Google's OAuth 2.0 server. Create a new project and follow the steps below:

--- a/website/docs/getting-started/setup/instance-configuration/authentication/openid-connect-oidc/active-directory.md
+++ b/website/docs/getting-started/setup/instance-configuration/authentication/openid-connect-oidc/active-directory.md
@@ -8,11 +8,10 @@ To configure Appsmith to use [Azure Active Directory (Azure AD)](https://portal.
 
 ## Prerequisites
 
-1. Before setting up Single Sign-On (SSO), ensure that you have already configured a [custom domain](/getting-started/setup/instance-configuration/custom-domain) for your instance.
-
-2. In Appsmith, go to **Admin Settings > Authentication** and click **Enable** on  **OIDC**.
-
-3. Copy the **Redirect URL** from the **OIDC** configuration page to add it when creating the application in Active Directory. 
+1. A self-hosted Appsmith instance. See the [installation guides](/getting-started/setup/installation-guides) for installing Appsmith.
+2. Before setting up Single Sign-On (SSO), ensure that you have already configured a [custom domain](/getting-started/setup/instance-configuration/custom-domain) for your instance.
+3. In Appsmith, go to **Admin Settings > Authentication** and click **Enable** on  **OIDC**.
+4. Copy the **Redirect URL** from the **OIDC** configuration page to add it when creating the application in Active Directory. 
 
 <figure>
   <img src="/img/oidc-configurations-in-appsmith.png" style= {{width:"600px", height:"auto"}} alt="OIDC configurations"/>

--- a/website/docs/getting-started/setup/instance-configuration/authentication/openid-connect-oidc/auth0.md
+++ b/website/docs/getting-started/setup/instance-configuration/authentication/openid-connect-oidc/auth0.md
@@ -9,11 +9,10 @@ To configure Appsmith to use [Auth0](https://auth0.com/) as an OIDC provider, fo
 
 ## Prerequisites
 
-1. Before setting up Single Sign-On (SSO), ensure that you have already configured a [custom domain](/getting-started/setup/instance-configuration/custom-domain) for your instance.
-
-2. In Appsmith, go to **Admin Settings > Authentication** and click **Enable** on  **OIDC**.
-
-3. Copy the **Redirect URL** from the **OIDC** configuration page to add it when creating the application in Auth0. 
+1. A self-hosted Appsmith instance. See the [installation guides](/getting-started/setup/installation-guides) for installing Appsmith.
+2. Before setting up Single Sign-On (SSO), ensure that you have already configured a [custom domain](/getting-started/setup/instance-configuration/custom-domain) for your instance.
+3. In Appsmith, go to **Admin Settings > Authentication** and click **Enable** on  **OIDC**.
+4. Copy the **Redirect URL** from the **OIDC** configuration page to add it when creating the application in Auth0. 
 
 <figure>
   <img src="/img/oidc-configurations-in-appsmith.png" style= {{width:"600px", height:"auto"}} alt="OIDC configurations"/>

--- a/website/docs/getting-started/setup/instance-configuration/authentication/openid-connect-oidc/aws-cognito.md
+++ b/website/docs/getting-started/setup/instance-configuration/authentication/openid-connect-oidc/aws-cognito.md
@@ -11,6 +11,11 @@ To configure Appsmith to use [Amazon Cognito](https://aws.amazon.com/cognito/) a
 OpenID Connect is available only in the [**business edition**](https://www.appsmith.com/pricing) for self-hosted instances. Note that only superusers of your Appsmith instance can set up OIDC.
 :::
 
+## Prerequisites
+
+1. A self-hosted Appsmith instance. See the [installation guides](/getting-started/setup/installation-guides) for installing Appsmith.
+2. Before setting up Single Sign-On (SSO), ensure that you have already configured a [custom domain](/getting-started/setup/instance-configuration/custom-domain) for your instance.
+
 ## Create user pool
 
 Log in to your [AWS account](https://console.aws.amazon.com/console/home). Go to **Services** > **Security, Identity & Compliance** > **Cognito** and follow the steps below:

--- a/website/docs/getting-started/setup/instance-configuration/authentication/openid-connect-oidc/okta.md
+++ b/website/docs/getting-started/setup/instance-configuration/authentication/openid-connect-oidc/okta.md
@@ -9,11 +9,10 @@ To configure Appsmith to use [Okta](https://www.okta.com/) as an OIDC provider, 
 
 ## Prerequisites
 
-1. Before setting up Single Sign-On (SSO), ensure that you have already configured a [custom domain](/getting-started/setup/instance-configuration/custom-domain) for your instance.
-
-2. In Appsmith, go to **Admin Settings > Authentication** and click **Enable** on **OIDC**.
-
-3. Copy the **Redirect URL** from the **OIDC** configuration page to add it when creating the application in Okta.
+1. A self-hosted Appsmith instance. See the [installation guides](/getting-started/setup/installation-guides) for installing Appsmith.
+2. Before setting up Single Sign-On (SSO), ensure that you have already configured a [custom domain](/getting-started/setup/instance-configuration/custom-domain) for your instance.
+3. In Appsmith, go to **Admin Settings > Authentication** and click **Enable** on **OIDC**.
+4. Copy the **Redirect URL** from the **OIDC** configuration page to add it when creating the application in Okta.
 
 <figure>
   <img src="/img/oidc-configurations-in-appsmith.png" style= {{width:"600px", height:"auto"}} alt="OIDC configurations"/>

--- a/website/docs/getting-started/setup/instance-configuration/authentication/openid-connect-oidc/ping-identity.md
+++ b/website/docs/getting-started/setup/instance-configuration/authentication/openid-connect-oidc/ping-identity.md
@@ -9,11 +9,10 @@ To configure Appsmith to use [Ping Identity](https://www.pingidentity.com/en.htm
 
 ## Prerequisites
 
-1. Before setting up Single Sign-On (SSO), ensure that you have already configured a [custom domain](/getting-started/setup/instance-configuration/custom-domain) for your instance.
-
-2. In Appsmith, go to **Admin Settings > Authentication** and click **Enable** on **OIDC**.
-
-3. Copy the **Redirect URL** from the **OIDC** configuration page to add it when creating the application in Ping Identity.
+1. A self-hosted Appsmith instance. See the [installation guides](/getting-started/setup/installation-guides) for installing Appsmith.
+2. Before setting up Single Sign-On (SSO), ensure that you have already configured a [custom domain](/getting-started/setup/instance-configuration/custom-domain) for your instance.
+3. In Appsmith, go to **Admin Settings > Authentication** and click **Enable** on **OIDC**.
+4. Copy the **Redirect URL** from the **OIDC** configuration page to add it when creating the application in Ping Identity.
 
 <figure>
   <img src="/img/oidc-configurations-in-appsmith.png" style= {{width:"600px", height:"auto"}} alt="OIDC configurations"/>

--- a/website/docs/getting-started/setup/instance-configuration/authentication/security-assertion-markup-language-saml/active-directory.mdx
+++ b/website/docs/getting-started/setup/instance-configuration/authentication/security-assertion-markup-language-saml/active-directory.mdx
@@ -11,11 +11,10 @@ To configure Appsmith to use [Azure Active Directory (Azure AD)](https://portal.
 
 ## Prerequisites
 
-1. Before setting up Single Sign-On (SSO), ensure that you have already configured a [custom domain](/getting-started/setup/instance-configuration/custom-domain) for your instance.
-
-2. In Appsmith, go to **Admin Settings > Authentication** and click **Enable** on  **SAML 2.0**.
-
-3. Copy the **Redirect URL** and **Entity URL** from the **SAML 2.0** configuration page to add them later in the Active Directory settings. 
+1. A self-hosted Appsmith instance. See the [installation guides](/getting-started/setup/installation-guides) for installing Appsmith.
+2. Before setting up Single Sign-On (SSO), ensure that you have already configured a [custom domain](/getting-started/setup/instance-configuration/custom-domain) for your instance.
+3. In Appsmith, go to **Admin Settings > Authentication** and click **Enable** on  **SAML 2.0**.
+4. Copy the **Redirect URL** and **Entity URL** from the **SAML 2.0** configuration page to add them later in the Active Directory settings. 
 
 <figure>
   <img src="/img/SAML-config_appsmith.png" style= {{width:"600px", height:"auto"}} alt="SAML configurations"/>

--- a/website/docs/getting-started/setup/instance-configuration/authentication/security-assertion-markup-language-saml/auth0.mdx
+++ b/website/docs/getting-started/setup/instance-configuration/authentication/security-assertion-markup-language-saml/auth0.mdx
@@ -11,10 +11,10 @@ import TabItem from '@theme/TabItem';
 To configure Appsmith to use [Auth0](https://auth0.com/) as a SAML provider, follow the steps below:
 
 ## Prerequisites
-
-1. Before setting up Single Sign-On (SSO), ensure that you have already configured a [custom domain](/getting-started/setup/instance-configuration/custom-domain) for your instance.
-2. In Appsmith, go to **Admin Settings** > **Authentication** and click **Enable** on  **SAML 2.0**.
-3. Copy the **Redirect URL** from the **SAML 2.0** configuration page to add it later in the Auth0 settings. 
+1. A self-hosted Appsmith instance. See the [installation guides](/getting-started/setup/installation-guides) for installing Appsmith.
+2. Before setting up Single Sign-On (SSO), ensure that you have already configured a [custom domain](/getting-started/setup/instance-configuration/custom-domain) for your instance.
+3. In Appsmith, go to **Admin Settings** > **Authentication** and click **Enable** on  **SAML 2.0**.
+4. Copy the **Redirect URL** from the **SAML 2.0** configuration page to add it later in the Auth0 settings. 
 
 <figure>
   <img src="/img/SAML-config_appsmith.png" style= {{width:"600px", height:"auto"}} alt="SAML configurations"/>

--- a/website/docs/getting-started/setup/instance-configuration/authentication/security-assertion-markup-language-saml/okta.mdx
+++ b/website/docs/getting-started/setup/instance-configuration/authentication/security-assertion-markup-language-saml/okta.mdx
@@ -11,11 +11,10 @@ To configure Appsmith to use [Okta](https://www.okta.com/) as a SAML provider, f
 
 ## Prerequisites
 
-1. Before setting up Single Sign-On (SSO), ensure that you have already configured a [custom domain](/getting-started/setup/instance-configuration/custom-domain) for your instance.
-
-2. In Appsmith, go to **Admin Settings** > **Authentication** and click **Enable** on  **SAML 2.0**.
-
-3. Copy the **Redirect URL** and **Entity ID** from the **SAML 2.0** configuration page to add them later in the Okta settings. 
+1. A self-hosted Appsmith instance. See the [installation guides](/getting-started/setup/installation-guides) for installing Appsmith.
+2. Before setting up Single Sign-On (SSO), ensure that you have already configured a [custom domain](/getting-started/setup/instance-configuration/custom-domain) for your instance.
+3. In Appsmith, go to **Admin Settings** > **Authentication** and click **Enable** on  **SAML 2.0**.
+4. Copy the **Redirect URL** and **Entity ID** from the **SAML 2.0** configuration page to add them later in the Okta settings. 
 
 <figure>
   <img src="/img/SAML-config_appsmith.png" style= {{width:"600px", height:"auto"}} alt="SAML configurations"/>

--- a/website/docs/getting-started/setup/instance-configuration/authentication/security-assertion-markup-language-saml/ping-identity.mdx
+++ b/website/docs/getting-started/setup/instance-configuration/authentication/security-assertion-markup-language-saml/ping-identity.mdx
@@ -12,11 +12,10 @@ To configure Appsmith to use [Ping Identity](https://www.pingidentity.com/en.htm
 
 ## Prerequisites
 
-1. Before setting up Single Sign-On (SSO), ensure that you have already configured a [custom domain](/getting-started/setup/instance-configuration/custom-domain) for your instance.
-
-2. In Appsmith, go to **Admin Settings** > **Authentication** and click **Enable** on  **SAML 2.0**.
-
-2. Copy the **Redirect URL** and **Entity ID** from the **SAML 2.0** configuration page to add them later in the Ping Identity settings. 
+1. A self-hosted Appsmith instance. See the [installation guides](/getting-started/setup/installation-guides) for installing Appsmith.
+2. Before setting up Single Sign-On (SSO), ensure that you have already configured a [custom domain](/getting-started/setup/instance-configuration/custom-domain) for your instance.
+3. In Appsmith, go to **Admin Settings** > **Authentication** and click **Enable** on  **SAML 2.0**.
+4. Copy the **Redirect URL** and **Entity ID** from the **SAML 2.0** configuration page to add them later in the Ping Identity settings. 
 
 <figure>
   <img src="/img/SAML-config_appsmith.png" style= {{width:"600px", height:"auto"}} alt="SAML configurations"/>

--- a/website/docs/getting-started/setup/instance-configuration/custom-domain/README.md
+++ b/website/docs/getting-started/setup/instance-configuration/custom-domain/README.md
@@ -9,8 +9,9 @@ This page explains how to set up SSL for your custom domain on the Appsmith inst
 
 ## Prerequisites
 Before configuring SSL for your custom domain, make sure you have the following:
-1. A domain name - You can get a custom domain from popular providers like [GoDaddy](https://in.godaddy.com/help/create-a-subdomain-4080), [Amazon Route 53](https://aws.amazon.com/premiumsupport/knowledge-center/create-subdomain-route-53/), [Digital Ocean](https://www.digitalocean.com/docs/networking/dns/how-to/add-subdomain/), [NameCheap](https://www.namecheap.com/support/knowledgebase/article.aspx/9776/2237/how-to-create-a-subdomain-for-my-domain), and [Domain.com](https://www.domain.com/help/article/domain-management-how-to-update-subdomains).
-2. Ports 80 and 443 are open and accessible.
+1. A self-hosted Appsmith instance. See the [installation guides](/getting-started/setup/installation-guides) for installing Appsmith.
+2. A domain name - You can get a custom domain from popular providers like [GoDaddy](https://in.godaddy.com/help/create-a-subdomain-4080), [Amazon Route 53](https://aws.amazon.com/premiumsupport/knowledge-center/create-subdomain-route-53/), [Digital Ocean](https://www.digitalocean.com/docs/networking/dns/how-to/add-subdomain/), [NameCheap](https://www.namecheap.com/support/knowledgebase/article.aspx/9776/2237/how-to-create-a-subdomain-for-my-domain), and [Domain.com](https://www.domain.com/help/article/domain-management-how-to-update-subdomains).
+3. Ports 80 and 443 are open and accessible.
 
 You can use your custom domain with the HTTP protocol, even if you haven't set up an SSL certificate yet. However, it's recommended to configure SSL to ensure secure connections by using HTTPS. You can either set up [SSL using Let's Encrypt](#configure-ssl-with-lets-encrypt) or add a [custom certificate](#configure-custom-ssl) to secure your connections.
 

--- a/website/docs/getting-started/setup/instance-configuration/custom-domain/configure-tls.mdx
+++ b/website/docs/getting-started/setup/instance-configuration/custom-domain/configure-tls.mdx
@@ -11,6 +11,7 @@ This page provides steps to configure TLS for your Appsmith deployment using a f
 ## Prerequisites
 * A domain name.
 * Ports 80 and 443 are open and accessible.
+* A self-hosted Appsmith instance on Kubernetes. See the [Kubernetes installation guide](/getting-started/setup/installation-guides/kubernetes) for installing Appsmith.
 * [Publish Appsmith Kubernetes installation to the internet](/getting-started/setup/installation-guides/kubernetes/publish-appsmith-online).
 
 ## Configure TLS (HTTPS) with Let's Encrypt

--- a/website/docs/getting-started/setup/instance-configuration/custom-mongodb-redis.md
+++ b/website/docs/getting-started/setup/instance-configuration/custom-mongodb-redis.md
@@ -14,6 +14,7 @@ To use external MongoDB with Appsmith v1.9.0 onwards, you need MongoDB version 5
 Follow the steps below to configure Appsmith to use an external MongoDB instance:
 
 ### Prerequisites
+* A self-hosted Appsmith instance. See the [installation guides](/getting-started/setup/installation-guides) for installing Appsmith.
 * Ensure that your external MongoDB has a replica set configuration in place. Connect to your database as an admin user and run [rs.initiate()](https://docs.mongodb.com/manual/reference/method/rs.initiate/). Note that if you're using MongoDB Cloud, the replica set configuration is already set up for you.
 * Ensure the MongoDB user account has `readWrite` and `clusterMonitor` roles assigned.
 

--- a/website/docs/getting-started/setup/instance-configuration/disable-intercom.md
+++ b/website/docs/getting-started/setup/instance-configuration/disable-intercom.md
@@ -3,7 +3,7 @@ sidebar_position: 4
 ---
 # Disable Intercom
 
-To disable Intercom on your self-hosted instance, set the key `APPSMITH_INTERCOM_APP_ID` to an empty string and `APPSMITH_DISABLE_INTERCOM` to 'true' in your `docker.env` file, and restart your instance.
+To turn off the intercom on your self-hosted instance, set the key `APPSMITH_INTERCOM_APP_ID` to an empty string and `APPSMITH_DISABLE_INTERCOM` to 'true' in your `docker.env` file, and restart your instance.
 
 Example:
 

--- a/website/docs/getting-started/setup/instance-configuration/disable-intercom.md
+++ b/website/docs/getting-started/setup/instance-configuration/disable-intercom.md
@@ -3,7 +3,7 @@ sidebar_position: 4
 ---
 # Disable Intercom
 
-To disable Intercom on your instance, please set the key `APPSMITH_INTERCOM_APP_ID` to an empty string and `APPSMITH_DISABLE_INTERCOM` to 'true' in your `docker.env` file, and restart your instance.
+To disable Intercom on your self-hosted instance, set the key `APPSMITH_INTERCOM_APP_ID` to an empty string and `APPSMITH_DISABLE_INTERCOM` to 'true' in your `docker.env` file, and restart your instance.
 
 Example:
 

--- a/website/docs/getting-started/setup/instance-configuration/google-maps.mdx
+++ b/website/docs/getting-started/setup/instance-configuration/google-maps.mdx
@@ -11,6 +11,7 @@ This page provides instructions to integrate Google Maps to use the [Map Widget]
 
 ## Prerequisites
 
+- A self-hosted Appsmith instance. See the [installation guides](/getting-started/setup/installation-guides) for installing Appsmith.
 - A [Google Cloud](https://www.google.com/aclk?sa=l&ai=DChcSEwi0373S7OX_AhW7Vn0KHT5BD30YABABGgJzZg&sig=AOD64_3YNMGHJAu3vGJmjK-vrl8qni2BxA&q&adurl&ved=2ahUKEwjjs7XS7OX_AhWy3TgGHWtHAkYQ0Qx6BAgIEAE) account. 
 
 ## Generate Google Maps API key 

--- a/website/docs/getting-started/setup/instance-management/README.mdx
+++ b/website/docs/getting-started/setup/instance-management/README.mdx
@@ -6,7 +6,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 # Instance Management
-One of the key features of Appsmith is its instance management capabilities. This page is a gateway to various management tasks you can perform on your Appsmith instance. 
+One of the key features of Appsmith is its instance management capabilities. This page is a gateway to various management tasks you can perform on your self-hosted instance. 
 
 You can manage your instance by:
 * Creating backups for the Appsmith instance and database

--- a/website/docs/getting-started/setup/instance-management/appsmithctl.mdx
+++ b/website/docs/getting-started/setup/instance-management/appsmithctl.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use the `appsmithctl` to backup and restore the Appsmith instance and database.
+description: Use the `appsmithctl` to backup and restore the self-hosted instance and database.
 ---
 
 import Tabs from '@theme/Tabs';
@@ -7,7 +7,7 @@ import TabItem from '@theme/TabItem';
 
 # Backup and Restore
 
-Appsmith comes with the `appsmithctl` command line utility. You can use the command line to interact with and manage your Appsmith instance. For example, back up and restore your Appsmith instance and database. This page provides steps to run the backup and restore commands.
+Appsmith comes with the `appsmithctl` command line utility. You can use the command line to interact with and manage your self-hosted instance. For example, back up and restore your Appsmith instance and database. This page provides steps to run the backup and restore commands.
 
 <VideoEmbed host="youtube" videoId="tlbK8Cke3sw" title="How To Use Appsmithctl For Instance Management" caption="How to use Appsmithctl for Docker"/>
 
@@ -31,7 +31,7 @@ Subcommands allow you to trigger different operations like exporting or importin
 
 ## Prerequisites
 
-- The Appsmith instance should be up and running. If you haven't already installed Appsmith, refer to the [Installation guides](/getting-started/setup/installation-guides).
+- The self-hosted instance should be up and running. If you haven't already installed Appsmith, refer to the [Installation guides](/getting-started/setup/installation-guides).
 - Access to execute `docker-compose` or `kubectl` commands
 
 ## Backup instance

--- a/website/docs/getting-started/setup/instance-management/maintenance-window.md
+++ b/website/docs/getting-started/setup/instance-management/maintenance-window.md
@@ -4,7 +4,7 @@ description: Instructions to schedule automatic updates for your Appsmith instan
 ---
 # Schedule Automatic Updates
 
-The page gives you steps to schedule automatic updates for your Appsmith instance.
+The page gives you steps to schedule automatic updates for your self-hosted instance.
 
 ## Schedule automatic updates for Docker installation
 You can define a time slot for automatic updates using a `cron` expression in the `--schedule` argument.

--- a/website/docs/getting-started/setup/instance-management/maintenance-window.md
+++ b/website/docs/getting-started/setup/instance-management/maintenance-window.md
@@ -10,7 +10,7 @@ The page gives you steps to schedule automatic updates for your self-hosted inst
 You can define a time slot for automatic updates using a `cron` expression in the `--schedule` argument.
 
 Follow these steps to update the `auto_update` container:
-1. Go to the location where `docker-compose.yml` file is located
+1. Go to the location where the `docker-compose.yml` file is located
 2. Open the ``docker-compose.yml` file
 3. Update the `command` attribute under `auto_update` as shown below:
 

--- a/website/docs/getting-started/setup/instance-management/supervisor.md
+++ b/website/docs/getting-started/setup/instance-management/supervisor.md
@@ -3,7 +3,7 @@ sidebar_position: 1
 ---
 # Monitor Processes
 
-The container runs multiple processes, including the Appsmith server, Nginx, MongoDB, etc., inside a single Docker container. These processes are started, managed, and monitored by [Supervisor](http://supervisord.org/).
+The container runs multiple processes, including the Appsmith server, Nginx, MongoDB, etc., inside a single Docker container. These processes are started, managed, and monitored by [Supervisor](http://supervisord.org/) for your self-hosted instance.
 
 Supervisor provides:
 * [Web Interface](#web-interface)


### PR DESCRIPTION
- Added self-hosted instance to either prerequisites or to the document introduction.

## Checklist
I have:
- [ ] run the content through Grammarly
- [ ] linked to sample apps when relevant
- [ ] added the meta description for each page in the PR
- [ ] minimized the callouts and added only when necessary
- [ ] added the `queryString` parameter to the Tabs (if used)
- [ ] masked PII in images. For example, login credentials, account details, and more
- [ ] added images only when necessary
- [ ] deleted the images that are no longer used for the updated pages in the PR
- [ ] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [ ] used the `<figure/>` tag instead of a markdown representation for images
- [ ] added the `<figcaption/>` tag to add a caption to the image
- [ ] added the `alt` attribute in the `<img/>` tag
- [ ] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [ ] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.