### PR TITLE
fix: Limitations for custom widgets

### DIFF
--- a/website/docs/reference/widgets/iframe.md
+++ b/website/docs/reference/widgets/iframe.md
@@ -459,7 +459,7 @@ With this setup, users can edit the code in the code editor, and when the submit
   <figcaption align = "center"><i>Custom Code Editor</i></figcaption>
 </figure>
 
-### Limitations for custom widgets:
+### Limitations
 
 With the Iframe widget, you cannot add widgets that rely on underlying platform capabilities, such as:
 

--- a/website/docs/reference/widgets/iframe.md
+++ b/website/docs/reference/widgets/iframe.md
@@ -466,7 +466,7 @@ You cannot create custom widgets using Iframe that rely on underlying platform c
 * Widgets that act as a canvas or parent for other widgets. Eg: _Container_
 * ```
 * Widgets that act as a _Modal_ or _Drawer_ on top of the existing canvas.
-* Using auto height or responsiveness features within your iframe.
+* Cannot use auto-height or responsiveness features for widgets within the Iframe.
 
 Appsmith currently lacks support for HTML formatting and error parsing. As a result, any HTML or CSS errors in the **srcDoc** field are not identified by Appsmith.
 Be cautious when handling code in the **srcDoc** field, as errors can be encountered.

--- a/website/docs/reference/widgets/iframe.md
+++ b/website/docs/reference/widgets/iframe.md
@@ -471,6 +471,6 @@ You cannot create custom widgets using Iframe that rely on underlying platform c
 
 Appsmith currently does not support HTML formatting and error parsing. As a result, Appsmith cannot identify any HTML or CSS errors in the **srcDoc** property.
 
-- For complex widgets with frequent updates, it is advisable to utilize an external service like CodeSandbox or host your own code to maintain your solution more efficiently.
+For complex widgets with frequent updates, it is advisable to utilize an external service like CodeSandbox or host your own code to maintain your solution more efficiently.
 
 

--- a/website/docs/reference/widgets/iframe.md
+++ b/website/docs/reference/widgets/iframe.md
@@ -467,7 +467,7 @@ With the Iframe widget, you cannot add widgets that rely on underlying platform 
 * Widgets acting as modals or drawers on top of the existing canvas.
 * Using auto height or responsiveness features within your iframe.
 
-Appsmith currently lacks support for HTML formatting and error parsing. As a result, any HTML or CSS errors in the **srcDoc** field is not identified by Appsmith.
+Appsmith currently lacks support for HTML formatting and error parsing. As a result, any HTML or CSS errors in the **srcDoc** field are not identified by Appsmith.
 Be cautious when handling code in the **srcDoc** field, as errors can be encountered.
 
 For complex widgets with frequent updates, it is advisable to utilize an external service like CodeSandbox or host your own code. This helps to maintain your solution more effectively.

--- a/website/docs/reference/widgets/iframe.md
+++ b/website/docs/reference/widgets/iframe.md
@@ -463,7 +463,8 @@ With this setup, users can edit the code in the code editor, and when the submit
 
 You cannot create custom widgets using Iframe that rely on underlying platform capabilities, such as:
 
-* Widgets behaving like a canvas or parent, enabling the dropping of additional widgets (example, Container).
+* Widgets that act as a canvas or parent for other widgets. Eg: _Container_
+* ```
 * Widgets acting as modals or drawers on top of the existing canvas.
 * Using auto height or responsiveness features within your iframe.
 

--- a/website/docs/reference/widgets/iframe.md
+++ b/website/docs/reference/widgets/iframe.md
@@ -407,8 +407,7 @@ The Iframe widget listens for messages sent from the page embedded within it. To
 
 Appsmith offers a wide range of widgets for building applications. Still, sometimes you may need a custom widget for a specific purpose, such as a calendar, accordion, social media widget, etc. In such cases, you can create the widget in HTML or a language like React and display it in the Iframe widget.
 
