### PR TITLE
fix: Update GraphQL to Diataxis

### DIFF
--- a/website/docs/connect-data/reference/graphql.md
+++ b/website/docs/connect-data/reference/graphql.md
@@ -18,10 +18,10 @@ The following section is a reference guide that provides a complete description 
 <dl>
   <dt><b>URL</b></dt>
   <dd>
-  
-The URL of the GraphQL service to query. For a guide about connecting to a local APIs, see [Connect Local Database]("/connect-data/how-to-guides/how-to-work-with-local-apis-on-appsmith").
 
-</dd><br/>
+The URL of the GraphQL service to query. For a guide about connecting to a local APIs, see [Connect Local Database](/connect-data/how-to-guides/how-to-work-with-local-apis-on-appsmith).
+
+  </dd>
 
   <dt><b>Headers</b></dt>
   <dd>
@@ -42,7 +42,7 @@ Key-value pairs that should be passed as parameters in the URL of your HTTP requ
   
 When enabled, you can enter a secret string of at least 32 characters in the <b>Session Details Signature Key</b> field. Every API call made to this datasource then includes an additional header, <code>X-Appsmith-Signature</code>, whose value is a <a href="https://jwt.io">JSON Web Token (JWT)</a> signed with a signature created from your secret string. This can be used to help prove the integrity and authenticity of your requests originating from Appsmith.
 
-  </dd><br/>timestamp
+  </dd><br/>
 
 <dt><b>Authentication Type</b></dt>
   <dd>Sets the method used to authenticate requests. Configure details under the <b>Authentication</b> dropdown after selecting your Authentication Type.</dd><br/>
@@ -53,11 +53,12 @@ When enabled, you can enter a secret string of at least 32 characters in the <b>
       <li>
         <b>OAuth 2.0:</b> Enables several fields for configuring an OAuth 2.0 integration.
         <ul>
-          <li><b>Grant Type:</b> An authorization grant type is a secured representation of the owner’s authorization presented in exchange for an access token. <br/>
+          <li><b>Grant Type:</b> An authorization grant type is a secured representation of the owner’s authorization presented in exchange for an access token.</li>
           <i>Options:</i>
-          <b>Authorization Code</b> : An authorization code is a temporary code authorized by an authorization server. You can get an access token in exchange for an authorization code. Once you get an access token, you can use it to access the resources or perform actions on behalf of the user.<br/>
-         <b>Client Credentials</b>.
-         </li>
+          <ul>
+            <li><b>Authorization Code</b> : An authorization code is a temporary code authorized by an authorization server. You can get an access token in exchange for an authorization code. Once you get an access token, you can use it to access the resources or perform actions on behalf of the user.</li>
+            <li><b>Client Credentials</b>.</li>
+          </ul>
           <li><b>Add Access Token To:</b> Sets whether the access token is sent as a <b>Request Header</b> or as a query parameter (<b>Request URL</b>).</li>
           <li><b>Header Prefix:</b> When the access token is sent as a header, this sets a string to prefix the access token. A common example is <code>Bearer</code>.</li>
           <li><b>Access Token URL:</b> The endpoint on the authentication server that is used to exchange the authorization code for an access token.</li>

--- a/website/docs/connect-data/reference/graphql.md
+++ b/website/docs/connect-data/reference/graphql.md
@@ -1,47 +1,104 @@
 ---
 sidebar_position: 8
+description: Connect Appsmith to a GraphQL API and create queries.
 ---
 # GraphQL
 
-This page describes how to connect your application to a GraphQL API and use queries to manage its content.
+This page provides information for connecting your application to a GraphQL API and for using queries to manage its content.
 
-<VideoEmbed host="youtube" videoId="KPLrbp-4Y6E" title="How To Build Apps With GraphQL APIs feat. Hasura" caption=""/>
+## Connection parameters
 
