### PR TITLE
docs: Changes to default roles as per access based on envs

### DIFF
--- a/.github/styles/Google/Will.yml
+++ b/.github/styles/Google/Will.yml
@@ -1,7 +1,0 @@
-extends: existence
-message: "Avoid using '%s'."
-link: 'https://developers.google.com/style/tense'
-ignorecase: true
-level: warning
-tokens:
-  - will

--- a/website/docs/advanced-concepts/invite-users.md
+++ b/website/docs/advanced-concepts/invite-users.md
@@ -43,9 +43,9 @@ The table below shows the permissions available for each role when you share a w
 
 |Role           |	<div style= {{width:"150px"}}> Create App </div> | <div style= {{width:"150px"}}> Edit App </div>  |<div style= {{width:"150px"}}> View App </div> |<div style= {{width:"150px"}}> Delete App </div>| <div style= {{width:"150px"}}> Make App Public </div> | <div style= {{width:"150px"}}> Invite Users </div>   | <div style= {{width:"150px"}}> Manage Users </div>  |
 |---------------|-----------------------------------------------|--------------------------------------------|------------------------------------------|-------------------------------------------|-------------------------------------------------------|------------------------------------------------------|-----------------------------------------------------|
-| **Administrator** |Create applications, pages and queries inside the workspace|Edit any application, page and query inside the workspace|View any application, page and query inside the workspace|Delete any application, page and query inside the workspace |Make any application inside the workspace public  |Invite other users to the workspace |	Manage users in a workspace |
-|**Developer**      | Create applications, pages and queries inside the workspace|Edit any application, page and query inside the workspace|View any application, page and query inside the workspace |Delete any application, page and query inside the workspace|	-             |Invite other users to the workspace |	-             |
-|**App Viewer**     |	-             |-             |View any application, page & query inside the workspace.|-|           -     |Invite other users to the workspace only as **App Viewer** |	-|
+| **Administrator** |Create applications, pages and queries inside the workspace in any environment |Edit any application, page and query inside the workspace in any environment |View any application, page and query inside the workspace in any environment |Delete any application, page and query inside the workspace in any environment |Make any application inside the workspace public |Invite other users to the workspace | Manage users in a workspace |
+|**Developer**      | Create applications, pages and queries inside the workspace in any environment |Edit any application, page and query inside the workspace in any environment |View any application, page and query inside the workspace in any environment |Delete any application, page and query inside the workspace in any environment |	-             |Invite other users to the workspace |	-             |
+|**App Viewer**     |	-             |-             |View any application, page & execute actions inside the workspace in production environment (Cannot see queries and datasources) |-|           -     |Invite other users to the workspace only as **App Viewer** |	-|
 
 ## Share application
 
@@ -70,12 +70,12 @@ The table below shows the permissions available for each role when you share an 
 
 |Role           |	<div style= {{width:"150px"}}> Create </div> | <div style= {{width:"150px"}}> Edit </div>  |<div style= {{width:"150px"}}> View </div> |<div style= {{width:"150px"}}> Delete </div>| <div style= {{width:"150px"}}> Make App Public </div> | <div style= {{width:"150px"}}> Invite Users </div>   | <div style= {{width:"150px"}}> Manage Users </div>  |
 |---------------|-----------------------------------------------|--------------------------------------------|------------------------------------------|-------------------------------------------|-------------------------------------------------------|------------------------------------------------------|-----------------------------------------------------|
-|**Developer**      | Create pages, datasources and queries inside the app|Edit pages, datasources and queries inside the app|View the app, its pages, datasources and queries. |Delete the app, its pages, datasources and queries|-|Invite other users with an equivalent or a lower role |	-       |
-|**App Viewer**     |	-              |     -          |View the app and execute actions (Cannot see queries,datasources)|-|           -     |Invite users only as **App Viewer** |	-|
+|**Developer**      | Create pages, datasources and queries inside the app in any environment |Edit pages, datasources and queries inside the app in any environment |View the app, its pages, datasources and queries in any environment |Delete the app, its pages, datasources and queries in any environment |-|Invite other users with an equivalent or a lower role |	-       |
+|**App Viewer**     |	-              |     -          |View the app and execute actions in production environment (Cannot see queries,datasources)|-|           -     |Invite users only as **App Viewer** |	-|
 
 ## Make application public
 
-You can make your applications public and share them with users who are not part of your workspace. These external users do not need to log in to Appsmith to access the shared applications.
+You can make your applications public and share them with users who are not part of your workspace. These external users do not need to log in to Appsmith to access the shared applications. The will only be able to see the production environment of your deployed application.
 
 To make an application public, you can click on the **Share** button within the application and turn on the **Make application public** switch. Once enabled, click **Copy Application URL** to copy the application link and share the application with your users.
 

--- a/website/docs/advanced-concepts/invite-users.md
+++ b/website/docs/advanced-concepts/invite-users.md
@@ -75,7 +75,7 @@ The table below shows the permissions available for each role when you share an 
 
 ## Make application public
 
-You can make your applications public and share them with users who are not part of your workspace. These external users do not need to log in to Appsmith to access the shared applications. The will only be able to see the production environment of your deployed application.
+You can make your applications public and share them with users who are not part of your workspace. These external users do not need to log in to Appsmith to access the shared applications. They will only be able to see the production environment of your deployed application.
 
 To make an application public, you can click on the **Share** button within the application and turn on the **Make application public** switch. Once enabled, click **Copy Application URL** to copy the application link and share the application with your users.
 


### PR DESCRIPTION
This set of changes needs to be shipped after [this PR](https://github.com/appsmithorg/appsmith-ee/pull/2055) is merged into production, and tagged.

Fixes #1617 

## Checklist
I have:
- [ ] run the content through Grammarly
- [ ] linked to sample apps when relevant
- [ ] added the meta description for each page in the PR
- [ ] minimized the callouts and added only when necessary
- [ ] added the `queryString` parameter to the Tabs (if used)
- [ ] masked PII in images. For example, login credentials, account details, and more
- [ ] added images only when necessary
- [ ] deleted the images that are no longer used for the updated pages in the PR
- [ ] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [ ] used the `<figure/>` tag instead of a markdown representation for images
- [ ] added the `<figcaption/>` tag to add a caption to the image
- [ ] added the `alt` attribute in the `<img/>` tag
- [ ] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [ ] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.