### PR TITLE
fix: Added datasource troubleshooting headings

### DIFF
--- a/website/docs/connect-data/reference/airtable.md
+++ b/website/docs/connect-data/reference/airtable.md
@@ -329,3 +329,6 @@ Data for the records to update. Expects an array of objects, where each object h
 
 </dl>
 
+## Troubleshooting
+
+If you are experiencing difficulties, you can refer to the [Datasource troubleshooting guide](/help-and-support/troubleshooting-guide/action-errors/datasource-errors) or contact the support team using the chat widget at the bottom right of this page.

--- a/website/docs/connect-data/reference/authenticated-api.md
+++ b/website/docs/connect-data/reference/authenticated-api.md
@@ -103,3 +103,7 @@ This information needs to be provided in .PEM (_Privacy Enhanced Mail_) format. 
 Once you have set up your Authenticated API datasource, you're ready to create queries.
 
 Visit the [REST API docs](/connect-data/reference/rest-api) to learn about the query configuration parameters.
+
+## Troubleshooting
+
+If you are experiencing difficulties, you can refer to the [Datasource troubleshooting guide](/help-and-support/troubleshooting-guide/action-errors/datasource-errors) or contact the support team using the chat widget at the bottom right of this page.

--- a/website/docs/connect-data/reference/curl-import.md
+++ b/website/docs/connect-data/reference/curl-import.md
@@ -17,3 +17,7 @@ curl -X GET https://example.com/resource
   <img src="/img/import_curl.gif" style= {{width:"100%", height:"auto"}} alt="Import cURL requests"/>
   <figcaption align = "center"><i>Import cURL requests</i></figcaption>
 </figure>
+
+## Troubleshooting
+
+If you are experiencing difficulties, you can refer to the [Datasource troubleshooting guide](/help-and-support/troubleshooting-guide/action-errors/datasource-errors) or contact the support team using the chat widget at the bottom right of this page.

--- a/website/docs/connect-data/reference/graphql.md
+++ b/website/docs/connect-data/reference/graphql.md
@@ -140,3 +140,6 @@ In the **Query variables** window:
   "id": {{ UpdateUserForm.data.id }}
 }
 ```
+## Troubleshooting
+
+If you are experiencing difficulties, you can refer to the [Datasource troubleshooting guide](/help-and-support/troubleshooting-guide/action-errors/datasource-errors) or contact the support team using the chat widget at the bottom right of this page.

--- a/website/docs/connect-data/reference/hubspot.md
+++ b/website/docs/connect-data/reference/hubspot.md
@@ -618,3 +618,7 @@ In addition to HubDB and CRM command types, Appsmith also provides the following
 | Settings - remove user                   |  Removes a set of users.                                    |
 | Settings - retrieve roles account        |  Fetches users in your HubSpot account.                                     |
 | Settings - see details account's teams   |  Fetches information about the team's account.                                    |
+
+## Troubleshooting
+
+If you are experiencing difficulties, you can refer to the [Datasource troubleshooting guide](/help-and-support/troubleshooting-guide/action-errors/datasource-errors) or contact the support team using the chat widget at the bottom right of this page.

--- a/website/docs/connect-data/reference/querying-amazon-s3.md
+++ b/website/docs/connect-data/reference/querying-amazon-s3.md
@@ -294,3 +294,6 @@ Expects a JSON array of file paths to be deleted from the S3 bucket.
   </dd>
 </dl> 
 
+## Troubleshooting
+
+If you are experiencing difficulties, you can refer to the [Datasource troubleshooting guide](/help-and-support/troubleshooting-guide/action-errors/datasource-errors) or contact the support team using the chat widget at the bottom right of this page.

--- a/website/docs/connect-data/reference/querying-arango-db.md
+++ b/website/docs/connect-data/reference/querying-arango-db.md
@@ -109,3 +109,7 @@ In the example above, the query uses the `id` of the row selected in the `UsersT
 ## See also
 
 [Data access and binding](/core-concepts/data-access-and-binding)
+
+## Troubleshooting
+
+If you are experiencing difficulties, you can refer to the [Datasource troubleshooting guide](/help-and-support/troubleshooting-guide/action-errors/datasource-errors) or contact the support team using the chat widget at the bottom right of this page.

--- a/website/docs/connect-data/reference/querying-dynamodb.md
+++ b/website/docs/connect-data/reference/querying-dynamodb.md
@@ -661,3 +661,7 @@ This operation updates auto scaling settings on your global tables. For example,
     "TableName": "users"
 }
 ```
+
+## Troubleshooting
+
+If you are experiencing difficulties, you can refer to the [Datasource troubleshooting guide](/help-and-support/troubleshooting-guide/action-errors/datasource-errors) or contact the support team using the chat widget at the bottom right of this page.

--- a/website/docs/connect-data/reference/querying-elasticsearch.md
+++ b/website/docs/connect-data/reference/querying-elasticsearch.md
@@ -137,6 +137,6 @@ A single document can be deleted using its `id` within an index using the `DELET
 
 Above, the record with its `id` is selected from a Table widget called `UsersTable`.
 
