### PR TITLE
fix: Update Security docs

### DIFF
--- a/website/docs/product/security.md
+++ b/website/docs/product/security.md
@@ -5,7 +5,7 @@ description: Learn about Appsmith's security features and how to protect your da
 
 This page explains the security features and considerations that Appsmith has implemented in its platform, and steps you can take to make your apps as safe as possible.
 
-## Secure data
+## Safe data
 
 Appsmith applications are secure-by-default, with a number of strategies in place to protect your data.
 
@@ -13,7 +13,7 @@ All sensitive credentials such as database credentials and Git SSH keys are encr
 
 Appsmith Cloud only connects to your databases and API endpoints through specific whitelisted IPs: `18.223.74.85` and `3.131.104.27`. All connections to Appsmith Cloud are encrypted with [TLS](https://en.wikipedia.org/wiki/Public\_key\_certificate). For self-hosted instances, it's possible to set up [SSL](https://en.wikipedia.org/wiki/Public\_key\_certificate) certificates during installation via [LetsEncrypt](https://letsencrypt.org/), or administrators can upload their own SSL certificate to Appsmith.
 
-## Secure queries
+## Safe queries
 
 Appsmith's backend system doesn't log or store any data returned from your databases or API endpoints, nor does it store information about responses or user input; Appsmith only acts as a proxy layer.
 
@@ -23,13 +23,11 @@ It's safe to add secrets to APIs or datasource configurations, as they are not e
 
 To avoid SQL injections, all SQL queries have [prepared statements](/connect-data/concepts/how-to-use-prepared-statements) enabled by default.
 
-## Secure JavaScript
+## Safe JavaScript
 
-JavaScript code written in any Appsmith app is executed on the client, and a user can inspect the site to view your code in their browser. Similarly, when you sync applications to Git repositories, the JavaScript code in your app is stored and accessible as a JavaScript file in the repository. Therefore, it is recommended to implement the standard best practices for dealing with client-side code. Specifically:
+JavaScript code written in any Appsmith app is executed on the client, and a user can inspect the site to view your code in their browser. Similarly, when you sync applications to Git repositories, the JavaScript code in your app is stored and accessible as a JavaScript file in the repository. Therefore, it's recommended to implement the standard best practices for dealing with client-side code.
 
-* Don't hard-code sensitive keys, credentials, or other sensitive information in plain text within JavaScript objects.
-
-* Don't store sensitive information using the [`storeValue()`](/reference/appsmith-framework/widget-actions/store-value) function, because the data is stored in the browser's local storage and can be viewed by the user.
+For example, it's important to avoid hard-coding sensitive keys or credentials in plain text. Similarly, it's not safe to store sensitive information using Appsmith's [`storeValue()`](/reference/appsmith-framework/widget-actions/store-value) function, because it stores its data in the browser's local storage and can be viewed by the user.
 
 Appsmith does not expose JavaScript DOM APIs directly to the user while writing JavaScript code, but it does implement some similar features like [`setInterval()`](/reference/appsmith-framework/widget-actions/intervals-time-events#setinterval) and [`clearInterval()`](/reference/appsmith-framework/widget-actions/intervals-time-events#clearinterval) which are available as global [framework functions](/reference/appsmith-framework/widget-actions).
 
@@ -37,14 +35,12 @@ The JavaScript `Fetch` API is supported, and it never sends cookies or session i
 
 ## Sandboxed Iframe widgets
 
-After v1.8.6 of Appsmith, [Iframe](/reference/widgets/iframe/) widgets have a `sandbox` attribute set on them by default to help protect from [XSS](https://en.wikipedia.org/wiki/Cross-site_scripting) vulnerabilities. This attribute is controlled with an environment variable in your Appsmith instance's `stacks/configuration/docker.env` file:
+After v1.8.6 of Appsmith, [Iframe](/reference/widgets/iframe/) widgets have a `sandbox` attribute set on them by default to help protect from [XSS](https://en.wikipedia.org/wiki/Cross-site_scripting) vulnerabilities. It reduces some capabilities of the iframe, but increases security and is unlikely to impede most real-world uses of this widget. The `sandbox` attribute is toggled using an environment variable in the Appsmith instance's `stacks/configuration/docker.env` file; setting `APPSMITH_DISABLE_IFRAME_WIDGET_SANDBOX` to `true` removes the `sandbox` attribute and its protections.
 
 ```sh
 APPSMITH_DISABLE_IFRAME_WIDGET_SANDBOX=false
 ```
 
-The `sandbox` attribute reduces some capabilities of the iframe, but increases security and is unlikely to impede most real-world uses of this widget.
-
-:::tip
+:::info
 Appsmith maintains an open communication channel with security researchers to report security vulnerabilities responsibly. If you notice a security vulnerability, please email [security@appsmith.com](mailto:security@appsmith.com), and it'll be resolved as quickly as possible.
 :::

--- a/website/docs/product/security.md
+++ b/website/docs/product/security.md
@@ -5,11 +5,6 @@ description: Learn about Appsmith's security features and how to protect your da
 
 This page explains the security features and considerations that Appsmith has implemented in its platform, and steps you can take to make your apps as safe as possible.
 
-## Does Appsmith store my data?
-
-
-
-
 ## Secure data
 
 Appsmith applications are secure-by-default, with a number of strategies in place to protect your data.

--- a/website/docs/product/security.md
+++ b/website/docs/product/security.md
@@ -1,4 +1,9 @@
+---
+description: Learn about Appsmith's security features and how to protect your data on the Appsmith platform.
+---
 # Security
+
+This page explains the security features and considerations that Appsmith has implemented in its platform, and steps you can take to make your apps as safe as possible.
 
 ## Does Appsmith store my data?
 
@@ -11,7 +16,7 @@ Appsmith applications are secure-by-default. The security measures implemented f
 * All sensitive credentials, such as database credentials and Git SSH keys, are encrypted with [AES-256 encryption](https://en.wikipedia.org/wiki/Advanced\_Encryption\_Standard). Each self-hosted Appsmith instance ensures [data-at-rest](https://en.wikipedia.org/wiki/Data\_at\_rest) security by configuring unique salt and password values.
 * All connections to Appsmith Cloud are encrypted with [TLS](https://en.wikipedia.org/wiki/Public\_key\_certificate). For self-hosted instances, it's possible to set up [SSL](https://en.wikipedia.org/wiki/Public\_key\_certificate) certificates during installation via [LetsEncrypt](https://letsencrypt.org/), or administrators can upload their own SSL certificate to Appsmith.
 * Appsmith Cloud only connects to your databases and API endpoints through whitelisted IPs: `18.223.74.85` and `3.131.104.27`. This ensures that your data is only exposed to specific IPs when using Appsmith Cloud.
-* Appsmith Cloud is hosted in AWS data centers on **SOC 1** and **SOC 2** compliant servers. Data redundancy is maintained on our cloud instances with regular backups.
+* Appsmith Cloud is hosted in AWS data centers on **SOC 1** and **SOC 2** compliant servers. Data redundancy is maintained on Appsmith Cloud instances with regular backups.
 * Internal access to Appsmith Cloud is controlled with a two-factor authentication aystem and instance audit logs.
 
 ## Securely executing queries

--- a/website/docs/product/security.md
+++ b/website/docs/product/security.md
@@ -7,46 +7,42 @@ This page explains the security features and considerations that Appsmith has im
 
 ## Does Appsmith store my data?
 
-Appsmith does not store any data returned from your API endpoints or DB queries. Appsmith only acts as a proxy layer. When you query your database/API endpoint, the Appsmith server only appends sensitive credentials before forwarding the request to your backend. It doesn’t expose sensitive credentials to the browser.
 
-## Security measures within Appsmith
 
-Appsmith applications are secure-by-default. The security measures implemented for Appsmith installations are:
 
-* All sensitive credentials, such as database credentials and Git SSH keys, are encrypted with [AES-256 encryption](https://en.wikipedia.org/wiki/Advanced\_Encryption\_Standard). Each self-hosted Appsmith instance ensures [data-at-rest](https://en.wikipedia.org/wiki/Data\_at\_rest) security by configuring unique salt and password values.
-* All connections to Appsmith Cloud are encrypted with [TLS](https://en.wikipedia.org/wiki/Public\_key\_certificate). For self-hosted instances, it's possible to set up [SSL](https://en.wikipedia.org/wiki/Public\_key\_certificate) certificates during installation via [LetsEncrypt](https://letsencrypt.org/), or administrators can upload their own SSL certificate to Appsmith.
-* Appsmith Cloud only connects to your databases and API endpoints through whitelisted IPs: `18.223.74.85` and `3.131.104.27`. This ensures that your data is only exposed to specific IPs when using Appsmith Cloud.
-* Appsmith Cloud is hosted in AWS data centers on **SOC 1** and **SOC 2** compliant servers. Data redundancy is maintained on Appsmith Cloud instances with regular backups.
-* Internal access to Appsmith Cloud is controlled with a two-factor authentication aystem and instance audit logs.
+## Secure data
 
-## Securely executing queries
+Appsmith applications are secure-by-default, with a number of strategies in place to protect your data.
 
-Appsmith's backend system doesn't store any data when responding to API calls or executing queries. The following security measures have been implemented:
+All sensitive credentials such as database credentials and Git SSH keys are encrypted with [AES-256 encryption](https://en.wikipedia.org/wiki/Advanced\_Encryption\_Standard), and each self-hosted Appsmith instance ensures [data-at-rest](https://en.wikipedia.org/wiki/Data\_at\_rest) security by configuring unique salt and password values. In the cloud, Appsmith is hosted in AWS data centers on **SOC 1** and **SOC 2** compliant servers, with data redundancy maintained by regular backups. Internal access to Appsmith Cloud is controlled with a two-factor authentication aystem and audit logs.
 
-* Appsmith's backend system doesn't store any information about query responses or user inputs. Appsmith acts only as a proxy and never logs or stores private data.
-* Appsmith securely stores queries' configuration and body to ensure that they are never exposed to clients while the app is in **View** mode. Users are not able to access data to infer the contents of a query.
-* To avoid SQL injections, all SQL queries have [prepared statements](/connect-data/concepts/how-to-use-prepared-statements) enabled by default.
+Appsmith Cloud only connects to your databases and API endpoints through specific whitelisted IPs: `18.223.74.85` and `3.131.104.27`. All connections to Appsmith Cloud are encrypted with [TLS](https://en.wikipedia.org/wiki/Public\_key\_certificate). For self-hosted instances, it's possible to set up [SSL](https://en.wikipedia.org/wiki/Public\_key\_certificate) certificates during installation via [LetsEncrypt](https://letsencrypt.org/), or administrators can upload their own SSL certificate to Appsmith.
 
-## Securely executing JavaScript
+## Secure queries
 
-The JavaScript code written in any Appsmith app is executed only on the client, and a user can inspect the site and view the code in the browser. Therefore, it is recommended to implement the standard best practices for dealing with client-side code.
+Appsmith's backend system doesn't log or store any data returned from your databases or API endpoints, nor does it store information about responses or user input; Appsmith only acts as a proxy layer.
 
-The code is stored in the same MongoDB database that Appsmith uses to store all other app configuration. To ensure that all data is secure, please read the following carefully:
+The configuration and body of your queries are securely stored, and are never exposed to clients while the app is in **View** mode. Users can't access any data that would allow them to infer the query's content. When a query is executed, the Appsmith server appends sensitive credentials just before forwarding the request to your backend, without exposing any sensitive credentials to the client's browser.
 
-* It's recommend that you do not hard code sensitive keys, credentials, or other sensitive information in plain text within JavaScript objects.
+It's safe to add secrets to APIs or datasource configurations, as they are not exposed while the app is in **View** mode. You can update the secrets in **Edit** mode, but it's not possible to view the current value of existing secrets, regardless of the app's mode.
 
-:::tip
-You can add secrets to APIs or datasource configurations, as they are not exposed while the app is in **View** mode. You can update the secrets in **Edit** mode, but it's not possible to view the current value of existing secrets that have been previously saved, regardless of the app's mode.
-:::
+To avoid SQL injections, all SQL queries have [prepared statements](/connect-data/concepts/how-to-use-prepared-statements) enabled by default.
 
-* When you sync applications to Git repositories, any JavaScript code in your app is stored as a JavaScript file in the repository. Therefore, it is recommended to follow standard best practices for dealing with visible JavaScript code.
-* Appsmith does not expose DOM APIs directly to the user while writing JavaScript code, but it supports a handful of simliar features like [`setInterval()`](/reference/appsmith-framework/widget-actions/intervals-time-events#setinterval) and [`clearInterval()`](/reference/appsmith-framework/widget-actions/intervals-time-events#clearinterval) available as [framework functions](/reference/appsmith-framework/widget-actions).
-* Appsmith supports the `Fetch` API, however it never sends cookies or session information when called from within Appsmith.
-* You should not store sensitive information using the [`storeValue()`](/reference/appsmith-framework/widget-actions/store-value) function, because the data is stored in the browser's local storage and can be viewed by the user.
+## Secure JavaScript
 
-## Sandboxing Iframe widgets
+JavaScript code written in any Appsmith app is executed on the client, and a user can inspect the site to view your code in their browser. Similarly, when you sync applications to Git repositories, the JavaScript code in your app is stored and accessible as a JavaScript file in the repository. Therefore, it is recommended to implement the standard best practices for dealing with client-side code. Specifically:
 
-After v1.8.6 of Appsmith, [Iframe](/reference/widgets/iframe/) widgets have a `sandbox` attribute set on them by default to help protect from XSS vulnerabilities. This attribute is controlled with an environment variable in your Appsmith instance's `stacks/configuration/docker.env` file:
+* Don't hard-code sensitive keys, credentials, or other sensitive information in plain text within JavaScript objects.
+
+* Don't store sensitive information using the [`storeValue()`](/reference/appsmith-framework/widget-actions/store-value) function, because the data is stored in the browser's local storage and can be viewed by the user.
+
+Appsmith does not expose JavaScript DOM APIs directly to the user while writing JavaScript code, but it does implement some simliar features like [`setInterval()`](/reference/appsmith-framework/widget-actions/intervals-time-events#setinterval) and [`clearInterval()`](/reference/appsmith-framework/widget-actions/intervals-time-events#clearinterval) which are available as global [framework functions](/reference/appsmith-framework/widget-actions).
+
+The JavaScript `Fetch` API is supported, and it never sends cookies or session information when called from within Appsmith.
+
+## Sandboxed Iframe widgets
+
+After v1.8.6 of Appsmith, [Iframe](/reference/widgets/iframe/) widgets have a `sandbox` attribute set on them by default to help protect from [XSS](https://en.wikipedia.org/wiki/Cross-site_scripting) vulnerabilities. This attribute is controlled with an environment variable in your Appsmith instance's `stacks/configuration/docker.env` file:
 
 ```sh
 APPSMITH_DISABLE_IFRAME_WIDGET_SANDBOX=false
@@ -55,5 +51,5 @@ APPSMITH_DISABLE_IFRAME_WIDGET_SANDBOX=false
 The `sandbox` attribute reduces some capabilities of the iframe, but increases security and is unlikely to impede most real-world uses of this widget.
 
 :::tip
-We maintain an open communication channel with security researchers to report security vulnerabilities responsibly. If you notice a security vulnerability, please email [security@appsmith.com](mailto:security@appsmith.com), and it'll be resolved as quickly as possible.
+Appsmith maintains an open communication channel with security researchers to report security vulnerabilities responsibly. If you notice a security vulnerability, please email [security@appsmith.com](mailto:security@appsmith.com), and it'll be resolved as quickly as possible.
 :::

--- a/website/docs/product/security.md
+++ b/website/docs/product/security.md
@@ -2,59 +2,53 @@
 
 ## Does Appsmith store my data?
 
-Appsmith does not store any data returned from your API endpoints or DB queries. Appsmith only acts as a proxy layer. When you query your database/API endpoint, the Appsmith server only appends sensitive credentials before forwarding the request to your backend. It doesn’t expose sensitive credentials to the browser as it can lead to security breaches. The routing ensures the security of your systems and data.
+Appsmith does not store any data returned from your API endpoints or DB queries. Appsmith only acts as a proxy layer. When you query your database/API endpoint, the Appsmith server only appends sensitive credentials before forwarding the request to your backend. It doesn’t expose sensitive credentials to the browser.
 
 ## Security measures within Appsmith
 
 Appsmith applications are secure-by-default. The security measures implemented for Appsmith installations are:
 
-* All sensitive credentials, such as database credentials, are encrypted with [AES-256 encryption](https://en.wikipedia.org/wiki/Advanced\_Encryption\_Standard). Each self-hosted Appsmith instance ensures [data-at-rest](https://en.wikipedia.org/wiki/Data\_at\_rest) security by configuring unique salt and password values.
-* On Appsmith Cloud, all connections are [TLS](https://en.wikipedia.org/wiki/Public\_key\_certificate) encrypted. For self-hosted instances, we offer the capability to set up [SSL ](https://en.wikipedia.org/wiki/Public\_key\_certificate)certificates via [LetsEncrypt ](https://letsencrypt.org/)during installation.
-* Appsmith Cloud will **only** connect to your databases/API endpoints through whitelisted IPs: **18.223.74.85** & **3.131.104.27**, ensuring that you only expose database access to specific IPs when using our cloud offering.
-* Appsmith Cloud is hosted in AWS data centers on **SOC 1** and **SOC 2** compliant servers. We also maintain data redundancy on our cloud instances via regular backups.
-* Internal access to Appsmith Cloud is controlled through a [Two-Factor Authentication System](https://en.wikipedia.org/wiki/Help:Two-factor\_authentication) and audit logs.
+* All sensitive credentials, such as database credentials and Git SSH keys, are encrypted with [AES-256 encryption](https://en.wikipedia.org/wiki/Advanced\_Encryption\_Standard). Each self-hosted Appsmith instance ensures [data-at-rest](https://en.wikipedia.org/wiki/Data\_at\_rest) security by configuring unique salt and password values.
+* All connections to Appsmith Cloud are encrypted with [TLS](https://en.wikipedia.org/wiki/Public\_key\_certificate). For self-hosted instances, it's possible to set up [SSL](https://en.wikipedia.org/wiki/Public\_key\_certificate) certificates during installation via [LetsEncrypt](https://letsencrypt.org/), or administrators can upload their own SSL certificate to Appsmith.
+* Appsmith Cloud only connects to your databases and API endpoints through whitelisted IPs: `18.223.74.85` and `3.131.104.27`. This ensures that your data is only exposed to specific IPs when using Appsmith Cloud.
+* Appsmith Cloud is hosted in AWS data centers on **SOC 1** and **SOC 2** compliant servers. Data redundancy is maintained on our cloud instances with regular backups.
+* Internal access to Appsmith Cloud is controlled with a two-factor authentication aystem and instance audit logs.
 
-:::note
-The above reference to the **audit logs** pertains only to the **cloud-hosted instance** of Appsmith and does **not** refer to the **audit logs** **feature.**
-:::
+## Securely executing queries
 
-## Securely Executing Queries & APIs
+Appsmith's backend system doesn't store any data when responding to API calls or executing queries. The following security measures have been implemented:
 
-Appsmith's backend system doesn't store any data when responding to API calls or executing any queries. The security measures implemented for Appsmith Executing Queries & APIs are:
+* Appsmith's backend system doesn't store any information about query responses or user inputs. Appsmith acts only as a proxy and never logs or stores private data.
+* Appsmith securely stores queries' configuration and body to ensure that they are never exposed to clients while the app is in **View** mode. Users are not able to access data to infer the contents of a query.
+* To avoid SQL injections, all SQL queries have [prepared statements](/connect-data/concepts/how-to-use-prepared-statements) enabled by default.
 
-* The Appsmith's backend system doesn't store any information about query responses or user inputs. Appsmith **only** acts as a proxy and never logs or stores the private/confidential data in Appsmith's data stores.
-* To protect the application so that users cannot infer the executed query - Appsmith stores the query configuration and ensures that the SQL query body or custom API URLs are never exposed to the client in `view` mode. 
-* To avoid SQL injections, all SQL queries have [prepared statements](../connect-data/concepts/how-to-use-prepared-statements.md) enabled by default.
+## Securely executing JavaScript
 
-## Securely Executing JavaScript
+The JavaScript code written in any Appsmith app is executed only on the client, and a user can inspect the site and view the code in the browser. Therefore, it is recommended to implement the standard best practices for dealing with client-side code.
 
-The JavaScript code written within Appsmith is executed on the client only, and a user can inspect the site and view the code in the browser. Hence, we recommend implementing the standard best practices when dealing with client-side code.
+The code is stored in the same MongoDB database that Appsmith uses to store all other app configuration. To ensure that all data is secure, please read the following carefully:
 
-The code is stored in the MongoDB database that Appsmith uses to store all other application configurations. To ensure that all data is secure, please read the following carefully:
-
-* We recommend that you **do** **not** hard code the sensitive keys, credentials, or other sensitive information in the JavaScript objects in plain text.
+* It's recommend that you do not hard code sensitive keys, credentials, or other sensitive information in plain text within JavaScript objects.
 
 :::tip
-You can add **secrets** to **APIs** or **datasource configurations** as they are **not** exposed in the **view mode**. You can update the **secrets** in **edit** **mode** but **cannot** view the existing **secrets** while **viewing** or **editing** the configurations.
+You can add secrets to APIs or datasource configurations, as they are not exposed while the app is in **View** mode. You can update the secrets in **Edit** mode, but it's not possible to view the current value of existing secrets that have been previously saved, regardless of the app's mode.
 :::
 
-* When you sync applications to git repositories, the JavaScript code is also synced and stored as a JavaScript file in the repository. As a result, we recommend following standard best practices when dealing with JavaScript code written on Appsmith.
-* We **do not** expose DOM APIs directly to the user while writing JavaScript code, but we support a few features via global actions like `setInterval()` and `clearInterval()` available on Appsmith.
-* Appsmith does not allow some actions like `Fetch`. You cannot call an external API directly from the JavaScript code. However, you can add an API on Appsmith and use it to request, read data, or manipulate the response from the external API.
-* You should not store sensitive information using a `storeValue` function because the data is stored in the browser's local storage and can be read.
+* When you sync applications to Git repositories, any JavaScript code in your app is stored as a JavaScript file in the repository. Therefore, it is recommended to follow standard best practices for dealing with visible JavaScript code.
+* Appsmith does not expose DOM APIs directly to the user while writing JavaScript code, but it supports a handful of simliar features like [`setInterval()`](/reference/appsmith-framework/widget-actions/intervals-time-events#setinterval) and [`clearInterval()`](/reference/appsmith-framework/widget-actions/intervals-time-events#clearinterval) available as [framework functions](/reference/appsmith-framework/widget-actions).
+* Appsmith supports the `Fetch` API, however it never sends cookies or session information when called from within Appsmith.
+* You should not store sensitive information using the [`storeValue()`](/reference/appsmith-framework/widget-actions/store-value) function, because the data is stored in the browser's local storage and can be viewed by the user.
 
 ## Sandboxing Iframe widgets
 
-The [Iframe](/reference/widgets/iframe/) widget on older versions of Appsmith is vulnerable to XSS attacks. This was fixed in v1.8.6 of Appsmith. For this fix to be applied on your Appsmith instance, ensure you have the following environment variable set in your `stacks/configuration/docker.env` file:
+After v1.8.6 of Appsmith, [Iframe](/reference/widgets/iframe/) widgets have a `sandbox` attribute set on them by default to help protect from XSS vulnerabilities. This attribute is controlled with an environment variable in your Appsmith instance's `stacks/configuration/docker.env` file:
 
 ```sh
 APPSMITH_DISABLE_IFRAME_WIDGET_SANDBOX=false
 ```
 
-This is automatically set for any Appsmith instance created after the release of v1.8.6.
-
-The fix works by setting a `sandbox` attribute on iframe widgets. This reduces what the widget is capable of, by a little bit, and shouldn't impact most real-world uses of this widget.
+The `sandbox` attribute reduces some capabilities of the iframe, but increases security and is unlikely to impede most real-world uses of this widget.
 
 :::tip
-We maintain an open communication channel with security researchers to report security vulnerabilities responsibly. If you notice a security vulnerability, please email [security@appsmith.com](mailto:security@appsmith.com), and we'll resolve it ASAP.
+We maintain an open communication channel with security researchers to report security vulnerabilities responsibly. If you notice a security vulnerability, please email [security@appsmith.com](mailto:security@appsmith.com), and it'll be resolved as quickly as possible.
 :::

--- a/website/docs/product/security.md
+++ b/website/docs/product/security.md
@@ -9,7 +9,7 @@ This page explains the security features and considerations that Appsmith has im
 
 Appsmith applications are secure-by-default, with a number of strategies in place to protect your data.
 
-All sensitive credentials such as database credentials and Git SSH keys are encrypted with [AES-256 encryption](https://en.wikipedia.org/wiki/Advanced\_Encryption\_Standard), and each self-hosted Appsmith instance ensures [data-at-rest](https://en.wikipedia.org/wiki/Data\_at\_rest) security by configuring unique salt and password values. In the cloud, Appsmith is hosted in AWS data centers on **SOC 1** and **SOC 2** compliant servers, with data redundancy maintained by regular backups. Internal access to Appsmith Cloud is controlled with a two-factor authentication aystem and audit logs.
+All sensitive credentials such as database credentials and Git SSH keys are encrypted with [AES-256 encryption](https://en.wikipedia.org/wiki/Advanced\_Encryption\_Standard), and each self-hosted Appsmith instance ensures [data-at-rest](https://en.wikipedia.org/wiki/Data\_at\_rest) security by configuring unique salt and password values. In the cloud, Appsmith is hosted in AWS data centers on **SOC 1** and **SOC 2** compliant servers, with data redundancy maintained by regular backups. Internal access to Appsmith Cloud is controlled with a two-factor authentication system and audit logs.
 
 Appsmith Cloud only connects to your databases and API endpoints through specific whitelisted IPs: `18.223.74.85` and `3.131.104.27`. All connections to Appsmith Cloud are encrypted with [TLS](https://en.wikipedia.org/wiki/Public\_key\_certificate). For self-hosted instances, it's possible to set up [SSL](https://en.wikipedia.org/wiki/Public\_key\_certificate) certificates during installation via [LetsEncrypt](https://letsencrypt.org/), or administrators can upload their own SSL certificate to Appsmith.
 
@@ -17,7 +17,7 @@ Appsmith Cloud only connects to your databases and API endpoints through specifi
 
 Appsmith's backend system doesn't log or store any data returned from your databases or API endpoints, nor does it store information about responses or user input; Appsmith only acts as a proxy layer.
 
-The configuration and body of your queries are securely stored, and are never exposed to clients while the app is in **View** mode. Users can't access any data that would allow them to infer the query's content. When a query is executed, the Appsmith server appends sensitive credentials just before forwarding the request to your backend, without exposing any sensitive credentials to the client's browser.
+The configuration and body of your queries are securely stored and are never exposed to clients while the app is in **View** mode. Users can't access any data that would allow them to infer the query's content. When a query is executed, the Appsmith server appends sensitive credentials just before forwarding the request to your backend, without exposing any sensitive credentials to the client's browser.
 
 It's safe to add secrets to APIs or datasource configurations, as they are not exposed while the app is in **View** mode. You can update the secrets in **Edit** mode, but it's not possible to view the current value of existing secrets, regardless of the app's mode.
 
@@ -31,7 +31,7 @@ JavaScript code written in any Appsmith app is executed on the client, and a use
 
 * Don't store sensitive information using the [`storeValue()`](/reference/appsmith-framework/widget-actions/store-value) function, because the data is stored in the browser's local storage and can be viewed by the user.
 
-Appsmith does not expose JavaScript DOM APIs directly to the user while writing JavaScript code, but it does implement some simliar features like [`setInterval()`](/reference/appsmith-framework/widget-actions/intervals-time-events#setinterval) and [`clearInterval()`](/reference/appsmith-framework/widget-actions/intervals-time-events#clearinterval) which are available as global [framework functions](/reference/appsmith-framework/widget-actions).
+Appsmith does not expose JavaScript DOM APIs directly to the user while writing JavaScript code, but it does implement some similar features like [`setInterval()`](/reference/appsmith-framework/widget-actions/intervals-time-events#setinterval) and [`clearInterval()`](/reference/appsmith-framework/widget-actions/intervals-time-events#clearinterval) which are available as global [framework functions](/reference/appsmith-framework/widget-actions).
 
 The JavaScript `Fetch` API is supported, and it never sends cookies or session information when called from within Appsmith.
 


### PR DESCRIPTION
Updates to Product Security page

Resolves #1492 

## Misc review changes:
* Changed heading names from "Secure" to "safe"
* changed "tip" callout to "info"
* converted javascript security suggestion bullets into statement sentences.
* slight adjustments to sandboxed iframe area

## Checklist
I have:
- [x] run the content through Grammarly
- [ ] linked to sample apps when relevant
- [x] added the meta description for each page in the PR
- [x] minimized the callouts and added only when necessary
- [ ] added the `queryString` parameter to the Tabs (if used)
- [ ] masked PII in images. For example, login credentials, account details, and more
- [ ] added images only when necessary
- [ ] deleted the images that are no longer used for the updated pages in the PR
- [ ] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [ ] used the `<figure/>` tag instead of a markdown representation for images
- [ ] added the `<figcaption/>` tag to add a caption to the image
- [ ] added the `alt` attribute in the `<img/>` tag
- [ ] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [x] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.