-## Connect to GraphQL
-
-To add a GraphQL datasource, click the (**+**) sign in the **Explorer** tab next to **Datasources**. On the next screen, select the **Authenticated GraphQL API** button. Your datasource is created and you are taken to a screen to configure its settings.
+The following section is a reference guide that provides a complete description of all the parameters to connect to a GraphQL API.
 
 <figure>
   <img src="/img/graphql-datasource-config.png" style={{width: "100%", height: "auto"}} alt="Configuring a GraphQL datasource" />
   <figcaption align="center"><i>Configuring a GraphQL datasource.</i></figcaption>
 </figure>
 
-:::tip
-If you want to connect to a local api, you can use a service like ngrok to expose it. For more information, see [How to connect to local api on Appsmith](/connect-data/how-to-guides/how-to-work-with-local-apis-on-appsmith).
-:::
+<dl>
+  <dt><b>URL</b></dt>
+  <dd>
+  
+The URL of the GraphQL service to query. For a guide about connecting to a local APIs, see [Connect Local Database]("/connect-data/how-to-guides/how-to-work-with-local-apis-on-appsmith").
 
-To connect to a GraphQL API endpoint, Appsmith needs the following parameters. All required fields are suffixed with an asterisk (*).
+</dd><br/>
 
-**URL*:** provide the URL of the GraphQL service to query. If you are on a self-hosted instance and connecting to an API on `localhost`, use `host.docker.internal` on Windows and macOS hosts and `172.17.0.1` on Linux hosts to access services running on the host machine from within the container.
+  <dt><b>Headers</b></dt>
+  <dd>
+  
+Key-value pairs to include in the header section of your HTTP requests.
 
-**Headers:**  provide any header key-value pairs that you'd like to include in your HTTP requests.
+  </dd><br/>
 
-**Query Parameters:** provide any parameters that should be passed as key-value pairs in the URL of your requests.
+  <dt><b>Query parameters</b></dt>
+  <dd>
+  
+Key-value pairs that should be passed as parameters in the URL of your HTTP requests.
 
-**Send Appsmith signature header:** choose whether to include a special token in your request headers to help prove authenticity and integrity. For more information, read the [Authenticated API reference](/connect-data/reference/authenticated-api).
+  </dd><br/>
 
-**Authentication Type:** choose the style of authentication to use for your queries. For more information, read the [Authenticated API reference](/connect-data/reference/authenticated-api).
+  <dt><b>Send Appsmith signature header</b></dt>
+  <dd>
+  
+When enabled, you can enter a secret string of at least 32 characters in the <b>Session Details Signature Key</b> field. Every API call made to this datasource then includes an additional header, <code>X-Appsmith-Signature</code>, whose value is a <a href="https://jwt.io">JSON Web Token (JWT)</a> signed with a signature created from your secret string. This can be used to help prove the integrity and authenticity of your requests originating from Appsmith.
 