-## See also
+## Troubleshooting
 
-[Data access and binding](/core-concepts/data-access-and-binding)
+If you are experiencing difficulties, you can refer to the [Datasource troubleshooting guide](/help-and-support/troubleshooting-guide/action-errors/datasource-errors) or contact the support team using the chat widget at the bottom right of this page.

--- a/website/docs/connect-data/reference/querying-firestore.md
+++ b/website/docs/connect-data/reference/querying-firestore.md
@@ -361,3 +361,7 @@ For example, the value <code>["meta.dateCreated"]</code> adds the following to y
 
   </dd>
 </dl>
+
+## Troubleshooting
+
+If you are experiencing difficulties, you can refer to the [Datasource troubleshooting guide](/help-and-support/troubleshooting-guide/action-errors/datasource-errors) or contact the support team using the chat widget at the bottom right of this page.

--- a/website/docs/connect-data/reference/querying-google-sheets.md
+++ b/website/docs/connect-data/reference/querying-google-sheets.md
@@ -325,4 +325,4 @@ This command updates multiple **Sheet Row(s)** entities. The following section l
 
 ## Troubleshooting
 
-If you experience difficulties, contact the support team using the chat widget at the bottom right of this page.
+If you are experiencing difficulties, you can refer to the [Datasource troubleshooting guide](/help-and-support/troubleshooting-guide/action-errors/datasource-errors) or contact the support team using the chat widget at the bottom right of this page.

--- a/website/docs/connect-data/reference/querying-mongodb/README.md
+++ b/website/docs/connect-data/reference/querying-mongodb/README.md
@@ -346,19 +346,15 @@ This command allows users to process data records and return computed results. T
   </dd>
 </dl>
 
-
 ### Raw
 
 This command allows you to write queries using the MongoDB database command syntax. See [**Raw Query Commands**](/connect-data/reference/querying-mongodb/mongo-syntax) for more information. 
 
 ## Troubleshooting
 