----
-**Example**: lets create a custom Code Editor Widget with the [Ace Code Editor Library](https://ace.c9.io/).
+Lets create a custom Code Editor Widget with the [Ace Code Editor Library](https://ace.c9.io/).
 
 1. In the **srcDoc** property, add the following code:
 
@@ -459,4 +458,18 @@ With this setup, users can edit the code in the code editor, and when the submit
   <img src="/img/custom-widget-code.png" style= {{width:"800px", height:"auto"}} alt="Display images on table row selection"/>
   <figcaption align = "center"><i>Custom Code Editor</i></figcaption>
 </figure>
+
+### Limitations for custom widgets:
+
+With the Iframe widget, you cannot add widgets that rely on underlying platform capabilities, such as:
+
+* Widgets behaving like a canvas or parent, enabling the dropping of additional widgets (example, Container).
+* Widgets acting as modals or drawers on top of the existing canvas.
+* Using auto height or responsiveness features within your iframe.
+
+Appsmith currently lacks support for HTML formatting and error parsing. As a result, any HTML or CSS errors in the **srcDoc** field is not identified by Appsmith.
+Be cautious when handling code in the **srcDoc** field, as errors can be encountered.
+
+For complex widgets with frequent updates, it is advisable to utilize an external service like CodeSandbox or host your own code. This helps to maintain your solution more effectively.
+
 

--- a/website/docs/reference/widgets/iframe.md
+++ b/website/docs/reference/widgets/iframe.md
@@ -468,7 +468,8 @@ You cannot create custom widgets using Iframe that rely on underlying platform c
 * Widgets that act as a _Modal_ or _Drawer_ on top of the existing canvas.
 * Cannot use auto-height or responsiveness features for widgets within the Iframe.
 
-Appsmith currently lacks support for HTML formatting and error parsing. As a result, any HTML or CSS errors in the **srcDoc** field are not identified by Appsmith.
+
+Appsmith currently does not support HTML formatting and error parsing. As a result, Appsmith cannot identify any HTML or CSS errors in the **srcDoc** property.
 Be cautious when handling code in the **srcDoc** field, as errors can be encountered.
 
 For complex widgets with frequent updates, it is advisable to utilize an external service like CodeSandbox or host your own code. This helps to maintain your solution more effectively.

--- a/website/docs/reference/widgets/iframe.md
+++ b/website/docs/reference/widgets/iframe.md
@@ -461,7 +461,7 @@ With this setup, users can edit the code in the code editor, and when the submit
 
 ### Limitations
 
-With the Iframe widget, you cannot add widgets that rely on underlying platform capabilities, such as:
+You cannot create custom widgets using Iframe that rely on underlying platform capabilities, such as:
 
 * Widgets behaving like a canvas or parent, enabling the dropping of additional widgets (example, Container).
 * Widgets acting as modals or drawers on top of the existing canvas.

--- a/website/docs/reference/widgets/iframe.md
+++ b/website/docs/reference/widgets/iframe.md
@@ -470,7 +470,6 @@ You cannot create custom widgets using Iframe that rely on underlying platform c
 
 
 Appsmith currently does not support HTML formatting and error parsing. As a result, Appsmith cannot identify any HTML or CSS errors in the **srcDoc** property.
-Be cautious when handling code in the **srcDoc** field, as errors can be encountered.
 
 For complex widgets with frequent updates, it is advisable to utilize an external service like CodeSandbox or host your own code. This helps to maintain your solution more effectively.
 

--- a/website/docs/reference/widgets/iframe.md
+++ b/website/docs/reference/widgets/iframe.md
@@ -463,8 +463,7 @@ With this setup, users can edit the code in the code editor, and when the submit
 
 You cannot create custom widgets using Iframe that rely on underlying platform capabilities, such as:
 
-* Widgets that act as a canvas or parent for other widgets. Eg: _Container_
-* ```
+* Widgets that act as a canvas or parent for other widgets. Eg: _Container_.
 * Widgets that act as a _Modal_ or _Drawer_ on top of the existing canvas.
 * Cannot use auto-height or responsiveness features for widgets within the Iframe.
 

--- a/website/docs/reference/widgets/iframe.md
+++ b/website/docs/reference/widgets/iframe.md
@@ -465,7 +465,7 @@ You cannot create custom widgets using Iframe that rely on underlying platform c
 
 * Widgets that act as a canvas or parent for other widgets. Eg: _Container_
 * ```
-* Widgets acting as modals or drawers on top of the existing canvas.
+* Widgets that act as a _Modal_ or _Drawer_ on top of the existing canvas.
 * Using auto height or responsiveness features within your iframe.
 
 Appsmith currently lacks support for HTML formatting and error parsing. As a result, any HTML or CSS errors in the **srcDoc** field are not identified by Appsmith.

--- a/website/docs/reference/widgets/iframe.md
+++ b/website/docs/reference/widgets/iframe.md
@@ -471,6 +471,6 @@ You cannot create custom widgets using Iframe that rely on underlying platform c
 
 Appsmith currently does not support HTML formatting and error parsing. As a result, Appsmith cannot identify any HTML or CSS errors in the **srcDoc** property.
 
-For complex widgets with frequent updates, it is advisable to utilize an external service like CodeSandbox or host your own code. This helps to maintain your solution more effectively.
+- For complex widgets with frequent updates, it is advisable to utilize an external service like CodeSandbox or host your own code to maintain your solution more efficiently.
 
 


### PR DESCRIPTION
## Checklist
I have:
- [x] run the content through Grammarly
- [ ] linked to sample apps when relevant
- [ ] added the meta description for each page in the PR
- [ ] minimized the callouts and added only when necessary
- [ ] added the `queryString` parameter to the Tabs (if used)
- [ ] masked PII in images. For example, login credentials, account details, and more
- [ ] added images only when necessary
- [ ] deleted the images that are no longer used for the updated pages in the PR
- [ ] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [ ] used the `<figure/>` tag instead of a markdown representation for images
- [ ] added the `<figcaption/>` tag to add a caption to the image
- [ ] added the `alt` attribute in the `<img/>` tag
- [ ] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [ ] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.