-**Use self-signed certificate:** choose whether to upload your own self-signed certificate for encryption. For more information, read the [Authenticated API reference](/connect-data/reference/authenticated-api).
+  </dd><br/>timestamp
+
+<dt><b>Authentication Type</b></dt>
+  <dd>Sets the method used to authenticate requests. Configure details under the <b>Authentication</b> dropdown after selecting your Authentication Type.</dd><br/>
+  <dd><i>Options:</i>
+    <ul>
+      <li><b>None:</b> Does not send any authentication information.</li>
+      <li><b>Basic:</b> Expects a <b>Username</b> and <b>Password</b>, which are sent in each request as a base64-encoded string in the request's Authorization header.</li>
+      <li>
+        <b>OAuth 2.0:</b> Enables several fields for configuring an OAuth 2.0 integration.
+        <ul>
+          <li><b>Grant Type:</b> An authorization grant type is a secured representation of the owner’s authorization presented in exchange for an access token. <br/>
+          <i>Options:</i>
+          <b>Authorization Code</b> : An authorization code is a temporary code authorized by an authorization server. You can get an access token in exchange for an authorization code. Once you get an access token, you can use it to access the resources or perform actions on behalf of the user.<br/>
+         <b>Client Credentials</b>.
+         </li>
+          <li><b>Add Access Token To:</b> Sets whether the access token is sent as a <b>Request Header</b> or as a query parameter (<b>Request URL</b>).</li>
+          <li><b>Header Prefix:</b> When the access token is sent as a header, this sets a string to prefix the access token. A common example is <code>Bearer</code>.</li>
+          <li><b>Access Token URL:</b> The endpoint on the authentication server that is used to exchange the authorization code for an access token.</li>
+          <li><b>Client ID:</b> The identifier issued to the client by the OAuth provider during app registration.</li>
+          <li><b>Client Secret:</b> The secret string issued to the client by the OAuth provider during app registration.</li>
+          <li><b>Scopes:</b> Sets the requested scopes that are requested. This field can have multiple comma-separated values.</li>
+          <li><b>Client Authorization:</b> Sends the client secret either in the request body as <code>client_id</code> and <code>client_secret</code> parameters or within the headers encoded as basic HTTP authentication.</li>
+          <li><b>Authorization URL:</b> The endpoint on the authentication server that is used to request authentication for the client.</li>
+          <li><b>Redirect URL:</b> The URL that the OAuth server should redirect to.</li>
+          <li><b>Custom Authentication Parameters:</b> User-defined key/value pairs to be encoded and sent as authentication parameters.</li>
+          <li><b>Audience:</b> Expects a URL, specifies the intended audience for the OAuth access token.</li>
+          <li><b>Resource:</b> Expects a URL, specifies an application to act as a resource server.</li>
+        </ul>
+      </li>
+      <li><b>API Key:</b> Sends a key/value pair which is sent as a base64-encoded string in the request's Authorization header. You can specify the key's prefix, as well as choose whether it's sent in the request header or the query params.</li>
+      <li><b>Bearer Token:</b> Sends a bearer token value as a base64-encoded string in the request's Authorization header. If you are using OIDC protocol to log in to your instance, you can use the <a href="/getting-started/setup/instance-configuration/authentication/json-web-tokens-jwt#access-token">access token</a> of the logged-in user as a bearer token.</li>
+    </ul>
+  </dd><br/>
+
+<dt><b>Use self-signed certificate</b></dt>
+  <dd>
+  
+When enabled, you can upload your own self-signed certificate for accessing your endpoint. These can be useful for accessing your API without relying on external agnecies to issue certificates for authenticating the origin of your requests.
+
+  </dd>
+  <dd>
+  
+This information needs to be provided in .PEM (_Privacy Enhanced Mail_) format. The certificate information is stored securely in an encrypted format in the database.
+
+  </dd>
+
+</dl>
 
 ## Create queries
+
+The following section is a reference guide that provides a complete description of all the read and write operation commands with their parameters to create GraphQL queries.
 
 <figure>
   <img src="/img/graphql-query-config.png" style={{width: "100%", height: "auto"}} alt="Creating a GraphQL query." />
   <figcaption align="center"><i>Creating a GraphQL query.</i></figcaption>
 </figure>
-
-You can write queries to fetch or write data by selecting the **+ New Query**  button on the Authenticated GraphQL datasource page, or by clicking (**+**) next to **Queries/JS** in the **Explorer** tab and selecting your GraphQL datasource. You'll be brought to a new query screen where you can write queries.
 
 GraphQL queries are written in the **Body** tab of the query screen. Use the **Query** window to construct your query or mutation, and the adjacent **Query Variables** window to add any variables to map into your query.
 
@@ -49,297 +106,113 @@ GraphQL queries are written in the **Body** tab of the query screen. Use the **Q
 
 Use a query like the one below to retrieve records from your datasource.
 