-[Mongo query failed to execute](/help-and-support/troubleshooting-guide/action-errors#configuration-error)<br />
-[Missing default database name](/help-and-support/troubleshooting-guide/query-errors#mongodb-name-can-not-be-null)
+If you're experiencing difficulties, you can refer to to the [Datasource troubleshooting guide](/help-and-support/troubleshooting-guide/action-errors/datasource-errors), or guides for errors like:
 
-If you experience difficulties, contact the support team using the chat widget at the bottom right of this page.
+* [Mongo query failed to execute](/help-and-support/troubleshooting-guide/action-errors#configuration-error)
+* [Missing default database name](/help-and-support/troubleshooting-guide/query-errors#mongodb-name-can-not-be-null)
 
-## See also
-
-[Data access and binding](/core-concepts/data-access-and-binding)
-
+If you still have trouble, you can contact the support team using the chat widget at the bottom right of this page.

--- a/website/docs/connect-data/reference/querying-oracle.md
+++ b/website/docs/connect-data/reference/querying-oracle.md
@@ -100,6 +100,6 @@ In the above example, `UsersTable` is the name of the Table widget where the use
 Prepared statements are turned on by default in your queries to help prevent SQL injection attacks. For more details, see [**Prepared Statements**](/connect-data/concepts/how-to-use-prepared-statements).
 :::
 
-## See also
+## Troubleshooting
 
-[Data access and binding](/core-concepts/data-access-and-binding)
+If you are experiencing difficulties, you can refer to the [Datasource troubleshooting guide](/help-and-support/troubleshooting-guide/action-errors/datasource-errors) or contact the support team using the chat widget at the bottom right of this page.

--- a/website/docs/connect-data/reference/querying-postgres.md
+++ b/website/docs/connect-data/reference/querying-postgres.md
@@ -131,13 +131,10 @@ Row level security is a PostgreSQL security feature the database provides to lim
 
 ## Troubleshooting
 
-[Missing required parameter](/help-and-support/troubleshooting-guide/action-errors#missing-query-error)<br />
-[PostgreSQL query failed to execute](/help-and-support/troubleshooting-guide/action-errors#configuration-error)<br />
-[Query preparation failed while inserting value](/help-and-support/troubleshooting-guide/action-errors#invalid-query-error)
+If you're experiencing difficulties, you can refer to to the [Datasource troubleshooting guide](/help-and-support/troubleshooting-guide/action-errors/datasource-errors), or guides for errors like:
 
-If you experience difficulties, contact the support team using the chat widget at the bottom right of this page.
+* [Missing required parameter](/help-and-support/troubleshooting-guide/action-errors#missing-query-error)
+* [PostgreSQL query failed to execute](/help-and-support/troubleshooting-guide/action-errors#configuration-error)
+* [Query preparation failed while inserting value](/help-and-support/troubleshooting-guide/action-errors#invalid-query-error)
 
-## See also
-
-[Data access and binding](/core-concepts/data-access-and-binding)
-
+If you still have trouble, you can contact the support team using the chat widget at the bottom right of this page.

--- a/website/docs/connect-data/reference/querying-redis.md
+++ b/website/docs/connect-data/reference/querying-redis.md
@@ -99,3 +99,6 @@ To delete the entire Redis hash or a single key/value pair, use `DEL`:
 DEL user:{{ EmailInput.text }}
 ```
 
+## Troubleshooting
+
+If you are experiencing difficulties, you can refer to the [Datasource troubleshooting guide](/help-and-support/troubleshooting-guide/action-errors/datasource-errors) or contact the support team using the chat widget at the bottom right of this page.

--- a/website/docs/connect-data/reference/querying-redshift.md
+++ b/website/docs/connect-data/reference/querying-redshift.md
@@ -103,3 +103,7 @@ DELETE FROM users WHERE id = {{ UsersTable.selectedRow.id }};
 ```
 
 In the above example, `UsersTable` is the name of the Table widget where the user selects the row for deletion.
+
+## Troubleshooting
+
+If you are experiencing difficulties, you can refer to the [Datasource troubleshooting guide](/help-and-support/troubleshooting-guide/action-errors/datasource-errors) or contact the support team using the chat widget at the bottom right of this page.

--- a/website/docs/connect-data/reference/querying-snowflake-db.md
+++ b/website/docs/connect-data/reference/querying-snowflake-db.md
@@ -97,6 +97,6 @@ DELETE FROM customer WHERE id = {{ CustomerTable.selectedRow.id }};
 
 In the above example, `CustomerTable` is the name of the Table widget where the user selects the row for deletion.
 
-## See also
+## Troubleshooting
 
-[Data access and binding](/core-concepts/data-access-and-binding)
+If you are experiencing difficulties, you can refer to the [Datasource troubleshooting guide](/help-and-support/troubleshooting-guide/action-errors/datasource-errors) or contact the support team using the chat widget at the bottom right of this page.

--- a/website/docs/connect-data/reference/rest-api.md
+++ b/website/docs/connect-data/reference/rest-api.md
@@ -124,13 +124,10 @@ Be sure to turn off **JSON Smart Substitution** for this query in the [query set
 
 ## Troubleshooting
 
+If you're experiencing difficulties, you can refer to to the [Datasource troubleshooting guide](/help-and-support/troubleshooting-guide/action-errors/datasource-errors), or guides for errors like:
+
 [Missing URL](/help-and-support/troubleshooting-guide/action-errors/rest-api-errors#missing-url-error)<br />
 [Missing client secret / client ID / access token](/help-and-support/troubleshooting-guide/action-errors/rest-api-errors#missing-client-secret--client-id--access-token-error)<br />
 [Secret key required](/help-and-support/troubleshooting-guide/action-errors/rest-api-errors#secret-key-required-error)
 
 If you experience difficulties, contact the support team using the chat widget at the bottom right of this page.
-
-## See also
-
-* [Data access and binding](/core-concepts/data-access-and-binding)
-

--- a/website/docs/connect-data/reference/twilio.md
+++ b/website/docs/connect-data/reference/twilio.md
@@ -178,3 +178,6 @@ You can use this command to cancel sending a specific scheduled message. The fol
 
 </dl>
 
+## Troubleshooting
+
+If you are experiencing difficulties, you can refer to the [Datasource troubleshooting guide](/help-and-support/troubleshooting-guide/action-errors/datasource-errors) or contact the support team using the chat widget at the bottom right of this page.

--- a/website/docs/connect-data/reference/using-smtp.md
+++ b/website/docs/connect-data/reference/using-smtp.md
@@ -129,3 +129,7 @@ Attaches one or more files to the email. Expects an array of file objects.
   </dd>
 
 </dl>
+
+## Troubleshooting
+
+If you are experiencing difficulties, you can refer to the [Datasource troubleshooting guide](/help-and-support/troubleshooting-guide/action-errors/datasource-errors) or contact the support team using the chat widget at the bottom right of this page.


### PR DESCRIPTION
Added Troubleshooting section to the bottom of all datasource reference pages.

Resolves #1524 

## Checklist
I have:
- [x] run the content through Grammarly
- [ ] linked to sample apps when relevant
- [ ] added the meta description for each page in the PR
- [ ] minimized the callouts and added only when necessary
- [ ] added the `queryString` parameter to the Tabs (if used)
- [ ] masked PII in images. For example, login credentials, account details, and more
- [ ] added images only when necessary
- [ ] deleted the images that are no longer used for the updated pages in the PR
- [ ] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [ ] used the `<figure/>` tag instead of a markdown representation for images
- [ ] added the `<figcaption/>` tag to add a caption to the image
- [ ] added the `alt` attribute in the `<img/>` tag
- [ ] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [x] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.