### PR TITLE
Added errors and limitation in iframe docs

### DIFF
--- a/website/docs/reference/widgets/iframe.md
+++ b/website/docs/reference/widgets/iframe.md
@@ -379,6 +379,19 @@ With this setup, users can edit the code in the code editor, and when the submit
   <figcaption align = "center"><i>Custom Code Editor</i></figcaption>
 </figure>
 
+### Current Limitations
+With the iframe model, you cannot add widgets which rely on underlying platform capabilities like. For example, but not limited to - 
+1. A widget behaving like a canvas or parent to drop more widgets. Eg - Container
+2. A widget which acts like a modal or a drawer on top of the existing canvas
+3. Use the auto height or responsiveness features in your iframe
+
+### Common errors
+
+Within Appsmith currently, html formatting and error parsing is not available. So if you have any html or css errors in the src doc field Appsmith cannot identify them. 
+
+It’s very easy to run into errors when configuring code in the src doc field. 
+
+Our advise for you is to use an external service like code sandbox or host your own code if the widget functionality is complex and frequently updates to maintain your solution better.
 
 
 ## Send Message Between App and Iframe


### PR DESCRIPTION
## Checklist
I have:
- [ ] run the content through Grammarly
- [ ] linked to sample apps when relevant
- [ ] added the meta description for each page in the PR
- [ ] minimized the callouts and added only when necessary
- [ ] added the `queryString` parameter to the Tabs (if used)
- [ ] masked PII in images. For example, login credentials, account details, and more
- [ ] added images only when necessary
- [ ] deleted the images that are no longer used for the updated pages in the PR
- [ ] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [ ] used the `<figure/>` tag instead of a markdown representation for images
- [ ] added the `<figcaption/>` tag to add a caption to the image
- [ ] added the `alt` attribute in the `<img/>` tag
- [ ] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [ ] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.