+In the example below, `UsersTable` is the name of a Table widget used to search for a user by name and display the results. This query uses `limit` and `offset` to implement [**server-side pagination**](/reference/widgets/table#server-side-pagination).
+
+In the **Query** window:
+
 ```javascript
-query GetUserPosts {
-  user (name: "<user-name>") {
-    posts (last: 5) {
-      id
-      title
-      slug
-    }
+query GetUserData (name: String!, $limit: Int!, $offset: Int!) {
+  user (name: $name, first: $first, offset: $offset) {
+    id
+    name
+    email
+    date_of_birth
   }
 }
 ```
 
-Depending on the schema of the API you are querying, it's highly recommended to use arguments like `first`, `last`, `limit`, etc. to prevent querying huge numbers of records at once. The preceding example used `last: 5` to only return the most recent 5 results.
+In the **Query variables** window:
 
----
-
-#### Example
-
-> Fetch issues from a sample `users` API, 10 records at a time, and put them into a Table widget `UsersTable` with columns for `name`, `id`, and `email`.
-
-**Setup:** to access the sample GraphQL API, create a **GraphQL API** datasource with the following URL:
-
-```https://viable-mosquito-19.hasura.app/v1/graphql```
-
-Then, create a query called `FetchUsers` based on your GraphQL datasource as a `POST` type request.
-
-* Create a [Table widget](/reference/widgets/table) on the canvas called `UsersTable`.
-
-* In the **Body** tab of your `FetchUsers` query page, fill in your query in the main **Query** box, and add any variables in JSON format in the adjacent **Query Variables** box.
-
-  ```javascript
-  // In the QUERY window:
-  query GetUsers ($limit: Int!, $offset: Int!){
-    users(limit: $limit, offset: $offset){
-      name
-      id
-      email
-    }
-  }
-  ```
-
-* In the **Pagination** tab of your query:
-  * Select **Paginate via Cursor based**
-  * Set **Limit Variable** to `limit`
-  * Set **Limit Value** to `{{ UsersTable.pageSize }}`
-  * Set **Offset Variable** to `offset`
-  * Set **Offset Value** to `{{ UsersTable.pageOffset }}`
-
-* In the **Table Data** property of your Table widget, bind the result of your query:
-
-  ```javascript
-  // in the Table Data property of IssueTable
-  {{ FetchUsers.data.data.users }}
-  ```
-
-* In the Table's properties, turn on **Server Side Pagination**
-  * In the **onPageChange** event that appears, choose to execute the `FetchUsers` query.
-
-Now your table should fill with data when the query is run, and the page buttons in the table header cycle through the records.
+```javascript
+{
+  "name": {{ UsersTable.searchText }},
+  "limit": {{ UsersTable.pageSize }},
+  "offset": {{ UsersTable.pageOffset }}
+}
+```
 
 ### Insert a record
 
 Use an insert mutation to add new records to your GraphQL datasource.
 
+In the example below, `CreateUserForm` is the name of a [Form widget](/reference/widgets/form) used to collect input for the new record.
+
+In the **Query** window:
+
 ```javascript
-mutation CreatePost {
-  createPost(data: {author: "Amal", title: ... }) {
-    post {
-      id
-      author
-      title
-    }
+mutation CreateUser (name: String!, email: String!, date_of_birth: String!){
+  createUser(name: $name, email: $email, date_of_birth: $date_of_birth) {
+    id
+    name
+    email
+    date_of_birth
   }
 }
 ```
 
-The `createPost` method takes the new record data, and once the request is processed, the API responds with the new `post{...}` data to confirm the operation.
+In the **Query variables** window:
 
----
-
-#### Example
-
-> Create a new user in a sample `users` API.
-
-**Setup:** to access the sample GraphQL API, create a **GraphQL API** datasource with the following URL:
-
-```https://viable-mosquito-19.hasura.app/v1/graphql```
-
-Then, create a query called `CreateUser` based on your GraphQL datasource as a `POST` type request.
-
-* To gather data for the new record, create a [JSON Form](/reference/widgets/json-form) on the canvas called `NewUserForm`. Add **Source Data** to the JSON Form to create input fields:
-
-  ```javascript
-  {
-    name: "",
-    email: ""
-  }
-  ```
-
-* In the JSON Form's Submit [button](/reference/widgets/button) properties, configure the **onClick** event to execute your query:
-
-  ```javascript
-  // Submit button's onClick event
-  {{ CreateUser.run() }}
-  ```
-
-* Once these form fields are filled out, you can add their values to your query in the **Body** tab like below:
-
-  ```javascript
-  // In the QUERY window
-  mutation CreateUser (
-    $name: String!,
-    $email: String!
-  ) {
-    insert_users_one(
-			object: {
-				name: $name,
-				email: $email				
-			}
-		)
-		{
-			name,
-			email
-		}
-  }
-  ```
-
-  ```javascript
-  // In the QUERY VARIABLES window
-  {
-    "name": {{ NewUserForm.formData.name }},
-    "email": {{ NewUserForm.formData.email }}
-  }
-  ```
-
-When the Submit button is clicked, your query is executed and the new record is inserted. If it is successful, you should receive the new record's `name` and `email` fields back in response.
+```javascript
+{
+  "name": {{ CreateUserForm.data.name }},
+  "email": {{ CreateUserForm.data.email }},
+  "date_of_birth": {{ CreateUserForm.data.date_of_birth }}
+}
+```
 
 ### Update a record
 
 Use an update mutation to modify an existing record in your dataset.
 
+In the example below, `UpdateUserForm` is the name of a [Form widget](/reference/widgets/form) used to collect input for the new record.
+
+In the **Query** window:
+
 ```javascript
-mutation UpdatePost {
-  updatePost(data: {id: "<id>", title: "New Title" }) {
-    post {
-      id
-      author
-      title
-    }
+mutation UpdateUser (id: Int!, name: String, email: String, date_of_birth: String){
+  updateUser(id: $id, name: $name, email: $email, date_of_birth: $date_of_birth) {
+    id
+    name
+    email
+    date_of_birth
   }
 }
 ```
 
-The `updatePost` method uses the new values to update the dataset, and once the request is processed, the API responds with the new `post{...}` data to confirm the operation.
+In the **Query variables** window:
 
----
-
-#### Example
-
-> Update an existing user in a sample `users` API.
-
-**Setup:** to access the sample `users` GraphQL API, create a **GraphQL API** datasource with the following URL:
-
-```https://viable-mosquito-19.hasura.app/v1/graphql```
-
-Then, create a query called `UpdateUser` based on your GraphQL datasource as a `POST` type request.
-
-* Start by [fetching existing users](#fetch-records) from your repository into a Table widget `UsersTable` with a query called `FetchUsers`. You'll need this to get your existing user data.
-
-* To gather new values for the record, create a [JSON Form](/reference/widgets/json-form) on the canvas called `UpdateUserForm`. Add **Source Data** to the JSON Form to create input fields, referencing the records in your `UsersTable` to help pre-fill the fields:
-
-  ```javascript
-  {{
-    {
-      id: {{ UsersTable.selectedRow.id }} // this value should not be changed
-      name: {{ UsersTable.selectedRow.name }},
-      email: {{ UsersTable.selectedRow.email }}
-    }
-  }}
-  ```
-
-* In the JSON Form's Submit [button](/reference/widgets/button) properties, configure the **onClick** event to execute your query:
-
-  ```javascript
-  // Submit button's onClick event
-  {{ UpdateUser.run(() => ListUsers.run(), () => {}) }}
-  ```
-  * The **onSuccess** callback is used above to refresh your table data after the operation is complete.
-
-* Once these form fields are filled out, you can add their values to your query in the **Body** tab like below.
-  * This code selects a record by its primary key (`id`), and uses `_set` to show which values to update on the record.
-
-  ```javascript
-  // In the QUERY window
-  mutation UpdateUser (
-    $id: Int!,
-    $name: String,
-    $email: String
-  ) {
-    update_users_by_pk(
-			pk_columns: {
-				id: $id
-			},
-			_set: {
-				name: $name,
-				email: $email
-			}
-		)
-		{
-      id,
-			name,
-			email
-		}
-  }
-  ```
-
-  ```javascript
-  // In the QUERY VARIABLES window
-  {
-    "id": {{ UsersTable.selectedRow.id }},
-    "name": {{ UpdateUserForm.formData.name }},
-    "email": {{ UpdateUserForm.formData.email }}
-  }
-  ```
-
-When the Submit button is clicked, your query is executed and the record is updated with new values. If the operation is successful, you'll receive a response with the record's `id`, `name`, and `value` as confirmation.
+```javascript
+{
+  "id": {{ UpdateUserForm.data.id }}
+  "name": {{ UpdateUserForm.data.name }},
+  "email": {{ UpdateUserForm.data.email }},
+  "date_of_birth": {{ UpdateUserForm.data.date_of_birth }}
+}
+```
 
 ### ​Delete a record​
 
 Use a delete mutation to delete an existing record from your dataset.
 
+In the example below, `UsersTable` is the name of a Table widget used to display the results from a previous query.
+
+In the **Query** window:
+
 ```javascript
-mutation DeletePost {
-  deletePost(data: {id: "<id>"}) {
-    post {
-      id
-      author
-      title
-    }
+mutation DeleteUser (id: Int!){
+  deleteUser(id: $id) {
+    id
+    name
+    email
+    date_of_birth
   }
 }
 ```
 
-The `deletePost` method uses the passed values to locate the record to delete, and once the request is processed, the API responds with the deleted `post{...}` data to confirm the operation.
+In the **Query variables** window:
 
----
-
-#### Example
-
-> Delete an existing user in a sample `users` API.
-
-**Setup:** to access the sample `users` GraphQL API, create a **GraphQL API** datasource with the following URL:
-
-```https://viable-mosquito-19.hasura.app/v1/graphql```
-
-Then, create a query called `DeleteUser` based on your GraphQL datasource as a `POST` type request.
-
-* Start by [fetching existing users](#fetch-records) from your repository into a Table widget `UsersTable` with a query called `FetchUsers`. You'll need this to get your existing user data.
-
-* Create a custom **Button-type column** in the Table widget update its **Label** to "Delete." Set the button's **onClick** event to execute your `DeleteUser` query:
-
-  ```javascript
-  // in the Delete button's onClick event
-  {{ DeleteUser.run(() => ListUsers.run(), () => {}) }}
-  ```
-  * The **onSuccess** callback is used above to refresh your table data after the operation is complete.
-
-* To delete a record, pass its `id` in your query:
-
-  ```javascript
-  // In the QUERY window
-  mutation DeleteUser ($id: Int!) {
-    delete_users_by_pk(id: $id)
-    {
-      id
-      name
-    }
-  }
-  ```
-
-  ```javascript
-  // In the QUERY VARIABLES window
-  {
-    "id": {{ UsersTable.triggeredRow.id }}
-  }
-  ```
-
-When the Submit button is clicked, your query is executed and the record is deleted. If the operation is successful, you should receive the record's `id` and `name` as confirmation.
-
-## Further reading
-
-* [Queries](/core-concepts/data-access-and-binding/querying-a-database/)
-* [Table widget](/reference/widgets/table)
-* [Form widget](/reference/widgets/form)
+```javascript
+{
+  "id": {{ UpdateUserForm.data.id }}
+}
+```


### PR DESCRIPTION
Updates GraphQL datasource docs to new Diataxis format.

Resolves #1547 

## Checklist
I have:
- [ ] run the content through Grammarly
- [ ] linked to sample apps when relevant
- [ ] added the meta description for each page in the PR
- [ ] minimized the callouts and added only when necessary
- [ ] added the `queryString` parameter to the Tabs (if used)
- [ ] masked PII in images. For example, login credentials, account details, and more
- [ ] added images only when necessary
- [ ] deleted the images that are no longer used for the updated pages in the PR
- [ ] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [ ] used the `<figure/>` tag instead of a markdown representation for images
- [ ] added the `<figcaption/>` tag to add a caption to the image
- [ ] added the `alt` attribute in the `<img/>` tag
- [ ] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [ ] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.