### PR TITLE
fix: Change datasource properties to headings

### DIFF
--- a/website/docs/connect-data/reference/airtable.md
+++ b/website/docs/connect-data/reference/airtable.md
@@ -16,16 +16,15 @@ The following section is a reference guide that provides a complete description 
   <figcaption align="center"><i>Configuring an Airtable datasource.</i></figcaption>
 </figure>
 
-<dl>
-  <dt><b>Authentication type</b></dt>
-  <dd>Sets the method to use for authenticating your queries to Airtable. Appsmith automatically handles sending your token in your request headers.</dd><br/>
-  <dd><i>Options:</i>
-    <ul>
-     <li><b>API key:</b> This authentication type has been deprecated by Airtable. For more information, see <a href="https://support.airtable.com/docs/airtable-api-key-deprecation-notice">Airtable Api Key Deprecation Notice</a>.</li>
-     <li><b>Personal access token:</b> Connects to Airtable using the provided Airtable Personal Access Token.</li>
-    </ul>
-  </dd>  
-</dl>
+#### Authentication type
+
+<dd>Sets the method to use for authenticating your queries to Airtable. Appsmith automatically handles sending your token in your request headers.</dd><br/>
+<dd><i>Options:</i>
+  <ul>
+    <li><b>API key:</b> This authentication type has been deprecated by Airtable. For more information, see <a href="https://support.airtable.com/docs/airtable-api-key-deprecation-notice">Airtable Api Key Deprecation Notice</a>.</li>
+    <li><b>Personal access token:</b> Connects to Airtable using the provided Airtable Personal Access Token.</li>
+  </ul>
+</dd>
 
 ## Create queries
 
@@ -56,23 +55,25 @@ For more information, see [Finding Airtable IDs](https://support.airtable.com/do
 
 This command to fetches data from your Airtable base. You can use the query configuration fields to filter, sort, and format the data that's returned to your app. The following section lists all the fields available for the **List records** command.
 
-<dl>
-  <dt><b>Base ID</b></dt>
-  <dd>
+#### Base ID
+
+<dd>
 
 A string that uniquely identifies your Airtable base. To find your Base ID, see [Find your Base ID](#find-your-base-id).
 
-  </dd>
+</dd>
 
-  <dt><b>Table name</b></dt>
-  <dd>
+#### Table name
+
+<dd>
 
 The name of the table to query from your base.
-  
-  </dd>
 
-  <dt><b>Fields</b></dt>
-  <dd>
+</dd>
+
+#### Fields
+
+<dd>
 
 Specifies which columns to return. If left blank, all columns are returned. The input to this field must be encoded using the JavaScript [`encodeURI()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI) method. See below:
 
@@ -98,10 +99,11 @@ Below, a variable number of columns are chosen with a [Multi-Select widget](/ref
 }}
 ```
 
-  </dd>
+</dd>
 
-  <dt><b>Filter by formula</b></dt>
-  <dd>
+#### Filter by formula
+
+<dd>
 
 Expects an [Airtable formula](https://support.airtable.com/docs/formula-field-reference), which only returns the records where the formula evaluates to `true`. For example:
 
@@ -117,24 +119,27 @@ Or you can return records where the percentage of positive reviews are above an 
 goodReviews / SUM(goodReviews, badReviews) > .85
 ```
   
-  </dd>
+</dd>
 
-  <dt><b>Max records</b></dt>
-  <dd>
+#### Max records
+
+<dd>
 
 Sets a limit for how many records are allowed to be selected in this query.
   
-  </dd>
+</dd>
 
-  <dt><b>Page size</b></dt>
-  <dd>
+#### Page size
+
+<dd>
 
 Sets an integer limit for how many records can be returned at a time; further results are sent in subsequent requests. The default value for this field is `100`.
   
-  </dd>
+</dd>
 
-  <dt><b>Sort</b></dt>
-  <dd>
+#### Sort
+
+<dd>
 
 Specifies which column to sort results by. The input for this field must be encoded using the JavaScript [`encodeURI()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI) method. See below:
   
@@ -160,59 +165,64 @@ Below, a variable number of columns are chosen with a [Multi-Select widget](/ref
 }}
 ```
 
-  </dd>
+</dd>
 
-  <dt><b>Cell format</b></dt>
-  <dd>
+#### Cell format
+
+<dd>
 
 Sets whether certain values are returned in `string` or `json` format. For example, ticked checkboxes are `"checked"` in string format, or `true` in JSON format.
   
-  </dd>
+</dd>
 
-  <dt><b>Time zone</b></dt>
-  <dd>
+#### Time zone
+
+<dd>
 
 Sets the time zone to use for displaying date values, expects value like `'America/Chicago'`. For more information, see [Supported Timezones for SET_TIMEZONE](https://support.airtable.com/docs/supported-timezones-for-set-timezone).
   
-  </dd>
+</dd>
 
-  <dt><b>User locale</b></dt>
-  <dd>
+#### User locale
+
+<dd>
 
 Sets format for displaying dates according to locale, expects a value like `'en-gb'` for British English. For more information, see [Supported locale modifiers for SET_LOCALE](https://support.airtable.com/docs/supported-locale-modifiers-for-set-locale).  
   
-  </dd>
+</dd>
 
-  <dt><b>Offset</b></dt>
-  <dd>
+#### Offset
+
+<dd>
 
 This field expects an `offset` token from the query's prior response. That token acts as a cursor to tell your base where in its records to begin returning results.
 
-  </dd>
+</dd>
 
-</dl>
 
 ### Create records
 
 This command creates new entries in your Airtable base. The following section lists all the fields available for the **Create records** command.
 
-<dl>
-  <dt><b>Base ID</b></dt>
-  <dd>
+#### Base ID
+
+<dd>
 
 A string that uniquely identifies your Airtable base. To find your Base ID, see [Find your Base ID](#find-your-base-id).
 
-  </dd>
+</dd>
 
-  <dt><b>Table name</b></dt>
-  <dd>
+#### Table name
+
+<dd>
 
 The name of the table to query from your base.
-  
-  </dd>
 
-  <dt><b>Records</b></dt>
-  <dd>
+</dd>
+
+#### Records
+
+<dd>
 
 Data for the new records to create. Expects an array of objects, where each object has a `fields` key containing an object of column key-value pairs. For example:
 
@@ -228,87 +238,88 @@ Data for the new records to create. Expects an array of objects, where each obje
 ]
 ```
   
-  </dd>
+</dd>
 
-</dl>
 
 ### Delete a record
 
 This command deletes one entry in your Airtable base. The following section lists all the fields available for the **Delete a record** command.
 
-<dl>
-  <dt><b>Base ID</b></dt>
-  <dd>
+#### Base ID
+
+<dd>
 
 A string that uniquely identifies your Airtable base. To find your Base ID, see [Find your Base ID](#find-your-base-id).
 
-  </dd>
+</dd>
 
-  <dt><b>Table name</b></dt>
-  <dd>
+#### Table name
+
+<dd>
 
 The name of the table to query from your base.
-  
-  </dd>
 
-  <dt><b>Record ID</b></dt>
-  <dd>
+</dd>
+
+#### Record ID
+
+<dd>
 
 The string ID of the record to delete.
-  
-  </dd>
 
-</dl>
+</dd>
 
 ### Retrieve a record
 
 This command fetches one entry from your Airtable base by its string ID. The following section lists all the fields available for the **Retrieve a record** command.
 
-<dl>
-  <dt><b>Base ID</b></dt>
-  <dd>
+#### Base ID
+
+<dd>
 
 A string that uniquely identifies your Airtable base. To find your Base ID, see [Find your Base ID](#find-your-base-id).
 
-  </dd>
+</dd>
 
-  <dt><b>Table name</b></dt>
-  <dd>
+#### Table name
+
+<dd>
 
 The name of the table to query from your base.
-  
-  </dd>
 
-  <dt><b>Record ID</b></dt>
-  <dd>
+</dd>
+
+#### Record ID
+
+<dd>
 
 The string ID of the record to retrieve.
-  
-  </dd>
 
-</dl>
+</dd>
 
 ### Update records
 
 This command updates entries in your Airtable base, selected by their string IDs. The following section lists all the fields available for the **Update records** command.
 
-<dl>
-  <dt><b>Base ID</b></dt>
-  <dd>
+#### Base ID
+
+<dd>
 
 A string that uniquely identifies your Airtable base. To find your Base ID, see [Find your Base ID](#find-your-base-id).
 
-  </dd>
+</dd>
 
-  <dt><b>Table name</b></dt>
-  <dd>
+#### Table name
+
+<dd>
 
 The name of the table to query from your base.
-  
-  </dd>
 
-  <dt><b>Records</b></dt>
-  <dd>
+</dd>
+
+#### Records
+
+<dd>
 
 Data for the records to update. Expects an array of objects, where each object has an `id` key containing the ID of the record to update, and a `fields` key containing an object of column key-value pairs. For example:
 
@@ -325,9 +336,7 @@ Data for the records to update. Expects an array of objects, where each object h
 ]
 ```
   
-  </dd>
-
-</dl>
+</dd>
 
 ## Troubleshooting
 

--- a/website/docs/connect-data/reference/authenticated-api.md
+++ b/website/docs/connect-data/reference/authenticated-api.md
@@ -21,82 +21,85 @@ The following section is a reference guide that provides a complete description 
 The datasource configuration fields do not accept JavaScript code or mustache syntax.
 :::
 
-<dl>
-  <dt><b>URL</b></dt>
-  <dd>
+#### URL
+
+<dd>
 
 The URL of the service to query. For a guide about connecting to a local APIs, see [Connect Local Database](/connect-data/how-to-guides/how-to-work-with-local-apis-on-appsmith).
 
-  </dd>
+</dd>
 
-  <dt><b>Headers</b></dt>
-  <dd>
-  
+#### Headers
+
+<dd>
+
 Key-value pairs to include in the header section of your HTTP requests.
 
-  </dd><br/>
+</dd>
 
-  <dt><b>Query parameters</b></dt>
-  <dd>
-  
+#### Query parameters
+
+<dd>
+
 Key-value pairs that should be passed as parameters in the URL of your HTTP requests.
 
-  </dd><br/>
+</dd>
 
-  <dt><b>Send Appsmith signature header</b></dt>
-  <dd>
-  
+#### Send Appsmith signature header
+
+<dd>
+
 When enabled, you can enter a secret string of at least 32 characters in the <b>Session Details Signature Key</b> field. Every API call made to this datasource then includes an additional header, <code>X-Appsmith-Signature</code>, whose value is a <a href="https://jwt.io">JSON Web Token (JWT)</a> signed with a signature created from your secret string. This can be used to help prove the integrity and authenticity of your requests originating from Appsmith.
 
-  </dd><br/>
+</dd>
 
-<dt><b>Authentication Type</b></dt>
-  <dd>Sets the method used to authenticate requests. Configure details under the <b>Authentication</b> dropdown after selecting your Authentication Type.</dd><br/>
-  <dd><i>Options:</i>
-    <ul>
-      <li><b>None:</b> Does not send any authentication information.</li>
-      <li><b>Basic:</b> Expects a <b>Username</b> and <b>Password</b>, which are sent in each request as a base64-encoded string in the request's Authorization header.</li>
-      <li>
-        <b>OAuth 2.0:</b> Enables several fields for configuring an OAuth 2.0 integration.
+#### Authentication Type
+
+<dd>Sets the method used to authenticate requests. Configure details under the <b>Authentication</b> dropdown after selecting your Authentication Type.</dd><br/>
+<dd><i>Options:</i>
+  <ul>
+    <li><b>None:</b> Does not send any authentication information.</li>
+    <li><b>Basic:</b> Expects a <b>Username</b> and <b>Password</b>, which are sent in each request as a base64-encoded string in the request's Authorization header.</li>
+    <li>
+      <b>OAuth 2.0:</b> Enables several fields for configuring an OAuth 2.0 integration.
+      <ul>
+        <li><b>Grant Type:</b> An authorization grant type is a secured representation of the owner’s authorization presented in exchange for an access token.</li>
+        <i>Options:</i>
         <ul>
-          <li><b>Grant Type:</b> An authorization grant type is a secured representation of the owner’s authorization presented in exchange for an access token.</li>
-          <i>Options:</i>
-          <ul>
-            <li><b>Authorization Code</b> : An authorization code is a temporary code authorized by an authorization server. You can get an access token in exchange for an authorization code. Once you get an access token, you can use it to access the resources or perform actions on behalf of the user.</li>
-            <li><b>Client Credentials</b>.</li>
-          </ul>
-          <li><b>Add Access Token To:</b> Sets whether the access token is sent as a <b>Request Header</b> or as a query parameter (<b>Request URL</b>).</li>
-          <li><b>Header Prefix:</b> When the access token is sent as a header, this sets a string to prefix the access token. A common example is <code>Bearer</code>.</li>
-          <li><b>Access Token URL:</b> The endpoint on the authentication server that is used to exchange the authorization code for an access token.</li>
-          <li><b>Client ID:</b> The identifier issued to the client by the OAuth provider during app registration.</li>
-          <li><b>Client Secret:</b> The secret string issued to the client by the OAuth provider during app registration.</li>
-          <li><b>Scopes:</b> Sets the requested scopes that are requested. This field can have multiple comma-separated values.</li>
-          <li><b>Client Authorization:</b> Sends the client secret either in the request body as <code>client_id</code> and <code>client_secret</code> parameters or within the headers encoded as basic HTTP authentication.</li>
-          <li><b>Authorization URL:</b> The endpoint on the authentication server that is used to request authentication for the client.</li>
-          <li><b>Redirect URL:</b> The URL that the OAuth server should redirect to.</li>
-          <li><b>Custom Authentication Parameters:</b> User-defined key/value pairs to be encoded and sent as authentication parameters.</li>
-          <li><b>Audience:</b> Expects a URL, specifies the intended audience for the OAuth access token.</li>
-          <li><b>Resource:</b> Expects a URL, specifies an application to act as a resource server.</li>
+          <li><b>Authorization Code</b> : An authorization code is a temporary code authorized by an authorization server. You can get an access token in exchange for an authorization code. Once you get an access token, you can use it to access the resources or perform actions on behalf of the user.</li>
+          <li><b>Client Credentials</b>.</li>
         </ul>
-      </li>
-      <li><b>API Key:</b> Sends a key/value pair which is sent as a base64-encoded string in the request's Authorization header. You can specify the key's prefix, as well as choose whether it's sent in the request header or the query params.</li>
-      <li><b>Bearer Token:</b> Sends a bearer token value as a base64-encoded string in the request's Authorization header. If you are using OIDC protocol to log in to your instance, you can use the <a href="/getting-started/setup/instance-configuration/authentication/json-web-tokens-jwt#access-token">access token</a> of the logged-in user as a bearer token.</li>
-    </ul>
-  </dd><br/>
+        <li><b>Add Access Token To:</b> Sets whether the access token is sent as a <b>Request Header</b> or as a query parameter (<b>Request URL</b>).</li>
+        <li><b>Header Prefix:</b> When the access token is sent as a header, this sets a string to prefix the access token. A common example is <code>Bearer</code>.</li>
+        <li><b>Access Token URL:</b> The endpoint on the authentication server that is used to exchange the authorization code for an access token.</li>
+        <li><b>Client ID:</b> The identifier issued to the client by the OAuth provider during app registration.</li>
+        <li><b>Client Secret:</b> The secret string issued to the client by the OAuth provider during app registration.</li>
+        <li><b>Scopes:</b> Sets the requested scopes that are requested. This field can have multiple comma-separated values.</li>
+        <li><b>Client Authorization:</b> Sends the client secret either in the request body as <code>client_id</code> and <code>client_secret</code> parameters or within the headers encoded as basic HTTP authentication.</li>
+        <li><b>Authorization URL:</b> The endpoint on the authentication server that is used to request authentication for the client.</li>
+        <li><b>Redirect URL:</b> The URL that the OAuth server should redirect to.</li>
+        <li><b>Custom Authentication Parameters:</b> User-defined key/value pairs to be encoded and sent as authentication parameters.</li>
+        <li><b>Audience:</b> Expects a URL, specifies the intended audience for the OAuth access token.</li>
+        <li><b>Resource:</b> Expects a URL, specifies an application to act as a resource server.</li>
+      </ul>
+    </li>
+    <li><b>API Key:</b> Sends a key/value pair which is sent as a base64-encoded string in the request's Authorization header. You can specify the key's prefix, as well as choose whether it's sent in the request header or the query params.</li>
+    <li><b>Bearer Token:</b> Sends a bearer token value as a base64-encoded string in the request's Authorization header. If you are using OIDC protocol to log in to your instance, you can use the <a href="/getting-started/setup/instance-configuration/authentication/json-web-tokens-jwt#access-token">access token</a> of the logged-in user as a bearer token.</li>
+  </ul>
+</dd>
 
-<dt><b>Use self-signed certificate</b></dt>
-  <dd>
-  
+#### Use self-signed certificate
+
+<dd>
+
 When enabled, you can upload your own self-signed certificate for accessing your endpoint. These can be useful for accessing your API without relying on external agnecies to issue certificates for authenticating the origin of your requests.
 
-  </dd>
-  <dd>
-  
+</dd>
+<dd>
+
 This information needs to be provided in .PEM (_Privacy Enhanced Mail_) format. The certificate information is stored securely in an encrypted format in the database.
 
-  </dd>
-
-</dl>
+</dd>
 
 ## Queries
 

--- a/website/docs/connect-data/reference/hubspot.md
+++ b/website/docs/connect-data/reference/hubspot.md
@@ -18,15 +18,16 @@ The following section is a reference guide that provides a complete description 
    <figcaption align = "center"><i>Configuring a HubSpot datasource.</i></figcaption>
 </figure>
 
-<dl>
-  <dt><b>Authentication Type</b></dt>
-  <dd><i>Options:</i>
-    <ul>
-    <li><b>Bearer Token:</b> An access token that authenticates your queries to HubSpot. For more information on finding your access token, follow HubSpot's <a href="https://developers.hubspot.com/docs/api/private-apps">Private App integration guide</a>.</li>
-    </ul>
-  </dd>
 
-</dl>
+#### Authentication Type
+
+<dd><i>Options:</i>
+  <ul>
+  <li><b>Bearer Token:</b> An access token that authenticates your queries to HubSpot. For more information on finding your access token, follow HubSpot's <a href="https://developers.hubspot.com/docs/api/private-apps">Private App integration guide</a>.</li>
+  </ul>
+</dd>
+
+
 
 ## Query HubSpot
 
@@ -45,406 +46,428 @@ The following sections describe the parameters for connecting to HubDB type quer
 
 The **HubDB - get published tables** command fetches information for the HubDB tables associated with your HubSpot account. The following is a list of all the fields available for **HubDB - get published tables**:
 
-<dl>
-  <dt><b>Sort</b></dt>
-  <dd>The name of a field by which to sort the fetched tables, such as <code>name</code> or creation time (<code>createdAt</code>). Requires a single field.
-  </dd><br />
+##### Sort
 
-  <dt><b>Next Page Token</b></dt>
-  <dd>A token sent in the response to your query that is used in subsequent queries to fetch the next page of data:</dd>
-  <dd><pre>{`{{ GetRowsQuery.data.paging?.next.after || "" }}`}</pre></dd><br />
+<dd>The name of a field by which to sort the fetched tables, such as <code>name</code> or creation time (<code>createdAt</code>). Requires a single field.
+</dd>
 
-  <dt><b>Limit</b></dt>
-  <dd>The maxiumum number of items that can be returned in a single query response.
-  </dd><br />
+##### Next Page Token
 
-  <dt><b>Created at</b></dt>
-  <dd>Returns only records that were created at this given date/time. Format: <code>YYYY-MM-DDThh:mm:ss.sZ</code>.
-  </dd><br />
+<dd>A token sent in the response to your query that is used in subsequent queries to fetch the next page of data:</dd>
+<dd><pre>{`{{ GetRowsQuery.data.paging?.next.after || "" }}`}</pre></dd>
 
-  <dt><b>Created after</b></dt>
-  <dd>Returns only records that were created after the given date/time. Format: <code>YYYY-MM-DDThh:mm:ss.sZ</code>.
-  </dd><br />
+##### Limit
 
-  <dt><b>Created before</b></dt>
-  <dd>Returns only records that were created before this given date/time. Format: <code>YYYY-MM-DDThh:mm:ss.sZ</code>.
-  </dd><br />
+<dd>The maxiumum number of items that can be returned in a single query response.
+</dd>
 
-  <dt><b>Updated at</b></dt>
-  <dd>Returns only records that were updated at this given date/time. Format: <code>YYYY-MM-DDThh:mm:ss.sZ</code>.
-  </dd><br />
+##### Created at
 
-  <dt><b>Updated after</b></dt>
-  <dd>Returns only records that were updated after the given date/time. Format: <code>YYYY-MM-DDThh:mm:ss.sZ</code>.
-  </dd><br />
+<dd>Returns only records that were created at this given date/time. Format: <code>YYYY-MM-DDThh:mm:ss.sZ</code>.
+</dd>
 
-  <dt><b>Updated before</b></dt>
-  <dd>Returns only records that were updated before this given date/time. Format: <code>YYYY-MM-DDThh:mm:ss.sZ</code>.
-  </dd><br />
+##### Created after
 
-  <dt><b>Archive</b></dt>
-  <dd>A boolean value; when <code>true</code>, the query only returns table data for tables that are archived.
-  </dd><br />
+<dd>Returns only records that were created after the given date/time. Format: <code>YYYY-MM-DDThh:mm:ss.sZ</code>.
+</dd>
 
-</dl>
+##### Created before
+
+<dd>Returns only records that were created before this given date/time. Format: <code>YYYY-MM-DDThh:mm:ss.sZ</code>.
+</dd>
+
+##### Updated at
+
+<dd>Returns only records that were updated at this given date/time. Format: <code>YYYY-MM-DDThh:mm:ss.sZ</code>.
+</dd>
+
+##### Updated after
+
+<dd>Returns only records that were updated after the given date/time. Format: <code>YYYY-MM-DDThh:mm:ss.sZ</code>.
+</dd>
+
+##### Updated before
+
+<dd>Returns only records that were updated before this given date/time. Format: <code>YYYY-MM-DDThh:mm:ss.sZ</code>.
+</dd>
+
+##### Archive
+
+<dd>A boolean value; when <code>true</code>, the query only returns table data for tables that are archived.
+</dd>
 
 #### Create table
 
 The **HubDB - create table** command creates a new HubDB table. The following is a list of all the fields available for **HubDB - create table**:
 
-<dl>
-  <dt><b>Name</b></dt>
-  <dd>The name of the new table.
-  </dd><br />
 
-  <dt><b>Label</b></dt>
-  <dd>The label of the new table.</dd><br />
+##### Name
 
-  <dt><b>Use for pages</b></dt>
-  <dd>A boolean that, when <code>true</code>, allows the new table to be used for creating dynamic website pages.</dd><br />
+<dd>The name of the new table.
+</dd>
 
-  <dt><b>Columns</b></dt>
-  <dd>A JSON array of column names to add to the new table: <code>["hello", "world", "apple"]</code></dd><br />
+##### Label
 
-  <dt><b>Allow Public API access</b></dt> 
-  <dd>A boolean that, when <code>true</code>, allows the table to be read via public API without authorization.</dd><br />
+<dd>The label of the new table.</dd>
 
-  <dt><b>Allow child tables</b></dt> 
-  <dd>A boolean that, when <code>true</code>, allows the creation of related child tables.</dd><br />
+##### Use for pages
 
-  <dt><b>Allow child table pages</b></dt> 
-  <dd>A boolean that, when <code>true</code>, allows the creation of multi-level dynamic pages referencing the child table.</dd><br />
+<dd>A boolean that, when <code>true</code>, allows the new table to be used for creating dynamic website pages.</dd>
 
-  <dt><b>Foreign table ID</b></dt> 
-  <dd>The ID of another table that is related to the new table as a Foreign Key.</dd><br />
+##### Columns
 
-  <dt><b>Foreign table ID</b></dt> 
-  <dd>The ID of a column from another table that is used as a Foreign Key.</dd><br />
+<dd>A JSON array of column names to add to the new table: <code>["hello", "world", "apple"]</code></dd>
 
-  <dt><b>Dynamic meta tags</b></dt>
-  <dd>Key/value pairs to use for setting which table columns map to which metadata types. For example, to set the **Meta description column** to be the column with an <code>id</code> of <code>3</code>, use: <code>&#123; "DESCRIPTION": 3 &#125;</code></dd>
+##### Allow Public API access
 
-</dl>
+<dd>A boolean that, when <code>true</code>, allows the table to be read via public API without authorization.</dd>
+
+##### Allow child tables
+
+<dd>A boolean that, when <code>true</code>, allows the creation of related child tables.</dd>
+
+##### Allow child table pages 
+
+<dd>A boolean that, when <code>true</code>, allows the creation of multi-level dynamic pages referencing the child table.</dd>
+
+##### Foreign table ID 
+
+<dd>The ID of another table that is related to the new table as a Foreign Key.</dd>
+
+##### Foreign table ID 
+
+<dd>The ID of a column from another table that is used as a Foreign Key.</dd>
+
+##### Dynamic meta tags
+
+<dd>Key/value pairs to use for setting which table columns map to which metadata types. For example, to set the **Meta description column** to be the column with an <code>id</code> of <code>3</code>, use: <code>&#123; "DESCRIPTION": 3 &#125;</code></dd>
 
 #### Get details of a published table
 
 The **HubDB - get details of a published table** command fetches data about a HubDB table. The following is a list of all the fields available for **HubDB - get details of a published table**:
 
-<dl>
-  <dt><b>Archived</b></dt>
-  <dd>A boolean value; when <code>true</code>, the query includes data for tables that are archived.
-  </dd><br />
 
-  <dt><b>Include foreign IDs</b></dt>
-  <dd>A boolean value; when <code>true</code>, the details for related child/foreign tables are included in the results.
-  </dd><br />
+##### Archived
 
-  <dt><b>Table ID or name</b></dt>
-  <dd>The name of your HubDB table, or its numerical <code>ID</code> value.
-  </dd><br />
+<dd>A boolean value; when <code>true</code>, the query includes data for tables that are archived.
+</dd>
 
-</dl>
+##### Include foreign IDs
 
-#### Archive table
+<dd>A boolean value; when <code>true</code>, the details for related child/foreign tables are included in the results.
+</dd>
+
+##### Table ID or name
+
+<dd>The name of your HubDB table, or its numerical <code>ID</code> value.
+</dd>
+
+##### Archive table
 
 The **HubDB - archive table** archives a HubDB table. The following is a list of all the fields available for **HubDB - archive table**:
 
-<dl>
-  <dt><b>Table ID or name</b></dt>
-  <dd>The name of your HubDB table, or its numerical <code>ID</code> value.
-  </dd><br />
+##### Table ID or name
 
-</dl>
+<dd>The name of your HubDB table, or its numerical <code>ID</code> value.
+</dd>
 
 #### Update existing table
 
 The **HubDB - update existing table** command fetches rows from a HubDB table. The following is a list of all the fields available for **HubDB - update existing table**:
 
-<dl>
-  <dt><b>Archived</b></dt>
-  <dd>A boolean value; when <code>true</code>, the query returns data only for tables that are archived.
-  </dd><br />
 
-  <dt><b>Include foreign IDs</b></dt>
-  <dd>A boolean value; when <code>true</code>, the details for related child/foreign tables are included in the results.
-  </dd><br />
+##### Archived
 
-  <dt><b>Table ID or name</b></dt>
-  <dd>The name of your HubDB table, or its numerical <code>ID</code> value.
-  </dd><br />
+<dd>A boolean value; when <code>true</code>, the query returns data only for tables that are archived.
+</dd>
 
-  <dt><b>Name</b></dt>
-  <dd>The name of the new table.
-  </dd><br />
+##### Include foreign IDs
 
-  <dt><b>Label</b></dt>
-  <dd>The label of the new table.</dd><br />
+<dd>A boolean value; when <code>true</code>, the details for related child/foreign tables are included in the results.
+</dd>
 
-  <dt><b>Use for pages</b></dt>
-  <dd>A boolean that, when <code>true</code>, allows the new table to be used for creating dynamic website pages.</dd><br />
+##### Table ID or name
 
-  <dt><b>Columns</b></dt>
-  <dd>A JSON array of column names to add to the new table: <code>["hello", "world", "apple"]</code></dd><br />
+<dd>The name of your HubDB table, or its numerical <code>ID</code> value.
+</dd>
 
-  <dt><b>Allow Public API access</b></dt> 
-  <dd>A boolean that, when <code>true</code>, allows the table to be read via public API without authorization.</dd><br />
+##### Name
 
-  <dt><b>Allow child tables</b></dt> 
-  <dd>A boolean that, when <code>true</code>, allows the creation of related child tables.</dd><br />
+<dd>The name of the new table.
+</dd>
 
-  <dt><b>Allow child table pages</b></dt> 
-  <dd>A boolean that, when <code>true</code>, allows the creation of multi-level dynamic pages referencing the child table.</dd><br />
+##### Label
 
-  <dt><b>Foreign table ID</b></dt> 
-  <dd>The ID of another table that is related to the new table as a Foreign Key.</dd><br />
+<dd>The label of the new table.</dd>
 
-  <dt><b>Foreign table ID</b></dt> 
-  <dd>The ID of a column from another table that is used as a Foreign Key.</dd><br />
+##### Use for pages
 
-  <dt><b>Dynamic meta tags</b></dt>
-  <dd>Key/value pairs to use for setting which table columns map to which metadata types. For example, to set the <b>Meta description column</b> to be the column with an <code>id</code> of <code>3</code>, use: <code>&#123; "DESCRIPTION": 3 &#125;</code></dd>
+<dd>A boolean that, when <code>true</code>, allows the new table to be used for creating dynamic website pages.</dd>
 
-</dl>
+##### Columns
 
+<dd>A JSON array of column names to add to the new table: <code>["hello", "world", "apple"]</code></dd>
 
-#### Clone table
+##### Allow Public API access 
+
+<dd>A boolean that, when <code>true</code>, allows the table to be read via public API without authorization.</dd>
+
+##### Allow child tables 
+
+<dd>A boolean that, when <code>true</code>, allows the creation of related child tables.</dd>
+
+##### Allow child table pages 
+
+<dd>A boolean that, when <code>true</code>, allows the creation of multi-level dynamic pages referencing the child table.</dd>
+
+##### Foreign table ID 
+
+<dd>The ID of another table that is related to the new table as a Foreign Key.</dd>
+
+##### Foreign table ID 
+
+<dd>The ID of a column from another table that is used as a Foreign Key.</dd>
+
+##### Dynamic meta tags
+
+<dd>Key/value pairs to use for setting which table columns map to which metadata types. For example, to set the <b>Meta description column</b> to be the column with an <code>id</code> of <code>3</code>, use: <code>&#123; "DESCRIPTION": 3 &#125;</code></dd>
+
+##### Clone table
 
 The **HubDB - clone table** command clones an existing HubDB table. The following is a list of all the fields available for **HubDB - clone table**:
 
-<dl>
-  <dt><b>Table ID or name</b></dt>
-  <dd>The name of your HubDB table, or its numerical <code>ID</code> value.
-  </dd><br />
+#### Table ID or name
 
-  <dt><b>New name</b></dt>
-  <dd>The name of your new HubDB table.
-  </dd><br />
+<dd>The name of your HubDB table, or its numerical <code>ID</code> value.
+</dd>
 
-  <dt><b>New label</b></dt>
-  <dd>The label of your new HubDB table.
-  </dd><br />
+##### New name
 
-  <dt><b>Copy rows</b></dt>
-  <dd>A boolean that, when <code>true</code>, copies the rows from the cloned table into the new table.
-  </dd><br />
+<dd>The name of your new HubDB table.
+</dd>
 
-</dl>
+##### New label
+
+<dd>The label of your new HubDB table.
+</dd>
+
+##### Copy rows
+
+<dd>A boolean that, when <code>true</code>, copies the rows from the cloned table into the new table.
+</dd>
 
 #### Export published version table
 
 The **HubDB - export published version table** command returns the file data for a HubDB table in a given format. The following is a list of all the fields available for **HubDB - export published version table**:
 
-<dl>
-  <dt><b>Include foreign IDs</b></dt>
-  <dd>A boolean value; when <code>true</code>, the details for related child/foreign tables are included in the results.
-  </dd><br />
+##### Include foreign IDs
 
-  <dt><b>Table ID or name</b></dt>
-  <dd>The name of your HubDB table, or its numerical <code>ID</code> value.
-  </dd><br />
+<dd>A boolean value; when <code>true</code>, the details for related child/foreign tables are included in the results.
+</dd>
 
-</dl>
+##### Table ID or name
 
-#### Unpublish table
+<dd>The name of your HubDB table, or its numerical <code>ID</code> value.
+</dd>
+
+##### Unpublish table
 
 The **HubDB - unpublish table** command unpublishes a given HubDB table. The following is a list of all the fields available for **HubDB - unpublish table**:
 
-<dl>
-  <dt><b>Include foreign IDs</b></dt>
-  <dd>The file format of the exported table data. Allows <code>CSV</code>, <code>XLSX</code>, or <code>XLS</code>.
-  </dd><br />
+##### Include foreign IDs
 
-  <dt><b>Table ID or name</b></dt>
-  <dd>The name of your HubDB table, or its numerical <code>ID</code> value.
-  </dd><br />
+<dd>The file format of the exported table data. Allows <code>CSV</code>, <code>XLSX</code>, or <code>XLS</code>.
+</dd>
 
-</dl>
+##### Table ID or name
 
+<dd>The name of your HubDB table, or its numerical <code>ID</code> value.
+</dd>
 
-#### Get table rows
+##### Get table rows
 
 The **HubDB - get table rows** command fetches rows from a HubDB table. The following is a list of all the fields available for **HubDB - get table rows**:
 
-<dl>
-  <dt><b>Sort</b></dt>
-  <dd>The name of a field by which to sort the fetched records. Requires a single column name, such as <code>name</code>.
-  </dd><br />
+##### Sort
 
-  <dt><b>Next Page Token</b></dt>
-  <dd>A token sent in the response to your query that is used in subsequent queries to fetch the next page of data:</dd>
-  <dd><pre>{`{{ GetRowsQuery.data.paging?.next.after || "" }}`}</pre></dd>
+<dd>The name of a field by which to sort the fetched records. Requires a single column name, such as <code>name</code>.
+</dd>
 
-  <dt><b>Limit</b></dt>
-  <dd>The maxiumum number of rows that can be returned in a single query response.
-  </dd><br />
+##### Next Page Token
 
-  <dt><b>Properties</b></dt>
-  <dd>A comma-separated list of columns that should be fetched for each returned record.
-  </dd><br />
+<dd>A token sent in the response to your query that is used in subsequent queries to fetch the next page of data:</dd>
+<dd><pre>{`{{ GetRowsQuery.data.paging?.next.after || "" }}`}</pre></dd>
 
-  <dt><b>Table ID or name</b></dt>
-  <dd>The name of your HubDB table, or its numerical <code>ID</code> value.
-  </dd><br />
+##### Limit
 
-</dl>
+<dd>The maxiumum number of rows that can be returned in a single query response.
+</dd>
 
+##### Properties
 
-#### Add new table row
+<dd>A comma-separated list of columns that should be fetched for each returned record.
+</dd>
+
+##### Table ID or name
+
+<dd>The name of your HubDB table, or its numerical <code>ID</code> value.
+</dd>
+
+##### Add new table row
 
 The **HubDB - add new table row** command creates a new row in a HubDB table. The following is a list of all the fields available for **HubDB - add new table row**:
 
-<dl>
-  <dt><b>Table ID or name</b></dt>
-  <dd>The name of your HubDB table, or its numerical <code>ID</code> value.
-  </dd><br />
+##### Table ID or name
+<dd>The name of your HubDB table, or its numerical <code>ID</code> value.
+</dd>
 
-  <dt><b>Path</b></dt>
-  <dd>If you're using HubSpot's dynamic pages, this field is the URL slug for the new page created for this table row.
-  </dd><br />
+##### Path
+<dd>If you're using HubSpot's dynamic pages, this field is the URL slug for the new page created for this table row.
+</dd>
 
-  <dt><b>Name</b></dt>
-  <dd>If you're using HubSpot's dynamic pages, this field is the page title for the new page created for this table row.</dd><rb/>
+##### Name
+<dd>If you're using HubSpot's dynamic pages, this field is the page title for the new page created for this table row.</dd><rb/>
 
-  <dt><b>Child table ID</b></dt>
-  <dd>The ID for another HubDB table. This is used as a Foreign Key to create a relationship between records. To connect a specific record from the child table, pass its <code>ID</code> as a string value in the JSON object of your query's <b>Values</b> field.
-  </dd><br />
+##### Child table ID
+<dd>The ID for another HubDB table. This is used as a Foreign Key to create a relationship between records. To connect a specific record from the child table, pass its <code>ID</code> as a string value in the JSON object of your query's <b>Values</b> field.
+</dd>
 
-  <dt><b>Values</b></dt>
-  <dd>A JSON object with key/value pairs representing the new record. If you are creating a relationship using the <b>Child table ID</b> field, you can pass the <code>ID</code> of a corresponding record from the child table as a string value. For example, if you refer to a child table called <code>buyer</code>:
-  <pre>{`{
+##### Values
+<dd>A JSON object with key/value pairs representing the new record. If you are creating a relationship using the <b>Child table ID</b> field, you can pass the <code>ID</code> of a corresponding record from the child table as a string value. For example, if you refer to a child table called <code>buyer</code>:
+<pre>{`{
     "name": "MyProduct",
     "buyer": "121529803132"
 }`}</pre>
-  </dd><br />
+</dd>
 
-</dl>
-
-
-#### Update existing row
+##### Update existing row
 
 The **HubDB - update existing row** command updates an existing row in a HubDB table. The following is a list of all the fields available for **HubDB - update existing row**:
 
-<dl>
-  <dt><b>Table ID or name</b></dt>
-  <dd>The name of your HubDB table, or its numerical <code>ID</code> value.
-  </dd><br />
+##### Table ID or name
 
-  <dt><b>Row ID</b></dt>
-  <dd>The <code>ID</code> of the table row that you'd like to update.</dd><rb/>
+<dd>The name of your HubDB table, or its numerical <code>ID</code> value.
+</dd>
 
-  <dt><b>Path</b></dt>
-  <dd>If you're using HubSpot's dynamic pages, this field is the URL slug for the new page created for this table row.
-  </dd><br />
+##### Row ID
 
-  <dt><b>Name</b></dt>
-  <dd>If you're using HubSpot's dynamic pages, this field is the page title for the new page created for this table row.</dd><rb/>
+<dd>The <code>ID</code> of the table row that you'd like to update.</dd>
 
-  <dt><b>Child table ID</b></dt>
-  <dd>The ID for another HubDB table. This is used as a Foreign Key to create a relationship between records. To connect a specific record from the child table, pass its <code>ID</code> as a string value in the JSON object of your query's <b>Values</b> field.
-  </dd><br />
+##### Path
 
-  <dt><b>Values</b></dt>
+<dd>If you're using HubSpot's dynamic pages, this field is the URL slug for the new page created for this table row.
+</dd>
+
+##### Name
+
+<dd>If you're using HubSpot's dynamic pages, this field is the page title for the new page created for this table row.</dd><rb/>
+
+##### Child table ID
+
+<dd>The ID for another HubDB table. This is used as a Foreign Key to create a relationship between records. To connect a specific record from the child table, pass its <code>ID</code> as a string value in the JSON object of your query's <b>Values</b> field.
+</dd>
+
+##### Values
+
   <dd>A JSON object with key/value pairs representing the new record. If you are creating a relationship using the <b>Child table ID</b> field, you can pass the <code>ID</code> of a corresponding record from the child table as a string value. For example, if you refer to a child table called <code>buyer</code>:
   <pre>{`{
     "name": "MyProduct",
     "buyer": "121529803132"
 }`}</pre>
-  </dd><br />
+</dd>
 
-</dl>
-
-#### Replace existing row
+##### Replace existing row
 
 The **HubDB - replace existing row** command replaces an existing row in a HubDB table. The following is a list of all the fields available for **HubDB - replace existing row**:
 
-<dl>
-  <dt><b>Table ID or name</b></dt>
-  <dd>The name of your HubDB table, or its numerical <code>ID</code> value.
-  </dd><br />
+##### Table ID or name
 
-  <dt><b>Row ID</b></dt>
-  <dd>The <code>ID</code> of the table row that you'd like to replace.</dd><rb/>
+<dd>The name of your HubDB table, or its numerical <code>ID</code> value.
+</dd>
 
-  <dt><b>Path</b></dt>
-  <dd>If you're using HubSpot's dynamic pages, this field is the URL slug for the new page created for this table row.
-  </dd><br />
+##### Row ID
 
-  <dt><b>Name</b></dt>
-  <dd>If you're using HubSpot's dynamic pages, this field is the page title for the new page created for this table row.</dd><rb/>
+<dd>The <code>ID</code> of the table row that you'd like to replace.</dd>
 
-  <dt><b>Child table ID</b></dt>
-  <dd>The ID for another HubDB table. This is used as a Foreign Key to create a relationship between records. To connect a specific record from the child table, pass its <code>ID</code> as a string value in the JSON object of your query's <b>Values</b> field.
-  </dd><br />
+##### Path
 
-  <dt><b>Values</b></dt>
-  <dd>A JSON object with key/value pairs representing the new record. If you are creating a relationship using the <b>Child table ID</b> field, you can pass the <code>ID</code> of a corresponding record from the child table as a string value. For example, if you refer to a child table called <code>buyer</code>:
-  <pre>{`{
+<dd>If you're using HubSpot's dynamic pages, this field is the URL slug for the new page created for this table row.
+</dd>
+
+##### Name
+
+<dd>If you're using HubSpot's dynamic pages, this field is the page title for the new page created for this table row.</dd>
+
+##### Child table ID
+
+<dd>The ID for another HubDB table. This is used as a Foreign Key to create a relationship between records. To connect a specific record from the child table, pass its <code>ID</code> as a string value in the JSON object of your query's <b>Values</b> field.
+</dd>
+
+##### Values
+
+<dd>A JSON object with key/value pairs representing the new record. If you are creating a relationship using the <b>Child table ID</b> field, you can pass the <code>ID</code> of a corresponding record from the child table as a string value. For example, if you refer to a child table called <code>buyer</code>:
+<pre>{`{
     "name": "MyProduct",
     "buyer": "121529803132"
 }`}</pre>
-  </dd><br />
-
-</dl>
-
+</dd>
 
 #### Permanently delete row
 
 The **HubDB - permanently delete row** command deletes an existing row from a HubDB table. The following is a list of all the fields available for **HubDB - permanently delete row**:
 
-<dl>
-  <dt><b>Table ID or name</b></dt>
-  <dd>The name of your HubDB table, or its numerical <code>ID</code> value.
-  </dd><br />
+##### Table ID or name
 
-  <dt><b>Row ID</b></dt>
-  <dd>The <code>ID</code> of the table row that you'd like to delete.</dd><br/>
+<dd>The name of your HubDB table, or its numerical <code>ID</code> value.
+</dd>
 
-</dl>
+##### Row ID
+
+<dd>The <code>ID</code> of the table row that you'd like to delete.</dd>
 
 #### Clone row
 
 The **HubDB - clone row** command clones an existing row in a HubDB table. The following is a list of all the fields available for **HubDB - clone row**:
 
-<dl>
-  <dt><b>Table ID or name</b></dt>
-  <dd>The name of your HubDB table, or its numerical <code>ID</code> value.
-  </dd><br />
+##### Table ID or name
 
-  <dt><b>Row ID</b></dt>
-  <dd>The ID of the table row to clone.
-  </dd><br />
+<dd>The name of your HubDB table, or its numerical <code>ID</code> value.
+</dd>
 
-</dl>
+##### Row ID
+
+<dd>The ID of the table row to clone.
+</dd>
 
 #### Get set rows
 
 The **HubDB - get set rows** command gets a batch of specific rows from a HubDB table. The following is a list of all the fields available for **HubDB - get set rows**:
 
-<dl>
-  <dt><b>Table ID or name</b></dt>
-  <dd>The name of your HubDB table, or its numerical <code>ID</code> value.
-  </dd><br />
 
-  <dt><b>Inputs</b></dt>
-  <dd>A JSON array with the IDs of the rows to get.
-  </dd><br />
+##### Table ID or name
 
-</dl>
+<dd>The name of your HubDB table, or its numerical <code>ID</code> value.
+</dd>
+
+##### Inputs
+
+<dd>A JSON array with the IDs of the rows to get.
+</dd>
 
 #### Permanently delete rows
 
 The **HubDB - permanently delete rows** command deletes a batch of specific rows from a HubDB table. The following is a list of all the fields available for **HubDB - permanently delete rows**:
 
-<dl>
-  <dt><b>Table ID or name</b></dt>
-  <dd>The name of your HubDB table, or its numerical <code>ID</code> value.
-  </dd><br />
+##### Table ID or name
 
-  <dt><b>Inputs</b></dt>
-  <dd>A JSON array with the IDs of the rows to get.
-  </dd><br />
+<dd>The name of your HubDB table, or its numerical <code>ID</code> value.
+</dd>
 
-</dl>
+##### Inputs
+
+<dd>A JSON array with the IDs of the rows to get.
+</dd>
+
 
 ### CRM
 
@@ -454,139 +477,143 @@ The following sections describe the parameters for connecting to CRM type querie
 
 The **CRM - list objects** command returns a list of entries for a given type of CRM objects. The following is a list of all the fields available for **CRM - list objects**:
 
-<dl>
-  <dt><b>Objects</b></dt>
-  <dd>The name of a type of CRM object to fetch, such as <code>contacts</code>.
-  </dd><br />
-
-</dl>
+##### Objects
+<dd>The name of a type of CRM object to fetch, such as <code>contacts</code>.
+</dd>
 
 #### Create object
 
 The **CRM - create objects** command creates a new object of the given type. The following is a list of all the fields available for **CRM - create objects**:
 
-<dl>
-  <dt><b>Objects</b></dt>
-  <dd>The name of a type of CRM object to fetch, such as <code>contacts</code>.
-  </dd><br />
 
-  <dt><b>Properties</b></dt>
-  <dd>A JSON object with key/value pairs that define the properties for the created CRM object.
-  </dd><br />
+##### Objects
 
-</dl>
+<dd>The name of a type of CRM object to fetch, such as <code>contacts</code>.
+</dd>
+
+##### Properties
+
+<dd>A JSON object with key/value pairs that define the properties for the created CRM object.
+</dd>
 
 #### Read object
 
 The **CRM - read object** command returns the details for a specific CRM object. The following is a list of all the fields available for **CRM - read object**:
 
-<dl>
-  <dt><b>Properties</b></dt>
-  <dd>A comma-separated list of columns that should be fetched for the object.
-  </dd><br />
+##### Properties
 
-  <dt><b>Properties with history</b></dt>
-  <dd>A comma-separated list of columns that should be fetched along with their history of previous values.
-  </dd><br />
+<dd>A comma-separated list of columns that should be fetched for the object.
+</dd>
 
-  <dt><b>Associations</b></dt>
-  <dd>A comma-separated list of related CRM object types whose IDs should be returned.
-  </dd><br />
+##### Properties with history
 
-  <dt><b>Archive</b></dt>
-  <dd>A boolean value; when <code>true</code>, the query only returns entries that are archived.
-  </dd><br />
+<dd>A comma-separated list of columns that should be fetched along with their history of previous values.
+</dd>
 
-  <dt><b>Object type</b></dt>
-  <dd>The name of a type of CRM object to fetch, such as <code>contacts</code>.
-  </dd><br />
+##### Associations
 
-  <dt><b>Object ID</b></dt>
-  <dd>The ID of the CRM object to fetch.
-  </dd><br />
+<dd>A comma-separated list of related CRM object types whose IDs should be returned.
+</dd>
 
-</dl>
+##### Archive
 
-#### Update object
+<dd>A boolean value; when <code>true</code>, the query only returns entries that are archived.
+</dd>
+
+##### Object type
+
+<dd>The name of a type of CRM object to fetch, such as <code>contacts</code>.
+</dd>
+
+##### Object ID
+
+<dd>The ID of the CRM object to fetch.
+</dd>
+
+##### Update object
 
 The **CRM - create objects** command updates a given CRM object. The following is a list of all the fields available for **CRM - create objects**:
 
-<dl>
-  <dt><b>Object type</b></dt>
-  <dd>The name of a type of CRM object to fetch, such as <code>contacts</code>.
-  </dd><br />
+##### Object type
 
-  <dt><b>Object ID</b></dt>
-  <dd>The ID of the CRM object to fetch.
-  </dd><br />
+<dd>The name of a type of CRM object to fetch, such as <code>contacts</code>.
+</dd>
 
-  <dt><b>Properties</b></dt>
-  <dd>A JSON object with key/value pairs that define the properties for the created CRM object.
-  </dd><br />
+##### Object ID
 
-</dl>
+<dd>The ID of the CRM object to fetch.
+</dd>
 
-#### Archive object
+##### Properties
+
+<dd>A JSON object with key/value pairs that define the properties for the created CRM object.
+</dd>
+
+##### Archive object
 
 The **CRM - Archive object** command archives a given CRM object. The following is a list of all the fields available for **CRM - Archive object**:
 
-<dl>
-  <dt><b>Object type</b></dt>
-  <dd>The name of a type of CRM object to fetch, such as <code>contacts</code>.
-  </dd><br />
+##### Object type
+<dd>The name of a type of CRM object to fetch, such as <code>contacts</code>.
+</dd>
 
-  <dt><b>Object ID</b></dt>
-  <dd>The ID of the CRM object to fetch.
-  </dd><br />
-
-</dl>
+##### Object ID
+<dd>The ID of the CRM object to fetch.
+</dd>
 
 #### Search object
 
-<dl>
-  <dt><b>Object type</b></dt>
-  <dd>The name of a type of CRM object to fetch, such as <code>contacts</code>.
-  </dd><br />
 
-  <dt><b>Property name</b></dt>
-  <dd>The name of a property by which to filter results
-  </dd><br />
+##### Object type
 
-  <dt><b>Value</b></dt>
-  <dd>The value that returned records should have for the property specified in <b>Property name</b>.
-  </dd><br />
+<dd>The name of a type of CRM object to fetch, such as <code>contacts</code>.
+</dd>
 
-  <dt><b>Operator</b></dt>
-  <dd>The logical operator that should be used to compare the object's actual property value to the value specified in <b>Value</b>.
-  </dd><br />
+##### Property name
 
-  <dt><b>Sorts</b></dt>
-  <dd>A sorting rule in the request body to list results in ascending or descending order. Only one sorting rule can be applied to any search. For example:<pre>{`{[
+<dd>The name of a property by which to filter results
+</dd>
+
+##### Value
+
+<dd>The value that returned records should have for the property specified in <b>Property name</b>.
+</dd>
+
+##### Operator
+
+<dd>The logical operator that should be used to compare the object's actual property value to the value specified in <b>Value</b>.
+</dd>
+
+##### Sorts
+
+<dd>A sorting rule in the request body to list results in ascending or descending order. Only one sorting rule can be applied to any search. For example:<pre>{`{[
       {
         "propertyName": "createdate",
         "direction": "DESCENDING"
       }
 ]}`}</pre>
-  </dd><br />
+</dd>
 
-  <dt><b>Query</b></dt>
-  <dd>A word to search for in the default text property of all CRM objects.
-  </dd><br />
+##### Query
 
-  <dt><b>Properties</b></dt>
-  <dd>A comma-separated list of columns that should be fetched for each returned record.
-  </dd><br />
+<dd>A word to search for in the default text property of all CRM objects.
+</dd>
 
-  <dt><b>Limit</b></dt>
-  <dd>The maxiumum number of rows that can be returned in a single query response.
-  </dd><br />  
+##### Properties
 
-  <dt><b>After</b></dt>
-  <dd>A token sent in the response to your query that is used in subsequent queries to fetch the next page of data:</dd>
-  <dd><pre>{`{{ SearchObjectQuery.data.paging?.next.after || "" }}`}</pre></dd>
+<dd>A comma-separated list of columns that should be fetched for each returned record.
+</dd>
 
+##### Limit
 
-</dl>
+<dd>The maxiumum number of rows that can be returned in a single query response.
+</dd> 
+
+##### After
+
+<dd>A token sent in the response to your query that is used in subsequent queries to fetch the next page of data:</dd>
+<dd><pre>{`{{ SearchObjectQuery.data.paging?.next.after || "" }}`}</pre></dd>
+
 
 ## Additional commands
 

--- a/website/docs/connect-data/reference/query-settings.md
+++ b/website/docs/connect-data/reference/query-settings.md
@@ -4,41 +4,47 @@ This page is a reference guide that provides a description of all the settings a
 
 You can find the following settings in the **Settings** tab of the query editor for an API or database query:
 
-<dl>
-  <dt><b>Encode query params</b></dt>
-  <dd>Toggles whether Appsmith converts parameters' special characters into their <a href="https://en.wikipedia.org/wiki/URL_encoding">URL-encoded</a> equivalents. It also encodes the form body when the <b>Content-Type</b> header is set to <code>FORM_URLENCODED</code>. This setting is available for API queries.
-  </dd><br />
+#### Encode query params
 
-  <dt><b>Use Prepared Statements</b></dt>
-  <dd>Toggles whether Appsmith uses pre-compiled and parameterized SQL statements to construct and execute database queries. This method improves the security of your SQL queries. This setting is turned on by default, and available for SQL database queries. For more details, see <a href="/connect-data/concepts/how-to-use-prepared-statements">Prepared Statements</a>.
-  </dd><br />
+<dd>Toggles whether Appsmith converts parameters' special characters into their <a href="https://en.wikipedia.org/wiki/URL_encoding">URL-encoded</a> equivalents. It also encodes the form body when the <b>Content-Type</b> header is set to <code>FORM_URLENCODED</code>. This setting is available for API queries.
+</dd>
 
-  <dt><b>Query timeout</b></dt>
-  <dd>Sets the time duration in milliseconds that the Appsmith server waits for the query to finish before it closes the connection. If your query takes longer than this duration, Appsmith throws a <a href="/help-and-support/troubleshooting-guide/action-errors#timeout-error">timeout error</a>. This setting defaults to 10000 ms with a maximum of 60000 ms.
-  </dd><br />
+#### Use Prepared Statements
 
-  <dt><b>Request confirmation before running query</b></dt>
-  <dd>When turned on, Appsmith asks the user for permission to run the query before each execution.
-  </dd><br />
+<dd>Toggles whether Appsmith uses pre-compiled and parameterized SQL statements to construct and execute database queries. This method improves the security of your SQL queries. This setting is turned on by default, and available for SQL database queries. For more details, see <a href="/connect-data/concepts/how-to-use-prepared-statements">Prepared Statements</a>.
+</dd>
 
-  <dt><b>Request confirmation before running API</b></dt>
-  <dd>When turned on, Appsmith asks the user for permission to run the query before each execution.
-  </dd><br />
+#### Query timeout
 
-  <dt><b>Run API on page load</b></dt>
-  <dd>When turned on, your query is executed every time the page loads or refreshes. This is automatically turned on when you bind the query's data to be displayed in a widget, though you can choose to turn it off.
-  </dd><br />
+<dd>Sets the time duration in milliseconds that the Appsmith server waits for the query to finish before it closes the connection. If your query takes longer than this duration, Appsmith throws a <a href="/help-and-support/troubleshooting-guide/action-errors#timeout-error">timeout error</a>. This setting defaults to 10000 ms with a maximum of 60000 ms.
+</dd>
 
-  <dt><b>Run query on page load</b></dt>
-  <dd>When turned on, your query is executed every time the page loads or refreshes. This is automatically turned on when you bind the query's data to be displayed in a widget, though you can choose to turn it off.
-  </dd><br />
+#### Request confirmation before running query
 
-  <dt><b>Smart JSON substitution</b></dt>
-  <dd>JavaScript objects and JSON objects are formatted similarly, however they have different rules for where quotation marks are required. When this setting is turned on, Appsmith intelligently adds or removes quotation marks from your JavaScript data as necessary to correctly cast them into JSON. This setting is turned on by default, however it may need to be turned off for some tasks such as sending raw binary data to an API. This setting is available for API queries. For a video guide on using this feature, see <a href="https://www.youtube.com/watch?v=-Z3y-pdNhXc">How to Use Smart JSON Substitution</a>.
-  </dd><br />
+<dd>When turned on, Appsmith asks the user for permission to run the query before each execution.
+</dd>
 
-  <dt><b>Smart BSON substitution</b></dt>
-  <dd>JavaScript objects and Binary JSON (BSON) objects are formatted similarly, however they have different rules for where quotation marks are required. When turned on, the query intelligently adds or removes quotation marks from your JavaScript data as necessary to correctly cast them into BSON. This setting is turned on by default, and available for <a href="/connect-data/reference/querying-mongodb">MongoDB</a> queries.
-  </dd>
+#### Request confirmation before running API
 
-</dl>
+<dd>When turned on, Appsmith asks the user for permission to run the query before each execution.
+</dd>
+
+#### Run API on page load
+
+<dd>When turned on, your query is executed every time the page loads or refreshes. This is automatically turned on when you bind the query's data to be displayed in a widget, though you can choose to turn it off.
+</dd>
+
+#### Run query on page load
+
+<dd>When turned on, your query is executed every time the page loads or refreshes. This is automatically turned on when you bind the query's data to be displayed in a widget, though you can choose to turn it off.
+</dd>
+
+#### Smart JSON substitution
+
+<dd>JavaScript objects and JSON objects are formatted similarly, however they have different rules for where quotation marks are required. When this setting is turned on, Appsmith intelligently adds or removes quotation marks from your JavaScript data as necessary to correctly cast them into JSON. This setting is turned on by default, however it may need to be turned off for some tasks such as sending raw binary data to an API. This setting is available for API queries. For a video guide on using this feature, see <a href="https://www.youtube.com/watch?v=-Z3y-pdNhXc">How to Use Smart JSON Substitution</a>.
+</dd>
+
+#### Smart BSON substitution
+
+<dd>JavaScript objects and Binary JSON (BSON) objects are formatted similarly, however they have different rules for where quotation marks are required. When turned on, the query intelligently adds or removes quotation marks from your JavaScript data as necessary to correctly cast them into BSON. This setting is turned on by default, and available for <a href="/connect-data/reference/querying-mongodb">MongoDB</a> queries.
+</dd>

--- a/website/docs/connect-data/reference/querying-amazon-s3.md
+++ b/website/docs/connect-data/reference/querying-amazon-s3.md
@@ -24,34 +24,37 @@ The following section is a reference guide that provides a complete description 
   <figcaption align="center"><i>Configuring an S3 datasource.</i></figcaption>
 </figure>
 
-<dl>
-  <dt><b>S3 service provider</b></dt>
-  <dd>Configures the datasource to connect to the specified S3 provider.</dd><br/>
-  <dd><i>Options:</i>
-    <ul>
-      <li>Amazon S3</li>
-      <li>Upcloud</li>
-      <li>Digital Ocean spaces</li>
-      <li>Wasabi</li>
-      <li>DreamObjects</li>
-      <li>MinIO</li>
-      <li>Other</li>
-    </ul>
-  </dd><br />
 
-  <dt><b>Access key</b></dt>
-  <dd>The key used to grant programmatic access to your resource.</dd><br />
+#### S3 service provider
 
-  <dt><b>Secret key</b></dt>
-  <dd>The secret key used to identify and authenticate your queries.</dd><br />
+<dd>Configures the datasource to connect to the specified S3 provider.</dd><br/>
+<dd><i>Options:</i>
+  <ul>
+    <li>Amazon S3</li>
+    <li>Upcloud</li>
+    <li>Digital Ocean spaces</li>
+    <li>Wasabi</li>
+    <li>DreamObjects</li>
+    <li>MinIO</li>
+    <li>Other</li>
+  </ul>
+</dd>
 
-  <dt><b>Endpoint URL</b></dt>
-  <dd>The network location of your S3 resource. This could be a domain or IP address. This field is required when <b>S3 service provider</b> is not Amazon S3. For a guide about connecting to a local resource, see <a href="/connect-data/how-to-guides/how-to-work-with-local-apis-on-appsmith"><b>Connect Local Database</b></a>.</dd><br />
+#### Access key
 
-  <dt><b>Region</b></dt>
-  <dd>Identifies which regional data center to connect to. This field appears when <b>S3 service provider</b> is MinIO or Other.</dd>
+<dd>The key used to grant programmatic access to your resource.</dd>
 
-</dl>
+#### Secret key
+
+<dd>The secret key used to identify and authenticate your queries.</dd>
+
+#### Endpoint URL
+
+<dd>The network location of your S3 resource. This could be a domain or IP address. This field is required when <b>S3 service provider</b> is not Amazon S3. For a guide about connecting to a local resource, see <a href="/connect-data/how-to-guides/how-to-work-with-local-apis-on-appsmith"><b>Connect Local Database</b></a>.</dd>
+
+#### Region
+
+<dd>Identifies which regional data center to connect to. This field appears when <b>S3 service provider</b> is MinIO or Other.</dd>
 
 ## Create queries
 
@@ -66,189 +69,210 @@ The following section is a reference guide that provides a complete description 
 
 This command returns an array of objects representing items that are contained within the bucket, each including at least a `fileName` property. The following section lists all the fields available for the **List files in a bucket** command.
 
-<dl>
-  <dt><b>Bucket name</b></dt>
-  <dd>
+
+#### Bucket name
+
+<dd>
 
 The name of the S3 bucket to query.
 
-  </dd>
+</dd>
 
-  <dt><b>Prefix</b></dt>
-  <dd>
+#### Prefix
+
+<dd>
 
 The directory path of the files you'd like to query.
 
 For example, in `sample/path/example.png`, the **Prefix** is `sample/path`. Using the prefix `sample/path` with no filtering returns all files in the `sample/path` directory.
 
-  </dd>
+</dd>
 
-  <dt><b>Where</b></dt>
-  <dd>
+#### Where
+
+<dd>
 
 These fields are used to create logic expressions that filter query results based on column values. Available comparison operators are `==`, `!=`, `in`, and `not in`.
 
-  </dd>
+</dd>
 
-  <dt><b>Generate signed URL</b></dt>
-  <dd>
+#### Generate signed URL
+
+<dd>
 
 Requests an authenticated, user-accessible URL for each file in the response. Users may follow the link in their browser to see the content of the file. The URL expires after the amount of time specified in **Expiry duration of signed URL**.
 
-  </dd>
+</dd>
 
-  <dt><b>Expiry duration of signed URL</b></dt>
-  <dd>
+#### Expiry duration of signed URL
+
+<dd>
 
 The length of time in minutes that the returned Signed URL is valid. Accepts number values up to `10080` minutes (7 days).
 
-  </dd>
+</dd>
 
-  <dt><b>Generate unsigned URL</b></dt>
-  <dd>
+#### Generate unsigned URL
+
+<dd>
 
 Requests the plain URL for each file in the query response. This URL does not expire, but it can't be used to access the resource directly, only via API.
 
-  </dd>
+</dd>
 
-  <dt><b>Sort by</b></dt>
-  <dd>
+#### Sort by
+
+<dd>
 
 Orders the query results in ascending or descending order based on a given column's value.
 
-  </dd>
+</dd>
 
-  <dt><b>Pagination limit</b></dt>
-  <dd>
+#### Pagination limit
+
+<dd>
 
 Limits the number of results that can be returned in a single response. Expects an integer.
 
-  </dd>
+</dd>
 
-  <dt><b>Pagination offset</b></dt>
-  <dd>
+#### Pagination offset
+
+<dd>
 
 Skips a given number of files before returning the further results. Expects an integer.
 
-  </dd>
-</dl>
+</dd>
 
 
 ### Create a new file
 
 This command creates a new object in the S3 bucket. If a file by the same name or path already exists within the bucket, the old file is overwritten by the new one. The following section lists all the fields available for the **Create a new file** command.
 
-<dl>
-  <dt><b>Bucket name</b></dt>
-  <dd>
+
+#### Bucket name
+
+<dd>
 
 The name of the S3 bucket to query.
 
-  </dd>
+</dd>
 
-  <dt><b>File path</b></dt>
-  <dd>
+#### File path
+
+<dd>
 
 The name under which to save the file. Be sure to include directories as prefixes to the filename if necessary.
 
-  </dd>
+</dd>
 
-  <dt><b>File data type</b></dt>
-  <dd>Sets the data format to use when sending the file content.</dd><br />
-  <dd><i>Options:</i>
-    <ul>
-     <li><b>Base64:</b> Sends data from the <b>Content</b> field encoded in Base64 format.</li>
-     <li><b>Text:</b> Sends data from the <b>Content</b> field as plain text.</li>
-    </ul>
-  </dd> 
+#### File data type
 
-  <dt><b>Expiry duration of signed URL</b></dt>
-  <dd>
+<dd>Sets the data format to use when sending the file content.</dd><br />
+<dd><i>Options:</i>
+  <ul>
+    <li><b>Base64:</b> Sends data from the <b>Content</b> field encoded in Base64 format.</li>
+    <li><b>Text:</b> Sends data from the <b>Content</b> field as plain text.</li>
+  </ul>
+</dd> 
+
+#### Expiry duration of signed URL
+
+<dd>
 
 The length of time in minutes that the returned Signed URL is valid. Accepts number values up to `10080` minutes (7 days).
 
-  </dd>
+</dd>
 
-  <dt><b>Content</b></dt>
-  <dd>
+#### Content
+
+<dd>
 
 The file data to be sent to the bucket. Expects a file object. You can use widgets such as a [Filepicker](/reference/widgets/filepicker) or a [Camera](/reference/widgets/camera) to upload files to S3. For guides on this subject, see [Upload or Download Files to and from S3](/connect-data/how-to-guides/how-to-upload-to-s3) or [Upload Images to and from S3](/connect-data/how-to-guides/how-to-use-the-camera-image-widget-to-upload-download-images).
 
-  </dd>
-</dl>
+</dd>
+
 
 ### Create multiple new files
 
 This command creates a batch of new objects in the S3 bucket. If a file by the same name/path already exists within the bucket, the old file is overwritten by the new one. The following section lists all the fields available for the **Create multiple new files** command.
 
-<dl>
-  <dt><b>Bucket name</b></dt>
-  <dd>
+
+#### Bucket name
+
+<dd>
 
 The name of the S3 bucket to query.
 
-  </dd>
+</dd>
 
-  <dt><b>Common file path</b></dt>
-  <dd>
+#### Common file path
+
+<dd>
 
 The prefix that is prepended to each of the new objects' file path as directories.
 
-  </dd>
+</dd>
 
-  <dt><b>File data type</b></dt>
-  <dd>Sets the data format to use when sending the file content.</dd><br />
-  <dd><i>Options:</i>
-    <ul>
-     <li><b>Base64:</b> Sends data from the <b>Content</b> field encoded in Base64 format.</li>
-     <li><b>Text:</b> Sends data from the <b>Content</b> field as plain text.</li>
-    </ul>
-  </dd> 
+#### File data type
 
-  <dt><b>Expiry duration of signed URL</b></dt>
-  <dd>
+<dd>Sets the data format to use when sending the file content.</dd><br />
+<dd><i>Options:</i>
+  <ul>
+    <li><b>Base64:</b> Sends data from the <b>Content</b> field encoded in Base64 format.</li>
+    <li><b>Text:</b> Sends data from the <b>Content</b> field as plain text.</li>
+  </ul>
+</dd> 
+
+#### Expiry duration of signed URL
+
+<dd>
 
 The length of time in minutes that the returned Signed URL is valid. Accepts number values up to `10080` minutes (7 days).
 
-  </dd>
+</dd>
 
-  <dt><b>Content</b></dt>
-  <dd>
+#### Content
+
+<dd>
 
 The file data to be sent to the bucket. Expects an array of file objects. You can use widgets such as a [Filepicker](/reference/widgets/filepicker) to upload files to S3. For a guide on this subject, see [Upload or Download Files to and from S3](/connect-data/how-to-guides/how-to-upload-to-s3).
 
-  </dd>
-</dl>
+</dd>
+
 
 ### Read file
 
 This command returns the data from a given file in your S3 bucket. By default, the raw content of the file is returned on the `fileData` property of the response. The following section lists all the fields available for the **Read file** command.
 
 
-<dl>
-  <dt><b>Bucket name</b></dt>
-  <dd>
+
+#### Bucket name
+
+<dd>
 
 The name of the S3 bucket to query.
 
-  </dd>
+</dd>
 
-  <dt><b>File path</b></dt>
-  <dd>
+#### File path
+
+<dd>
 
 The path to the file in your S3 bucket.
 
-  </dd>
+</dd>
 
-  <dt><b>Base64 Encode File</b></dt>
-  <dd>Sets whether Appsmith encodes the incoming file's content into Base64.</dd><br />
-  <dd><i>Options:</i>
-    <ul>
-     <li><b>Yes:</b> Incoming file data is encoded into Base64 format before it is returned.</li>
-     <li><b>No:</b> Incoming file data is returned as sent with no additional encoding.</li>
-    </ul>
-  </dd>
-</dl>
+#### Base64 Encode File
+
+<dd>Sets whether Appsmith encodes the incoming file's content into Base64.</dd><br />
+<dd><i>Options:</i>
+  <ul>
+    <li><b>Yes:</b> Incoming file data is encoded into Base64 format before it is returned.</li>
+    <li><b>No:</b> Incoming file data is returned as sent with no additional encoding.</li>
+  </ul>
+</dd>
+
 
 :::tip
 If your `fileData` content is in Base64 format and needs to be decoded, use the [JavaScript `atob()` method](https://developer.mozilla.org/en-US/docs/Web/API/atob).
@@ -258,41 +282,45 @@ If your `fileData` content is in Base64 format and needs to be decoded, use the 
 
 This command deletes a given file from your S3 bucket. The following section lists all the fields available for the **Delete file** command.
 
-<dl>
-  <dt><b>Bucket name</b></dt>
-  <dd>
+
+#### Bucket name
+
+<dd>
 
 The name of the S3 bucket to query.
 
-  </dd>
+</dd>
 
-  <dt><b>File path</b></dt>
-  <dd>
+#### File path
+
+<dd>
 
 The path to the file in your S3 bucket.
 
-  </dd>
-</dl> 
+</dd>
+ 
 
 ### Delete multiple files
 
 This command deletes a batch of files from your S3 bucket. The following section lists all the fields available for the **Delete multiple files** command.
 
-<dl>
-  <dt><b>Bucket name</b></dt>
-  <dd>
+
+#### Bucket name
+
+<dd>
 
 The name of the S3 bucket to query.
 
-  </dd>
+</dd>
 
-  <dt><b>List of Files</b></dt>
-  <dd>
+#### List of Files
+
+<dd>
 
 Expects a JSON array of file paths to be deleted from the S3 bucket.
 
-  </dd>
-</dl> 
+</dd>
+ 
 
 ## Troubleshooting
 

--- a/website/docs/connect-data/reference/querying-arango-db.md
+++ b/website/docs/connect-data/reference/querying-arango-db.md
@@ -22,29 +22,32 @@ The following is a reference guide that provides a description of the parameters
   <figcaption align = "center"><i>Configuring an ArangoDB datasource.</i></figcaption>
 </figure>
 
-<dl>
-  <dt><b>Host Address</b></dt>
-  <dd>The network location of your ArangoDB database. This can be a domain name or an IP address. To connect to a local ArangoDB database, see <a href="/connect-data/how-to-guides/how-to-work-with-local-apis-on-appsmith"><b>Connect Local Database</b></a> for directions. </dd><br />
+#### Host Address
 
-  <dt><b>Port</b></dt>
-  <dd>The port number to connect to on the server. If none is specified, Appsmith attempts to connect to port 8529.</dd><br />
+<dd>The network location of your ArangoDB database. This can be a domain name or an IP address. To connect to a local ArangoDB database, see <a href="/connect-data/how-to-guides/how-to-work-with-local-apis-on-appsmith"><b>Connect Local Database</b></a> for directions. </dd>
 
-  <dt><b>Database Name</b></dt>
-  <dd>The name of your database. </dd><br />
+#### Port
 
-  <dt><b>Authentication</b></dt>
-  <dd>The <b>Username</b> and <b>Password</b> for the user with which you are connecting to the database.</dd><br />
+<dd>The port number to connect to on the server. If none is specified, Appsmith attempts to connect to port 8529.</dd>
 
-  <dt><b>SSL Mode</b></dt>
-  <dd>Determines whether your queries use an SSL connection to communicate with the database.</dd><br />
-  <dd><i>Options:</i>
-    <ul>
-        <li><b>Default:</b> The same as Disabled.</li>
-        <li><b>Enabled:</b> Only allows an SSL connection.</li>
-        <li><b>Disabled:</b> Does not attempt an SSL connection; it uses a plain unencrypted connection.</li>
-    </ul>
-  </dd>
-</dl>
+#### Database Name
+
+<dd>The name of your database. </dd>
+
+#### Authentication
+
+<dd>The <b>Username</b> and <b>Password</b> for the user with which you are connecting to the database.</dd>
+
+#### SSL mode
+
+<dd>Determines whether your queries use an SSL connection to communicate with the database.</dd><br/>
+<dd><i>Options:</i>
+  <ul>
+      <li><b>Default:</b> The same as Disabled.</li>
+      <li><b>Enabled:</b> Only allows an SSL connection.</li>
+      <li><b>Disabled:</b> Does not attempt an SSL connection; it uses a plain unencrypted connection.</li>
+  </ul>
+</dd>
 
 ## Query ArangoDB
 

--- a/website/docs/connect-data/reference/querying-dynamodb.md
+++ b/website/docs/connect-data/reference/querying-dynamodb.md
@@ -21,28 +21,29 @@ The following section is a reference guide that provides a complete description 
   <figcaption align="center"><i>Configuring a DynamoDB datasource.</i></figcaption>
 </figure>
 
-<dl>
-  <dt><b>Region</b></dt>
-  <dd>
-  
+#### Region
+
+<dd>
+
 The region where your DynamoDB instance is hosted.
 
-  </dd><br/>
+</dd>
 
-  <dt><b>AWS Access Key ID</b></dt>
-  <dd>
+#### AWS Access Key ID
+
+<dd>
 
 The AWS access key used to identify your IAM user for DynamoDB. Be sure to use the access key for your IAM user with the set of privileges you want your Appsmith app to have. For more information on using an AWS access key, see [Create Access Key](https://aws.amazon.com/premiumsupport/knowledge-center/create-access-key/).
 
-  </dd>
+</dd>
 
-  <dt><b>AWS Secret Access Key</b></dt>
-  <dd>
+#### AWS Secret Access Key
+
+<dd>
 
 The secret value used to authenticate your queries to DynamoDB. This value is accessible from your AWS security credentials page. To learn more about your AWS Secret Key, see the [AWS Security Blog](https://aws.amazon.com/blogs/security/how-to-find-update-access-keys-password-mfa-aws-management-console/).
 
-  </dd>
-</dl>
+</dd>
 
 ## Create queries
 

--- a/website/docs/connect-data/reference/querying-elasticsearch.md
+++ b/website/docs/connect-data/reference/querying-elasticsearch.md
@@ -22,19 +22,21 @@ The following is a reference guide that provides a description of the parameters
   <figcaption align = "center"><i>Connect to Elasticsearch</i></figcaption>
 </figure>
 
-<dl>
-  <dt><b>Host URL</b></dt>
-  <dd>The network location where your Elasticsearch data is hosted. This can be a domain name or an IP address. To connect to a local database, see <a href="/connect-data/how-to-guides/how-to-work-with-local-apis-on-appsmith"><b>Connect Local Database</b></a> for directions. </dd><br />
+#### Host URL
 
-  <dt><b>Port</b></dt>
-  <dd>The port number to connect to on the server. </dd><br />
+<dd>The network location where your Elasticsearch data is hosted. This can be a domain name or an IP address. To connect to a local database, see <a href="/connect-data/how-to-guides/how-to-work-with-local-apis-on-appsmith"><b>Connect Local Database</b></a> for directions. </dd>
 
-  <dt><b>Username/Password for Basic Auth</b></dt>
-  <dd>The account credentials used to log in to Elasticsearch.</dd><br />
+#### Port
 
-  <dt><b>Authorization Header</b></dt>
-  <dd>Instead of the username/password fields, you can provide an <b>Authorization Header</b> to authenticate your queries. This field is only used when the <b>Username/Password for Basic Auth</b> fields are empty.</dd><br />
-</dl>
+<dd>The port number to connect to on the server. </dd>
+
+#### Username/Password for Basic Auth
+
+<dd>The account credentials used to log in to Elasticsearch.</dd>
+
+#### Authorization Header
+
+<dd>Instead of the username/password fields, you can provide an <b>Authorization Header</b> to authenticate your queries. This field is only used when the <b>Username/Password for Basic Auth</b> fields are empty.</dd>
 
 ## Query Elasticsearch
 
@@ -44,24 +46,25 @@ The following section provides examples of creating basic CRUD queries to Elasti
 For details on building more complex queries, see the [Elasticsearch Document API documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs.html).
 :::
 
-<dl>
-  <dt><b>Method</b></dt>
-  <dd>The HTTP method to use for your query.</dd><br />
-  <dd><i>Options:</i>
-    <ul>
-      <li><b>GET:</b> Method used for requesting and fetching data.</li>
-      <li><b>POST:</b> Method used for creating or updating records.</li>
-      <li><b>PUT:</b> Method used for creating or updating records.</li>
-      <li><b>DELETE:</b> Method used for deleting records.</li>
-    </ul>
-  </dd>  
+#### Method
 
-  <dt><b>Path</b></dt>
-  <dd>The endpoint to which your query is sent. This usually is made up of the index name and the name of an operation. For example: <code>/users/_search</code> is the endpoint used for searching the <code>users</code> index.</dd><br />
+<dd>The HTTP method to use for your query.</dd><br />
+<dd><i>Options:</i>
+  <ul>
+    <li><b>GET:</b> Method used for requesting and fetching data.</li>
+    <li><b>POST:</b> Method used for creating or updating records.</li>
+    <li><b>PUT:</b> Method used for creating or updating records.</li>
+    <li><b>DELETE:</b> Method used for deleting records.</li>
+  </ul>
+</dd>  
 
-  <dt><b>Body</b></dt>
-  <dd>The body content of your query.</dd><br />
-</dl>
+#### Path
+
+<dd>The endpoint to which your query is sent. This usually is made up of the index name and the name of an operation. For example: <code>/users/_search</code> is the endpoint used for searching the <code>users</code> index.</dd>
+
+#### Body
+
+<dd>The body content of your query.</dd>
 
 ### Search documents
 

--- a/website/docs/connect-data/reference/querying-firestore.md
+++ b/website/docs/connect-data/reference/querying-firestore.md
@@ -16,28 +16,29 @@ The following section is a reference guide that provides a complete description 
   <figcaption align="center"><i>Configuring a Firestore datasource.</i></figcaption>
 </figure>
 
-<dl>
-  <dt><b>Database URL</b></dt>
-  <dd>
+#### Database URL
+
+<dd>
 
 The domain or network location of your database instance. This value includes your **Project ID** in the format `https://PROJECT_ID.firebaseio.com`.
 
-  </dd>
+</dd>
 
-  <dt><b>Project ID</b></dt>
-  <dd>
+#### Project ID
+
+<dd>
 
 The unique identifier for your Firestore project, accessible in your Firebase project's **Project Settings**. For more information, see [Understand Firebase projects](https://firebase.google.com/docs/projects/learn-more#project-id).
 
-  </dd>
+</dd>
 
-  <dt><b>Service account credentials</b></dt>
-  <dd>
+#### Service account credentials
+
+<dd>
 
 A string of credentials generated on Firebase that is used to authenticate your queries. You can generate these credentials from your Firebase project's **Project Settings** page under **Service Accounts**. Open the downloaded file and copy-paste its entire contents into the **Service account credentials** field in your Appsmith datasource configuration. For
 
-  </dd>
-</dl>
+</dd>
 
 ## Create queries
 
@@ -52,42 +53,45 @@ The following section is a reference guide that provides a complete description 
 
 This command lists all documents from a given collection. The following section lists all the fields available for the **List Documents** command.
 
-<dl>
-  <dt><b>Collection Name</b></dt>
-  <dd>
+#### Collection Name
+
+<dd>
 
 The name of the collection to query.
 
-  </dd>
+</dd>
 
-  <dt><b>Where</b></dt>
-  <dd>
+#### Where
+
+<dd>
 
 Defines conditions that documents' column values must meet to appear in your results. The available comparison operators are `==`, `<`, `<=`, `>=`, `>`, `in`, `contains`, and `contains any`.
 
-  </dd>
-  <dd><i>Options:</i>
-    <ul>
-     <li><b>Add condition:</b> Adds another simple single-line expression.</li>
-     <li><b>Add group condition:</b> Adds a nested expression with multiple levels of <code>AND</code> statements.</li>
-    </ul>
-  </dd>
-  <dd>
-    <figure>
-      <img src="/img/firestore-where-conditions.png" style={{width: "100%", height: "auto"}} alt="Use Where conditions to create multiple levels of filtering." />
-      <figcaption align="center"><i>Use Where conditions to create multiple levels of filtering.</i></figcaption>
-    </figure>
-  </dd>
+</dd>
+<dd><i>Options:</i>
+  <ul>
+    <li><b>Add condition:</b> Adds another simple single-line expression.</li>
+    <li><b>Add group condition:</b> Adds a nested expression with multiple levels of <code>AND</code> statements.</li>
+  </ul>
+</dd>
+<dd>
+  <figure>
+    <img src="/img/firestore-where-conditions.png" style={{width: "100%", height: "auto"}} alt="Use Where conditions to create multiple levels of filtering." />
+    <figcaption align="center"><i>Use Where conditions to create multiple levels of filtering.</i></figcaption>
+  </figure>
+</dd>
 
-  <dt><b>Order by</b></dt>
-  <dd>
+#### Order by
+
+<dd>
 
 Sorts query results by a column value. Expects a JSON array containing a single string which is the column's name. By default this sorts in ascending order, or you can add a `-` prefix to the column name to sort in descending order. For example, `["name"]` is ascending and `["-name"]` is descending.
 
-  </dd>
+</dd>
 
-  <dt><b>Start after</b></dt>
-  <dd>
+#### Start after
+
+<dd>
 
 Sets a record that acts as a starting cursor for pagination. Expects an object that is a whole document, i.e. a document that was returned from a prior query. For example, you can pass the last record from the most recent execution of a query:
 
@@ -97,10 +101,11 @@ Sets a record that acts as a starting cursor for pagination. Expects an object t
 
 Each time the query is run, it fetches the next set of results that come after the previous execution. 
 
-  </dd>
+</dd>
 
-  <dt><b>End before</b></dt>
-  <dd>
+#### End before
+
+<dd>
 
 Sets a record that acts as an ending cursor for pagination. Expects an object that is a whole document, i.e. a document that was returned from a prior query. For example, you can pass the first record from the most recent execution of a query:
 
@@ -110,30 +115,31 @@ Sets a record that acts as an ending cursor for pagination. Expects an object th
 
 When the query is paged backwards, it fetches the set of results that lead up to the current results.
 
-  </dd>
+</dd>
 
-  <dt><b>Limit</b></dt>
-  <dd>
+#### Limit
+
+<dd>
 
 Sets a limit for how many documents may be returned by the query.
 
-  </dd>
-</dl>
+</dd>
 
 ### Create Document
 
 This command creates a new document within a given collection. Firestore automatically generates an identifier for the created document. The following section lists all the fields available for the **Create Document** command.
 
-<dl>
-  <dt><b>Collection Name</b></dt>
-  <dd>
+#### Collection Name
+
+<dd>
 
 The name of the collection where the new document should be created.
 
-  </dd>
+</dd>
 
-  <dt><b>Body</b></dt>
-  <dd>
+#### Body
+
+<dd>
 
 Expects a JSON object that represents the document to be created. For example:
 
@@ -145,16 +151,17 @@ Expects a JSON object that represents the document to be created. For example:
 }
 ```
 
-  </dd>
+</dd>
 
-  <dt><b>Timestamp Path</b></dt>
-  <dd>
+#### Timestamp Path
+
+<dd>
 
 When filled, adds a timestamp key-value pair into the created document that shows when the document was created. Expects an array with a single string value, for example `["TIMESTAMP_KEY_NAME"]`. The string you provide in this field is used as the key to the timestamp value in your document. You can create a timestamp key-value pair within a nested object by using `.` to specify the path.
 
-  </dd>
-  <dd>
-  
+</dd>
+<dd>
+
 For example, the value <code>["meta.dateCreated"]</code> adds the following to your document:
 
 ```json
@@ -169,24 +176,23 @@ For example, the value <code>["meta.dateCreated"]</code> adds the following to y
 }
 ```
   
-  </dd>
-</dl>
+</dd>
 
 ### Update Document
 
 This command updates an existing document at a given path. The following section lists all the fields available for the **Update Document** command.
 
+#### Collection/Document path
 
-<dl>
-  <dt><b>Collection/Document path</b></dt>
-  <dd>
+<dd>
 
 The path to the document to update. For example, the path `Users/Admins/admin001` refers to a document `admin001` in the the `Admins` directory of the `Users` Collection.
 
-  </dd>
+</dd>
 
-  <dt><b>Body</b></dt>
-  <dd>
+#### Body
+
+<dd>
 
 Expects a JSON object that represents the new key-value pairs to update the document with. You only need to include the key-value pairs that are changing, adding all keys is not necessary. For example:
 
@@ -196,22 +202,24 @@ Expects a JSON object that represents the new key-value pairs to update the docu
 }
 ```
 
-  </dd>
+</dd>
 
-  <dt><b>Delete Key Path</b></dt>
-  <dd>
+#### Delete Key Path
+
+<dd>
 
 When filled, deletes the key located at the path specified by this field. You can delete nested keys by providing the path from the root of the object. Expects an array with a single string value, for example `["PARENT_KEY.KEY_TO_DELETE"]`.
 
-  </dd>
+</dd>
 
-  <dt><b>Timestamp Path</b></dt>
-  <dd>
+#### Timestamp Path
+
+<dd>
 
 When filled, adds a timestamp key-value pair into the created document that shows when the document was updated. Expects an array with a single string value, for example `["TIMESTAMP_KEY_NAME"]`. The string you provide in this field is used as the key to the timestamp value in your document. You can create a timestamp key-value pair within a nested object by using `.` to specify the path.
 
-  </dd>
-  <dd>
+</dd>
+<dd>
   
 For example, the value <code>["meta.lastModified"]</code> adds the following to your document:
 
@@ -227,34 +235,31 @@ For example, the value <code>["meta.lastModified"]</code> adds the following to 
 }
 ```
 
-  </dd>
-</dl>
+</dd>
 
 ### Delete Document
 
 This command deletes an existing document at a given path. The following section lists all the fields available for the **Delete Document** command.
 
-<dl>
-  <dt><b>Collection/Document path</b></dt>
-  <dd>
+#### Collection/Document path
+
+<dd>
 
 The path to the document to delete. For example, the path `Users/Admins/admin001` refers to a document `admin001` in the the `Admins` directory of the `Users` Collection.
 
-  </dd>
-</dl>
+</dd>
 
 ### Get Document
 
 This command fetches a single existing document at a given path. The following section lists all the fields available for the **Get Document** command.
 
-<dl>
-  <dt><b>Collection/Document path</b></dt>
-  <dd>
+#### Collection/Document path
+
+<dd>
 
 The path to the document to fetch. For example, the path `Users/Admins/admin001` refers to a document `admin001` in the the `Admins` directory of the `Users` Collection.
 
-  </dd>
-</dl>
+</dd>
 
 ### Upsert Document
 
@@ -262,16 +267,17 @@ This command creates a new document or replaces an existing document at the give
 
 If you use **Upsert Document**, your query completely replaces whatever record exists at the given path, so be sure to provide all necessary fields including those that have not changed.
 
-<dl>
-  <dt><b>Collection/Document path</b></dt>
-  <dd>
+#### Collection/Document path
+
+<dd>
 
 The path to the document to update. For example, the path `Users/Admins/admin001` refers to a document `admin001` in the the `Admins` directory of the `Users` Collection.
 
-  </dd>
+</dd>
 
-  <dt><b>Body</b></dt>
-  <dd>
+#### Body
+
+<dd>
 
 Expects a JSON object that represents the document to be created. If a document already exists at the path given in **Collection/Document path**, this command completely replaces it with the content of this field. For example:
 
@@ -283,16 +289,17 @@ Expects a JSON object that represents the document to be created. If a document 
 }
 ```
 
-  </dd>
+</dd>
 
-  <dt><b>Timestamp Path</b></dt>
-  <dd>
+#### Timestamp Path
+
+<dd>
 
 When filled, adds a timestamp key-value pair into the created document that shows when the document was created. Expects an array with a single string value, for example `["TIMESTAMP_KEY_NAME"]`. The string you provide in this field is used as the key to the timestamp value in your document. You can create a timestamp key-value pair within a nested object by using `.` to specify the path.
 
-  </dd>
-  <dd>
-  
+</dd>
+<dd>
+
 For example, the value <code>["meta.dateCreated"]</code> adds the following to your document:
 
 ```json
@@ -307,23 +314,23 @@ For example, the value <code>["meta.dateCreated"]</code> adds the following to y
 }
 ```
 
-  </dd>
-</dl>
+</dd>
 
 ### Add document to collection
 
 This command creates a new document within a given collection, under the identifier you provide. The following section lists all the fields available for the **Add document to collection** command.
 
-<dl>
-  <dt><b>Collection/Document path</b></dt>
-  <dd>
+#### Collection/Document path
+
+<dd>
 
 The path to where the document should be created. The last part of this string becomes the document's identifier. For example, a path `Users/Admins/admin001` will create a document `admin001` in the `Users` Collection in the `Admins` directory.
 
-  </dd>
+</dd>
 
-  <dt><b>Body</b></dt>
-  <dd>
+#### Body
+
+<dd>
 
 Expects a JSON object that represents the document to be created. For example:
 
@@ -335,15 +342,16 @@ Expects a JSON object that represents the document to be created. For example:
 }
 ```
 
-  </dd>
+</dd>
 
-  <dt><b>Timestamp Path</b></dt>
-  <dd>
+#### Timestamp Path
+
+<dd>
 
 When filled, adds a timestamp key-value pair into the created document that shows when the document was created. Expects an array with a single string value, for example `["TIMESTAMP_KEY_NAME"]`. The string you provide in this field is used as the key to the timestamp value in your document. You can create a timestamp key-value pair within a nested object by using `.` to specify the path.
 
-  </dd>
-  <dd>
+</dd>
+<dd>
   
 For example, the value <code>["meta.dateCreated"]</code> adds the following to your document:
 
@@ -359,8 +367,7 @@ For example, the value <code>["meta.dateCreated"]</code> adds the following to y
 }
 ```
 
-  </dd>
-</dl>
+</dd>
 
 ## Troubleshooting
 

--- a/website/docs/connect-data/reference/querying-google-sheets.md
+++ b/website/docs/connect-data/reference/querying-google-sheets.md
@@ -14,18 +14,17 @@ This page provides information for connecting Appsmith to Google Sheets and for 
   <figcaption align="center"><i>Configuring a new Google Sheets datasource.</i></figcaption>
 </figure>
 
-<dl>
-  <dt><b>Permissions | Scope:</b></dt>
-  <dd>Defines the privileges your app has when querying spreadsheets. Use this to allow the minimum necessary privileges for your app's functions.</dd><br/>
-  <dd><i>Options:</i>
-    <ul>
-     <li><b>Read / Write / Delete | Selected Google Sheets:</b> Your app has read, write, and delete access only for the sheets that you specify while authorizing the datasource.</li>
-     <li><b>Read / Write / Delete | All Google Sheets:</b> Your app has read, write, and delete access for all sheets on your Google account.</li>
-     <li><b>Read / Write | All Google Sheets:</b> Your app has read and write (but not delete) access for all sheets on your Google account.</li>
-     <li><b>Read | All Google Sheets:</b> Your app has read-only access to all sheets on your Google account.</li>
-    </ul>
-  </dd>  
-</dl>
+#### Permissions | Scope:
+
+<dd>Defines the privileges your app has when querying spreadsheets. Use this to allow the minimum necessary privileges for your app's functions.</dd><br/>
+<dd><i>Options:</i>
+  <ul>
+    <li><b>Read / Write / Delete | Selected Google Sheets:</b> Your app has read, write, and delete access only for the sheets that you specify while authorizing the datasource.</li>
+    <li><b>Read / Write / Delete | All Google Sheets:</b> Your app has read, write, and delete access for all sheets on your Google account.</li>
+    <li><b>Read / Write | All Google Sheets:</b> Your app has read and write (but not delete) access for all sheets on your Google account.</li>
+    <li><b>Read | All Google Sheets:</b> Your app has read-only access to all sheets on your Google account.</li>
+  </ul>
+</dd>
 
 Clicking **Save and Authorize** takes you to a Google login where you can authorize your account and select your sheets.
 
@@ -42,60 +41,64 @@ The following section is a reference guide that provides a complete description 
 
 This command fetches metadata for a given **Spreadsheet** entity. The following section lists all the fields available for the **Fetch Details** command.
 
-<dl>
-  <dt><b>Entity</b></dt>
-  <dd>Sets which entity type to query.
-  </dd><br/>
-  <dd><i>Options:</i>
-    <ul>
-     <li><b>Spreadsheet:</b> Returns metadata for a spreadsheet document.</li>
-    </ul>
-  </dd><br />
+#### Entity
 
-  <dt><b>Spreadsheet</b></dt>
-  <dd> The name of the spreadsheet document you'd like to query.
-  </dd>
+<dd>Sets which entity type to query.
+</dd><br/>
+<dd><i>Options:</i>
+  <ul>
+    <li><b>Spreadsheet:</b> Returns metadata for a spreadsheet document.</li>
+  </ul>
+</dd>
 
-</dl>
+#### Spreadsheet
+
+<dd> The name of the spreadsheet document you'd like to query.</dd>
+
 
 ### Insert One
 
 This command inserts a given entity type: **Sheet Row(s)** or **Spreadsheet**. The following section lists all the fields available for the **Insert One** command.
 
-<dl>
-  <dt><b>Entity</b></dt>
-  <dd>Sets which entity type to query.
-  </dd><br/>
-  <dd><i>Options:</i>
-    <ul>
-     <li><b>Sheet Row(s):</b> Inserts a single record as a row in the spreadsheet.</li>
-     <li><b>Spreadsheet:</b> Creates a new spreadsheet document. Optionally, you can use the <b>Row Objects</b> field to provide rows that should be created along with the document.</li>
-    </ul>
-  </dd><br />
+#### Entity
 
-  <dt><b>Spreadsheet</b></dt>
-  <dd> The name of the spreadsheet document you'd like to query.
-  </dd><br />
+<dd>Sets which entity type to query.
+</dd><br/>
+<dd><i>Options:</i>
+  <ul>
+    <li><b>Sheet Row(s):</b> Inserts a single record as a row in the spreadsheet.</li>
+    <li><b>Spreadsheet:</b> Creates a new spreadsheet document. Optionally, you can use the <b>Row Objects</b> field to provide rows that should be created along with the document.</li>
+  </ul>
+</dd>
 
-  <dt><b>Sheet Name</b></dt>
-  <dd> The name of the page you'd like to query from your spreadsheet.
-  </dd><br />
+#### Spreadsheet
 
-  <dt><b>Table Heading Row Index</b></dt>
-  <dd>The index of the row in your spreadsheet that contains the headings or labels for your table columns. The first row of the spreadsheet is index 1.
-  </dd><br />
+<dd> The name of the spreadsheet document you'd like to query.
+</dd>
 
-  <dt><b>Row Object</b></dt>
-  <dd>Available when the <b>Entity</b> is <b>Sheet Row(s)</b>. This expects a JSON-formatted object whose key/value pairs represent the columns and values from your table record.</dd>
-  <dd><i>Example:</i>
-  <pre>{`{
-    "name": {{ UserForm.name }},
-    "email": {{ UserForm.email }},
-    "status": "pending"
+#### Sheet Name
+
+<dd> The name of the page you'd like to query from your spreadsheet.
+</dd>
+
+#### Table Heading Row Index
+
+<dd>The index of the row in your spreadsheet that contains the headings or labels for your table columns. The first row of the spreadsheet is index 1.
+</dd>
+
+#### Row Object
+
+<dd>Available when the <b>Entity</b> is <b>Sheet Row(s)</b>. This expects a JSON-formatted object whose key/value pairs represent the columns and values from your table record.</dd>
+<dd><i>Example:</i>
+<pre>{`{
+  "name": {{ UserForm.name }},
+  "email": {{ UserForm.email }},
+  "status": "pending"
 }`}</pre>
-  </dd><br/>
+</dd>
 
-  <dt><b>Row Objects</b></dt>
+  #### Row Objects
+
   <dd>Available when the <b>Entity</b> is <b>Spreadsheet</b>. This expects an array of JSON-formatted objects whose key/value pairs represent columns and values to add to your new spreadsheet when it is created.</dd>
   <dd><i>Example:</i>
   <pre>{`[{
@@ -108,175 +111,189 @@ This command inserts a given entity type: **Sheet Row(s)** or **Spreadsheet**. T
   "email": "samal@example.com",
   "status": "accepted"
 }]`}</pre>
-  </dd>
+</dd>
 
-</dl>
 
 ### Update One
 
 This command updates a **Sheet Row(s)** entity. The following section lists all the fields available for the **Update One** command.
 
-<dl>
-  <dt><b>Entity</b></dt>
-  <dd>Sets which entity type to query.
-  </dd><br/>
-  <dd><i>Options:</i>
-    <ul>
-     <li><b>Sheet Row(s):</b> Updates a single existing row in the spreadsheet.</li>
-    </ul>
-  </dd><br />
+#### Entity
 
-  <dt><b>Spreadsheet</b></dt>
-  <dd> The name of the spreadsheet document you'd like to query.
-  </dd><br />
+<dd>Sets which entity type to query.
+</dd><br/>
+<dd><i>Options:</i>
+  <ul>
+    <li><b>Sheet Row(s):</b> Updates a single existing row in the spreadsheet.</li>
+  </ul>
+</dd>
 
-  <dt><b>Sheet Name</b></dt>
-  <dd> The name of the page you'd like to query from your spreadsheet.
-  </dd><br />
+#### Spreadsheet
 
-  <dt><b>Table Heading Row Index</b></dt>
-  <dd>The index of the row in your spreadsheet that contains the headings or labels for your table columns. The first row of the spreadsheet is index 1.
-  </dd><br />
+<dd> The name of the spreadsheet document you'd like to query.
+</dd>
 
-  <dt><b>Update Row Object</b></dt>
-  <dd>A JSON-formatted object whose key/value pairs represent the columns and values from your table record. You must include a <code>rowIndex</code> key to specify which record to update. If you fetched the record from another Google Sheets query, this index value should be available on its <code>rowIndex</code> property.</dd>
-  <dd><i>Example:</i>
-  <pre>{`{
+#### Sheet Name
+
+<dd> The name of the page you'd like to query from your spreadsheet.
+</dd>
+
+#### Table Heading Row Index
+
+<dd>The index of the row in your spreadsheet that contains the headings or labels for your table columns. The first row of the spreadsheet is index 1.
+</dd>
+
+#### Update Row Object
+
+<dd>A JSON-formatted object whose key/value pairs represent the columns and values from your table record. You must include a <code>rowIndex</code> key to specify which record to update. If you fetched the record from another Google Sheets query, this index value should be available on its <code>rowIndex</code> property.</dd>
+<dd><i>Example:</i>
+<pre>{`{
     ...{{ UsersTable.selectedRow }}, // includes rowIndex key
     "status": "accepted"
 }`}</pre>
-  </dd>
-
-</dl>
+</dd>
 
 ### Delete One
 
 This command deletes a given entity: **Sheet Row(s)**, **Spreadsheet**, or **Sheet**. The following section lists all the fields available for the **Delete One** command.
 
-<dl>
-  <dt><b>Entity</b></dt>
-  <dd>Sets which entity type to query.
-  </dd><br/>
-  <dd><i>Options:</i>
-    <ul>
-     <li><b>Sheet Row(s):</b> Deletes a single row of a spreadsheet.</li>
-     <li><b>Spreadsheet:</b> Deletes a new spreadsheet document.</li>
-     <li><b>Sheet:</b> Deletes a page from a spreadsheet document.</li>
-    </ul>
-  </dd><br />
+#### Entity
 
-  <dt><b>Spreadsheet</b></dt>
-  <dd> The name of the spreadsheet document you'd like to query.
-  </dd><br />
+<dd>Sets which entity type to query.
+</dd><br/>
+<dd><i>Options:</i>
+  <ul>
+    <li><b>Sheet Row(s):</b> Deletes a single row of a spreadsheet.</li>
+    <li><b>Spreadsheet:</b> Deletes a new spreadsheet document.</li>
+    <li><b>Sheet:</b> Deletes a page from a spreadsheet document.</li>
+  </ul>
+</dd>
 
-  <dt><b>Sheet Name</b></dt>
-  <dd> The name of the page you'd like to query from your spreadsheet.
-  </dd><br />
+#### Spreadsheet
 
-  <dt><b>Row Index</b></dt>
-  <dd>The index of the record to delete from the spreadsheet. If you fetched the record from another Google Sheets query, this index value should be available on its <code>rowIndex</code> property.</dd>
+<dd> The name of the spreadsheet document you'd like to query.
+</dd>
 
-</dl>
+#### Sheet Name
+
+<dd> The name of the page you'd like to query from your spreadsheet.
+</dd>
+
+#### Row Index
+
+<dd>The index of the record to delete from the spreadsheet. If you fetched the record from another Google Sheets query, this index value should be available on its <code>rowIndex</code> property.</dd>
+
 
 ### Fetch Many
 
 This command fetches a given entity type: **Sheet Row(s)** or **Spreadsheet**. The following section lists all the fields available for the **Fetch Many** command.
 
-<dl>
-  <dt><b>Entity</b></dt>
-  <dd>Sets which entity type to query.
-  </dd><br/>
-  <dd><i>Options:</i>
-    <ul>
-     <li><b>Sheet Row(s):</b> Fetches a subset of horizontal records from a page of a spreadsheet document.</li>
-     <li><b>Spreadsheet:</b> Fetches a list of existing spreadsheet documents.</li>
-    </ul>
-  </dd><br />
+#### Entity
 
-  <dt><b>Spreadsheet</b></dt>
-  <dd> The name of the spreadsheet document you'd like to query.
-  </dd><br />
+<dd>Sets which entity type to query.
+</dd><br/>
+<dd><i>Options:</i>
+  <ul>
+    <li><b>Sheet Row(s):</b> Fetches a subset of horizontal records from a page of a spreadsheet document.</li>
+    <li><b>Spreadsheet:</b> Fetches a list of existing spreadsheet documents.</li>
+  </ul>
+</dd>
 
-  <dt><b>Sheet Name</b></dt>
-  <dd> The name of the page you'd like to query from your spreadsheet.
-  </dd><br />
+#### Spreadsheet
 
-  <dt><b>Table Heading Row Index</b></dt>
-  <dd>The index of the row in your spreadsheet that contains the headings or labels for your table columns. The first row of the spreadsheet is index 1.
-  </dd><br />
+<dd> The name of the spreadsheet document you'd like to query.
+</dd>
 
-  <dt><b>Filter Format</b></dt>
-  <dd>Sets the method of selecting records from your spreadsheet.
-  </dd><br/>
-  <dd><i>Options:</i>
-    <ul>
-     <li><b>Where Clause:</b> Fetches records based on logic and conditions. This also allows you to sort and paginate your results.</li>
-     <li><b>Cell Range:</b> Fetches a block of spreadsheet cells defined by spreadsheet-style notation, such as `A2:B7`.</li>
-    </ul>
-  </dd><br />
+#### Sheet Name
 
-  <p>The following settings are available when <b>Filter Format</b> is set to <b>Where Clause</b>:</p><br />
+<dd> The name of the page you'd like to query from your spreadsheet.
+</dd>
 
-  <dt><b>Filter By</b></dt>
-  <dd>This is used to build expressions that return records when a column value meets some criteria. You can evaluate records using `in`, `not in`, `contains`, and logic operators.</dd>
-  <dd><i>Buttons:</i>
-    <ul>
-     <li><b>Add Condition:</b> Adds another simple single-line expression.</li>
-     <li><b>Cell Range:</b> Adds a nested expression with multiple levels of And/Or statements.</li>
-    </ul>
-  </dd><br />
+#### Table Heading Row Index
 
-  <dt><b>Sort By</b></dt>
-  <dd>Sorts the resulting records according to the specified column.</dd>
-  <dd><i>Buttons:</i>
-    <ul>
-     <li><b>Add Parameter:</b> Adds another column for sorting on multiple levels.</li>
-    </ul>
-  </dd><br />
+<dd>The index of the row in your spreadsheet that contains the headings or labels for your table columns. The first row of the spreadsheet is index 1.
+</dd>
 
-  <dt><b>Pagination Limit</b></dt>
-  <dd>Limits the number of records you can receive in a single response. Use with <b>Pagination Offset</b> to implement pagination for large datasets.</dd><br/>
+#### Filter Format
 
-  <dt><b>Pagination Offset</b></dt>
-  <dd>Allows skipping a given number of records before returning results. Use with <b>Pagination Limit</b> to implement pagination for large datasets.</dd><br/>
+<dd>Sets the method of selecting records from your spreadsheet.
+</dd><br/>
+<dd><i>Options:</i>
+  <ul>
+    <li><b>Where Clause:</b> Fetches records based on logic and conditions. This also allows you to sort and paginate your results.</li>
+    <li><b>Cell Range:</b> Fetches a block of spreadsheet cells defined by spreadsheet-style notation, such as `A2:B7`.</li>
+  </ul>
+</dd>
 
-  <p>The following setting is available when <b>Filter Format</b> is set to <b>Cell Range</b>:</p><br />
+<p>The following settings are available when <b>Filter Format</b> is set to <b>Where Clause</b>:</p>
 
-  <dt><b>Cell Range</b></dt>
-  <dd>This mode uses Google Sheets' row number and column letter syntax (such as `A1-B14`) to select cells. Even when the column header row isn't part of your selection, your fetched data still includes the column labels for your selected cells. This mode doesn't allow conditions, sorting, or pagination.</dd>
+#### Filter By
 
-</dl>
+<dd>This is used to build expressions that return records when a column value meets some criteria. You can evaluate records using `in`, `not in`, `contains`, and logic operators.</dd>
+<dd><i>Buttons:</i>
+  <ul>
+    <li><b>Add Condition:</b> Adds another simple single-line expression.</li>
+    <li><b>Cell Range:</b> Adds a nested expression with multiple levels of And/Or statements.</li>
+  </ul>
+</dd>
+
+#### Sort By
+
+<dd>Sorts the resulting records according to the specified column.</dd>
+<dd><i>Buttons:</i>
+  <ul>
+    <li><b>Add Parameter:</b> Adds another column for sorting on multiple levels.</li>
+  </ul>
+</dd>
+
+#### Pagination Limit
+
+<dd>Limits the number of records you can receive in a single response. Use with <b>Pagination Offset</b> to implement pagination for large datasets.</dd>
+
+#### Pagination Offset
+
+<dd>Allows skipping a given number of records before returning results. Use with <b>Pagination Limit</b> to implement pagination for large datasets.</dd>
+
+<p>The following setting is available when <b>Filter Format</b> is set to <b>Cell Range</b>:</p>
+
+#### Cell Range
+
+<dd>This mode uses Google Sheets' row number and column letter syntax (such as `A1-B14`) to select cells. Even when the column header row isn't part of your selection, your fetched data still includes the column labels for your selected cells. This mode doesn't allow conditions, sorting, or pagination.</dd>
 
 ### Insert Many
 
 This command inserts multiple **Sheet Row(s)** entities. The following section lists all the fields available for the **Insert Many** command.
 
-<dl>
-  <dt><b>Entity</b></dt>
-  <dd>Sets which entity type to query.
-  </dd><br/>
-  <dd><i>Options:</i>
-    <ul>
-     <li><b>Sheet Row(s):</b> Inserts several records as a rows in the spreadsheet.</li>
-    </ul>
-  </dd><br />
+#### Entity
 
-  <dt><b>Spreadsheet</b></dt>
-  <dd> The name of the spreadsheet document you'd like to query.
-  </dd><br />
+<dd>Sets which entity type to query.
+</dd><br/>
+<dd><i>Options:</i>
+  <ul>
+    <li><b>Sheet Row(s):</b> Inserts several records as a rows in the spreadsheet.</li>
+  </ul>
+</dd>
 
-  <dt><b>Sheet Name</b></dt>
-  <dd> The name of the page you'd like to query from your spreadsheet.
-  </dd><br />
+#### Spreadsheet
 
-  <dt><b>Table Heading Row Index</b></dt>
-  <dd>The index of the row in your spreadsheet that contains the headings or labels for your table columns. The first row of the spreadsheet is index 1.
-  </dd><br />
+<dd> The name of the spreadsheet document you'd like to query.
+</dd>
 
-  <dt><b>Row Objects</b></dt>
-  <dd>Expects an array of JSON-formatted objects whose key/value pairs represent columns and values to add to the spreadsheet.</dd>
-  <dd><i>Example:</i>
-  <pre>{`[{
+#### Sheet Name
+
+<dd> The name of the page you'd like to query from your spreadsheet.
+</dd>
+
+#### Table Heading Row Index
+
+<dd>The index of the row in your spreadsheet that contains the headings or labels for your table columns. The first row of the spreadsheet is index 1.
+</dd>
+
+#### Row Objects
+
+<dd>Expects an array of JSON-formatted objects whose key/value pairs represent columns and values to add to the spreadsheet.</dd>
+<dd><i>Example:</i>
+<pre>{`[{
     "name": "Kim",
     "email": "hkim@example.com",
     "status": "accepted"
@@ -286,42 +303,43 @@ This command inserts multiple **Sheet Row(s)** entities. The following section l
   "email": "samal@example.com",
   "status": "accepted"
 }]`}</pre>
-  </dd>
-
-</dl>
+</dd>
 
 ### Update Many
 
 This command updates multiple **Sheet Row(s)** entities. The following section lists all the fields available for the **Update Many** command.
 
-<dl>
-  <dt><b>Entity</b></dt>
-  <dd>Sets which entity type to query.
-  </dd><br/>
-  <dd><i>Options:</i>
-    <ul>
-     <li><b>Sheet Row(s):</b> Updates multiple existing rows in the spreadsheet.</li>
-    </ul>
-  </dd><br />
+#### Entity
 
-  <dt><b>Spreadsheet</b></dt>
-  <dd> The name of the spreadsheet document you'd like to query.
-  </dd><br />
+<dd>Sets which entity type to query.
+</dd><br/>
+<dd><i>Options:</i>
+  <ul>
+    <li><b>Sheet Row(s):</b> Updates multiple existing rows in the spreadsheet.</li>
+  </ul>
+</dd>
 
-  <dt><b>Sheet Name</b></dt>
-  <dd> The name of the page you'd like to query from your spreadsheet.
-  </dd><br />
+#### Spreadsheet
 
-  <dt><b>Table Heading Row Index</b></dt>
-  <dd>The index of the row in your spreadsheet that contains the headings or labels for your table columns. The first row of the spreadsheet is index 1.
-  </dd><br />
+<dd> The name of the spreadsheet document you'd like to query.
+</dd>
 
-  <dt><b>Update Row Object(s)</b></dt>
-  <dd>An array of JSON-formatted objects whose key/value pairs represent the columns and values from your table record. You must include a <code>rowIndex</code> key in each row object to specify which record to update in the spreadsheet. Note that the <code>rowIndex</code> property of your row objects in Appsmith refers to its index in the array of table records, not the record's row number in the Google spreadsheet.</dd>
-  <dd><i>Example:</i>
-  <pre>{`{{ UsersTable.updatedRows }} // includes rowIndex key in each object`}</pre>
-  </dd>
-</dl>
+#### Sheet Name
+
+<dd> The name of the page you'd like to query from your spreadsheet.
+</dd>
+
+#### Table Heading Row Index
+
+<dd>The index of the row in your spreadsheet that contains the headings or labels for your table columns. The first row of the spreadsheet is index 1.
+</dd>
+
+#### Update Row Object(s)
+
+<dd>An array of JSON-formatted objects whose key/value pairs represent the columns and values from your table record. You must include a <code>rowIndex</code> key in each row object to specify which record to update in the spreadsheet. Note that the <code>rowIndex</code> property of your row objects in Appsmith refers to its index in the array of table records, not the record's row number in the Google spreadsheet.</dd>
+<dd><i>Example:</i>
+<pre>{`{{ UsersTable.updatedRows }} // includes rowIndex key in each object`}</pre>
+</dd>
 
 ## Troubleshooting
 

--- a/website/docs/connect-data/reference/querying-mongodb/README.md
+++ b/website/docs/connect-data/reference/querying-mongodb/README.md
@@ -28,104 +28,109 @@ The following section is a reference guide that provides a complete description 
    <figcaption align = "center"><i>Connect MongoDB using Connection String URI</i></figcaption>
 </figure>
 
-<dl>
-  <dt><b>Use Mongo Connection String URI</b></dt><br />
-  <dd><i>Options:</i>
-    <ul>
-     <li><b>Yes:</b> Connect to MongoDB database using the Connection String URI format</li>
-     <li><b>No:</b> Connect to MongoDB database by configuring multiple parameter fields.</li>
-    </ul>
-  </dd>  
-</dl>
+#### Use Mongo Connection String URI
 
-<dl>
-  <dt><b>Connection String URI</b></dt>
-  <dd>A MongoDB connection string URI (Uniform Resource Identifier) is a standardized way to specify the location and other details of a MongoDB database. This field is visible only if you select <b>Yes</b> in the <b>Use Mongo Connection String URI</b> list. See <a href="https://www.mongodb.com/docs/manual/reference/connection-string/#connection-string-uri-format"><b>Connection String URI Format</b></a> for details on how to specify the MongoDB connection string.</dd><br />
-  <dd><i>Example:</i></dd>
-  <dd><pre><code>
-   mongodb+srv://mockdb-admin:****@mockdb.kce5o.mongodb.net/movies?retryWrites=true&w=majority&authSource=admin
-  </code></pre></dd>
-</dl>
+<dd><i>Options:</i>
+  <ul>
+    <li><b>Yes:</b> Connect to MongoDB database using the Connection String URI format</li>
+    <li><b>No:</b> Connect to MongoDB database by configuring multiple parameter fields.</li>
+  </ul>
+</dd>
+
+#### Connection String URI
+
+<dd>A MongoDB connection string URI (Uniform Resource Identifier) is a standardized way to specify the location and other details of a MongoDB database. This field is visible only if you select <b>Yes</b> in the <b>Use Mongo Connection String URI</b> list. See <a href="https://www.mongodb.com/docs/manual/reference/connection-string/#connection-string-uri-format"><b>Connection String URI Format</b></a> for details on how to specify the MongoDB connection string.</dd><br />
+<dd><i>Example:</i></dd>
+<dd><pre><code>
+  mongodb+srv://mockdb-admin:****@mockdb.kce5o.mongodb.net/movies?retryWrites=true&w=majority&authSource=admin
+</code></pre></dd>
 
 ---
  
 The following section lists the parameters to connect MongoDB by configuring multiple parameter fields instead of the *Connection String URI* format.
+
 <figure>
   <img src="/img/configure-mongodb-using-connection-mode.png" style= {{width:"100%", height:"auto"}} alt="Connect MongoDB using multiple parameter fields"/>
   <figcaption align = "center"><i>Connect MongoDB using multiple parameter fields</i></figcaption>
  </figure>
 
-<dl>
-  <dt><b>Connection Mode</b></dt>
-  <dd> Specifies the mode in which the Appsmith application can interact with the database. This field and the subsequent fields are visible only if you select <b>No</b> in the <b>Use Mongo Connection String URI</b> list.  </dd><br />
-  <dd><i>Options:</i>
-    <ul>
-     <li><b>Read Only:</b> This mode permits only read-only operations by default.</li>
-     <li><b>Read/Write:</b> This mode permits both read-write operations by default.</li>
-    </ul>
-  </dd>  
- 
- <dt><b>Connection Type</b></dt>
-  <dd> Specifies whether to connect to a MongoDB instance or replica set deployment.</dd><br />
-  <dd><i>Options:</i>
-    <ul>
-     <li><b>Direct Connection:</b> Enables you to connect to a single MongoDB instance</li>
-     <li><b>Replicate Set:</b> Enables you to connect to a group of connected instances that store the same set of data. This configuration provides data redundancy and high data availability. To connect to a replica set deployment, you must specify each instance's hostname and port numbers.</li>
-    </ul>
-  </dd> 
-  
-  <dt><b>Host Address</b></dt>
-  <dd>Specifies the server's IP address or domain name where MongoDB is running. If you want to connect to a local MongoDB database, see  <a href="/connect-data/how-to-guides/how-to-work-with-local-apis-on-appsmith"><b>Connect Local Database</b></a> for directions on configuring the connection parameters. 
-  </dd><br />
+#### Connection Mode
 
-  <dt><b>Port</b></dt>
-  <dd>The port number on which MongoDB listens for incoming connections. Appsmith connects to port <code>27017</code> by default if you don't specify one. 
-  </dd><br />
+<dd> Specifies the mode in which the Appsmith application can interact with the database. This field and the subsequent fields are visible only if you select <b>No</b> in the <b>Use Mongo Connection String URI</b> list.  </dd><br />
+<dd><i>Options:</i>
+  <ul>
+    <li><b>Read Only:</b> This mode permits only read-only operations by default.</li>
+    <li><b>Read/Write:</b> This mode permits both read-write operations by default.</li>
+  </ul>
+</dd>  
 
-  <dt><b>Default Database Name</b></dt>
-  <dd>Specifies the default authentication database to use when authenticating a user. In MongoDB, when a user is authenticated, the authentication process checks the user's credentials against a specific database. By default, this database is <code>admin</code>, but you can specify a different database by using the <b>Default Database Name</b> parameter. 
-  </dd><br />
+#### Connection Type
 
-  <dt><b>Database Name</b></dt>
-  <dd>Specifies the database name associated with the user's credentials. If <b>Database Name</b> is unspecified, it
- defaults to the name specified in the <b>Default Database Name</b> field. If <b>Default Database Name</b> is unspecified, then <b>Database Name</b> defaults to <code>admin</code>.
- </dd><br />
+<dd> Specifies whether to connect to a MongoDB instance or replica set deployment.</dd><br />
+<dd><i>Options:</i>
+  <ul>
+    <li><b>Direct Connection:</b> Enables you to connect to a single MongoDB instance</li>
+    <li><b>Replicate Set:</b> Enables you to connect to a group of connected instances that store the same set of data. This configuration provides data redundancy and high data availability. To connect to a replica set deployment, you must specify each instance's hostname and port numbers.</li>
+  </ul>
+</dd> 
 
-  <dt><b>Authentication Type</b></dt>
-  <dd>Specifies the authentication mechanism that MongoDB uses to authenticate the connection. </dd><br />
-  <dd><i>Options:</i>
-    <ul>
-     <li><b>SCRAM-SHA-1:</b> Provides secure password storage through the use of a salted hash function. See <a href="https://www.mongodb.com/docs/manual/core/security-scram/#std-label-authentication-scram-sha-1">SCRAM-SHA-1</a> for details.</li>
-     <li><b>SCRAM-SHA-256:</b> Uses the SHA-256 hashing algorithm for password storage. See <a href="https://www.mongodb.com/docs/manual/core/security-scram/#std-label-authentication-scram-sha-256">SCRAM-SHA-256</a> for details.</li>
-     <li><b>MONGODB-CR:</b> Uses a challenge-response protocol to authenticate users based on a combination of a password and a random challenge string. See <a href="https://www.mongodb.com/docs/v3.2/core/security-mongodb-cr/">MONGODB-CR</a> for details.</li>
-    </ul>
-  </dd> 
-</dl>
+#### Host Address
+
+<dd>Specifies the server's IP address or domain name where MongoDB is running. If you want to connect to a local MongoDB database, see <a href="/connect-data/how-to-guides/how-to-work-with-local-apis-on-appsmith"><b>Connect Local Database</b></a> for directions on configuring the connection parameters. 
+</dd>
+
+#### Port
+
+<dd>The port number on which MongoDB listens for incoming connections. Appsmith connects to port <code>27017</code> by default if you don't specify one. 
+</dd>
+
+#### Default Database Name
+
+<dd>Specifies the default authentication database to use when authenticating a user. In MongoDB, when a user is authenticated, the authentication process checks the user's credentials against a specific database. By default, this database is <code>admin</code>, but you can specify a different database by using the <b>Default Database Name</b> parameter. 
+</dd>
+
+#### Database Name
+
+<dd>Specifies the database name associated with the user's credentials. If <b>Database Name</b> is unspecified, it
+defaults to the name specified in the <b>Default Database Name</b> field. If <b>Default Database Name</b> is unspecified, then <b>Database Name</b> defaults to <code>admin</code>.
+</dd>
+
+#### Authentication Type
+
+<dd>Specifies the authentication mechanism that MongoDB uses to authenticate the connection. </dd><br />
+<dd><i>Options:</i>
+  <ul>
+    <li><b>SCRAM-SHA-1:</b> Provides secure password storage through the use of a salted hash function. See <a href="https://www.mongodb.com/docs/manual/core/security-scram/#std-label-authentication-scram-sha-1">SCRAM-SHA-1</a> for details.</li>
+    <li><b>SCRAM-SHA-256:</b> Uses the SHA-256 hashing algorithm for password storage. See <a href="https://www.mongodb.com/docs/manual/core/security-scram/#std-label-authentication-scram-sha-256">SCRAM-SHA-256</a> for details.</li>
+    <li><b>MONGODB-CR:</b> Uses a challenge-response protocol to authenticate users based on a combination of a password and a random challenge string. See <a href="https://www.mongodb.com/docs/v3.2/core/security-mongodb-cr/">MONGODB-CR</a> for details.</li>
+  </ul>
+</dd>
 
 :::info
 You cannot specify MONGODB-CR as the authentication mechanism when connecting to MongoDB 4.0+ deployments.
 :::
 
-<dl>
-  <dt><b>Username</b></dt>
-  <dd>Provide the username required for authenticating connection requests to the database.
-  </dd><br />
+#### Username
 
-  <dt><b>Password</b></dt>
-  <dd>Provide the password required for authenticating connection requests for the given username to the database.
-  </dd><br />
+<dd>Provide the username required for authenticating connection requests to the database.
+</dd>
 
-  <dt><b>SSL Mode</b></dt>
-  <dd>SSL can be used to secure the connection between the client and the server by encrypting all data that is transmitted between them. 
-  </dd><br />
-  <dd><i>Options:</i>
-    <ul>
-     <li><b>Default:</b> Depends on <b>Connection Type</b> field. If using the <b>Replica set</b> option, this is <code>Enabled</code>. If using the <b>Direct Connection</b>, this is <code>Disabled</code>.</li>
-     <li><b>Enabled:</b> Initiates the connection with TLS/SSL. Rejects the connection if SSL is not available.</li>
-     <li><b>Disabled:</b> Initiates the connection without TLS/SSL. Disallows all administrative requests over HTTPS. It uses a plain unencrypted connection. </li>
-    </ul>
-  </dd>  
-</dl>
+#### Password
+
+<dd>Provide the password required for authenticating connection requests for the given username to the database.
+</dd>
+
+#### SSL Mode
+
+<dd>SSL can be used to secure the connection between the client and the server by encrypting all data that is transmitted between them. 
+</dd><br />
+<dd><i>Options:</i>
+  <ul>
+    <li><b>Default:</b> Depends on <b>Connection Type</b> field. If using the <b>Replica set</b> option, this is <code>Enabled</code>. If using the <b>Direct Connection</b>, this is <code>Disabled</code>.</li>
+    <li><b>Enabled:</b> Initiates the connection with TLS/SSL. Rejects the connection if SSL is not available.</li>
+    <li><b>Disabled:</b> Initiates the connection without TLS/SSL. Disallows all administrative requests over HTTPS. It uses a plain unencrypted connection. </li>
+  </ul>
+</dd>
 
 ## Query MongoDB
 
@@ -144,207 +149,210 @@ The following section is a reference guide that provides a complete description 
 
 This command fetches documents from a collection. The following section lists all the fields available for the **Find Documents** command.
 
-<dl>
-  <dt><b>Collection</b></dt>
-  <dd>The name of the target collection from which you want to retrieve documents.
-  </dd><br />
+#### Collection
 
-  <dt><b>Query</b></dt>
-  <dd>Specifies the criteria that match the documents you want to retrieve.</dd><br/>
+<dd>The name of the target collection from which you want to retrieve documents.
+</dd>
 
-  <dd><i>Example:</i></dd>
-  <dd><pre>{`{ 
+#### Query
+
+<dd>Specifies the criteria that match the documents you want to retrieve.</dd><br/>
+
+<dd><i>Example:</i></dd>
+<dd><pre>{`{ 
   rating: { $gte: 4 },
   cuisine: {{cuisineList.selectedOptionValue}}
 }`}</pre></dd>
-  <dd>In the above example, the query filters documents from a restaurant collection where the rating field is greater than 4 and the cuisine matches the one selected in the Select widget <code>cusineList</code>.</dd><br />
+<dd>In the above example, the query filters documents from a restaurant collection where the rating field is greater than 4 and the cuisine matches the one selected in the Select widget <code>cusineList</code>.</dd>
 
-  <dt><b>Sort</b></dt>
-  <dd>Specifies the order in which the documents should be returned. 
-  </dd><br/>
-  <dd><i>Example:</i></dd>
-  <dd><pre>{`{ name: 1 }
-`}</pre></dd>
-  <dd>In the above example, the query sorts the results by the <code>name</code> field in ascending order.</dd><br />
+#### Sort
 
-  <dt><b>Projection</b></dt>
-  <dd>Specifies which fields to include in the returned documents.</dd><br/>
-  <dd><i>Example:</i></dd>
-  <dd><pre>{`{ name: 1, rating: 1, address: 1 }
+<dd>Specifies the order in which the documents should be returned. 
+</dd><br/>
+<dd><i>Example:</i></dd>
+<dd><pre>{`{ name: 1 }
 `}</pre></dd>
-  <dd>In the above example, the query only returns the <code>name</code>, <code>rating</code>, and <code>address</code> fields in the matching documents.</dd><br />
+<dd>In the above example, the query sorts the results by the <code>name</code> field in ascending order.</dd>
 
-  <dt><b>Limit</b></dt>
-  <dd>Specifies the maximum number of documents to return. The default value is 10. If this field is not specified, the query returns 10 documents.
-  </dd><br />
-  <dd><i>Example:</i></dd>
-  <dd><pre>{`{{tableItems.pageSize}}
-`}</pre></dd>
-  <dd>In the above example, <code>tableItems</code> is the name of the Table widget where you display the results from the query. The query limits the results based on the table widget's pageSize property.</dd><br />
+#### Projection
 
-  <dt><b>Skip</b></dt>
-  <dd>This field specifies the number of documents to skip before returning results. </dd><br />
-  <dd><i>Example:</i></dd>
-  <dd><pre>{`{{tableItems.pageOffset}}
+<dd>Specifies which fields to include in the returned documents.</dd><br/>
+<dd><i>Example:</i></dd>
+<dd><pre>{`{ name: 1, rating: 1, address: 1 }
 `}</pre></dd>
-  <dd>In the above examples for the <b>Limit</b> and <b>Skip</b> fields, the queries use <a href="/reference/widgets/table#server-side-pagination"><b>server-side pagination</b></a> to limit the number of query results returned by the server and fetch additional results when the user moves to the next page in the Table widget. You can fork this <a href="https://app.appsmith.com/applications/623cca594d9aea1b062b33c6/pages/623cca594d9aea1b062b33cd"><b>Sample App</b></a> to see how to implement server-side pagination on the Table widget.</dd>
-</dl>
+<dd>In the above example, the query only returns the <code>name</code>, <code>rating</code>, and <code>address</code> fields in the matching documents.</dd>
+
+#### Limit
+
+<dd>Specifies the maximum number of documents to return. The default value is 10. If this field is not specified, the query returns 10 documents.
+</dd><br />
+<dd><i>Example:</i></dd>
+<dd><pre>{`{{tableItems.pageSize}}
+`}</pre></dd>
+<dd>In the above example, <code>tableItems</code> is the name of the Table widget where you display the results from the query. The query limits the results based on the table widget's pageSize property.</dd>
+
+  #### Skip
+
+<dd>This field specifies the number of documents to skip before returning results. </dd><br />
+<dd><i>Example:</i></dd>
+<dd><pre>{`{{tableItems.pageOffset}}
+`}</pre></dd>
+<dd>In the above examples for the <b>Limit</b> and <b>Skip</b> fields, the queries use <a href="/reference/widgets/table#server-side-pagination"><b>server-side pagination</b></a> to limit the number of query results returned by the server and fetch additional results when the user moves to the next page in the Table widget. You can fork this <a href="https://app.appsmith.com/applications/623cca594d9aea1b062b33c6/pages/623cca594d9aea1b062b33cd"><b>Sample App</b></a> to see how to implement server-side pagination on the Table widget.</dd>
 
 ### Insert Documents
 
 This command inserts one or more documents and returns a document containing the status of all inserts. The following section lists all the fields for the **Insert Documents** command.
 
-<dl>
-  <dt><b>Collection</b></dt>
-  <dd>The name of the target collection where you want to insert the documents.
-  </dd><br />
+#### Collection
+<dd>The name of the target collection where you want to insert the documents.
+</dd>
 
-  <dt><b>Documents</b></dt>
-  <dd>Specifies an array of one or more documents you want to insert into the collection.</dd><br />
-  <dd><i>Example:</i></dd>
-  <dd><pre>{`[
+#### Documents
+<dd>Specifies an array of one or more documents you want to insert into the collection.</dd><br />
+<dd><i>Example:</i></dd>
+<dd><pre>{`[
   { 
     "_id": {{NewMovieForm.data.idInput}}, 
     "name": {{NewMovieForm.data.nameInput}}, 
     "rating": {{NewMovieForm.data.ratingSelect}}
   }
 ]`}</pre></dd>
-  <dd>In the above example, the query inserts a new movie using the data entered in the Form widget.</dd><br />
-</dl>
+<dd>In the above example, the query inserts a new movie using the data entered in the Form widget.</dd>
 
 ### Update Documents
 
 This command modifies the documents in a collection based on a specified set of filters. The following section lists all the fields available for the **Update Documents** command. 
 
-<dl>
-  <dt><b>Collection</b></dt>
-  <dd>The name of the target collection where you want to update documents.
-  </dd><br />
+#### Collection
 
-  <dt><b>Query</b></dt>
-  <dd>Specifies the criteria that match the documents you want to update.</dd><br />
-  <dd><i>Example:</i></dd>
-  <dd><pre>{`{ 
+<dd>The name of the target collection where you want to update documents.
+</dd>
+
+#### Query
+<dd>Specifies the criteria that match the documents you want to update.</dd>
+<dd><i>Example:</i></dd>
+<dd><pre>{`{ 
   "_id": {{tableItems.selectedRow.id}} 
 }`}</pre></dd>
-  <dd>In the above example, the query filters the record where the <code>_id</code> field is equal to the value in the <code>id</code> column of the row selected on the Table widget named <code>tableItems</code>.</dd><br />
+<dd>In the above example, the query filters the record where the <code>_id</code> field is equal to the value in the <code>id</code> column of the row selected on the Table widget named <code>tableItems</code>.</dd>
 
-  <dt><b>Update</b></dt>
-  <dd>Specifies the modifications you want to make to the selected documents. 
-  </dd><br />
-  <dd><i>Example:</i></dd>
-  <dd><pre>{`{ 
+#### Update 
+
+<dd>Specifies the modifications you want to make to the selected documents. 
+</dd><br />
+<dd><i>Example:</i></dd>
+<dd><pre>{`{ 
   $set: {
     "name":  {{tableItems.updatedRow.name}},
     "rating": {{tableItems.updatedRow.rating}}
   }
 }`}</pre></dd>
-  <dd>In the above example, the query updates the <code>name</code> and <code>rating</code> fields with the values updated in the table cells using <a href="/reference/widgets/table/inline-editing"><b>inline editing</b></a>.</dd><br />
+<dd>In the above example, the query updates the <code>name</code> and <code>rating</code> fields with the values updated in the table cells using <a href="/reference/widgets/table/inline-editing"><b>inline editing</b></a>.</dd>
 
-  <dt><b>Limit</b></dt>
-  <dd>Specifies whether to delete single or multiple documents</dd><br />
-  <dd><i>Options:</i>
-    <ul>
-     <li><b>Single Document:</b> Limits the update to one document that meets the query criteria.</li>
-     <li><b>All Matching Documents:</b> Updates the fields in all documents that meet the query criteria.</li>
-    </ul>
-  </dd>  
-</dl>
-
+#### Limit
+<dd>Specifies whether to delete single or multiple documents</dd><br />
+<dd><i>Options:</i>
+  <ul>
+    <li><b>Single Document:</b> Limits the update to one document that meets the query criteria.</li>
+    <li><b>All Matching Documents:</b> Updates the fields in all documents that meet the query criteria.</li>
+  </ul>
+</dd>
 
 ### Delete Documents
 
 This command removes one or more documents from the collection based on specified filters. The following section lists all the fields available for the **Delete Documents** command.
 
-<dl>
-  <dt><b>Collection</b></dt>
-  <dd>The name of the target collection where you want to delete documents.
-  </dd><br />
+#### Collection
 
-  <dt><b>Query</b></dt>
-  <dd>Specifies the criteria that match the documents to delete.</dd><br />
-  <dd><i>Example:</i></dd>
-  <dd><pre>{`{ 
+<dd>The name of the target collection where you want to delete documents.
+</dd>
+
+#### Query
+
+<dd>Specifies the criteria that match the documents to delete.</dd><br />
+<dd><i>Example:</i></dd>
+<dd><pre>{`{ 
   "rating": {{selectRating.selectedOptionValue}} 
 }`}</pre></dd>
-  <dd>In the above example, the query deletes all the documents where the <code>rating</code> field contains the same value as the one selected in the Select widget named <code>selectRating</code>.</dd><br />
+<dd>In the above example, the query deletes all the documents where the <code>rating</code> field contains the same value as the one selected in the Select widget named <code>selectRating</code>.</dd>
 
-  <dt><b>Limit</b></dt>
-  <dd>Specifies whether to delete single or multiple documents</dd><br />
-  <dd><i>Options:</i>
-    <ul>
-     <li><b>Single Document:</b> Limits the update to one document that meets the query criteria.</li>
-     <li><b>All Matching Documents:</b> Updates the fields in all documents that meet the query criteria.</li>
-    </ul>
-  </dd>  
-</dl>
+#### Limit
+
+<dd>Specifies whether to delete single or multiple documents</dd><br />
+<dd><i>Options:</i>
+  <ul>
+    <li><b>Single Document:</b> Limits the update to one document that meets the query criteria.</li>
+    <li><b>All Matching Documents:</b> Updates the fields in all documents that meet the query criteria.</li>
+  </ul>
+</dd>
 
 ### Count
 
 This command counts the number of documents in a collection that match a specified set of criteria. The following section lists all the fields available for the **Count** command.
 
-<dl>
-  <dt><b>Collection</b></dt>
-  <dd>The name of the target collection where you want to count the documents.
-  </dd><br />
+#### Collection
 
-  <dt><b>Query</b></dt>
-  <dd>This field specifies the criteria for selecting the documents to count.</dd><br />
-  <dd><i>Example:</i></dd>
-  <dd><pre>{`{ 
+<dd>The name of the target collection where you want to count the documents.
+</dd>
+
+#### Query
+
+<dd>This field specifies the criteria for selecting the documents to count.</dd><br />
+<dd><i>Example:</i></dd>
+<dd><pre>{`{ 
   "release_dt": { $gte: {{releaseDate.formattedDate}} 
 }`}</pre></dd>
-  <dd>In the above example, the query counts the documents in a <code>movies</code> collection where the release date is greater than the date picked in the Datepicker widget <code>releaseDate</code>.</dd>
-</dl>
+<dd>In the above example, the query counts the documents in a <code>movies</code> collection where the release date is greater than the date picked in the Datepicker widget <code>releaseDate</code>.</dd>
 
 ### Distinct
 
 This command finds the unique or distinct values for a specified field across a single collection. The following section lists all the fields available for the **Distinct** command.
 
-<dl>
-  <dt><b>Collection</b></dt>
-  <dd>Specifies the name of the target collection to query for distinct values.
-  </dd><br />
+#### Collection
 
-  <dt><b>Query</b></dt>
-  <dd>Specifies the documents from which to retrieve the distinct values.</dd><br />
-  <dd><i>Example:</i></dd>
-  <dd><pre>{`{ 
+<dd>Specifies the name of the target collection to query for distinct values.
+</dd>
+
+#### Query
+
+<dd>Specifies the documents from which to retrieve the distinct values.</dd><br />
+<dd><i>Example:</i></dd>
+<dd><pre>{`{ 
   "rating": {{selectRating.selectedOptionValue}} 
 }`}</pre></dd>
-  <dd>In the above example, the query retrieves distinct values from the documents where the <code>rating</code> field contains the same value as the one selected in the Select widget named <code>selectRating</code>.</dd><br />
+<dd>In the above example, the query retrieves distinct values from the documents where the <code>rating</code> field contains the same value as the one selected in the Select widget named <code>selectRating</code>.</dd>
 
-  <dt><b>Key</b></dt>
-  <dd> Specifies the name of the field for which to return distinct values.
-  </dd>
-</dl>
+#### Key
+
+<dd> Specifies the name of the field for which to return distinct values.
+</dd>
 
 
 ### Aggregate
 
 This command allows users to process data records and return computed results. The aggregation framework provides several operators to perform a variety of operations like filtering, grouping, sorting, projecting, and calculating. See <a href="https://www.mongodb.com/docs/manual/reference/operator/aggregation-pipeline/"><b>Aggregation Pipeline Stages</b></a> for information on the aggregation operators. The following section lists all the fields available for the **Aggregate** command.
 
-<dl>
-  <dt><b>Collection</b></dt>
-  <dd>Specifies the name of the target collection that serves as the input for the aggregation pipeline.
-  </dd><br />
+#### Collection
 
-  <dt><b>Array of Pipelines</b></dt>
-  <dd>An array of aggregation pipeline stages that process and transform the document stream as part of the aggregation pipeline. </dd><br />
-  <dd><i>Example:</i></dd>
-  <dd><pre>{`{ 
+<dd>Specifies the name of the target collection that serves as the input for the aggregation pipeline.
+</dd>
+
+#### Array of Pipelines
+
+<dd>An array of aggregation pipeline stages that process and transform the document stream as part of the aggregation pipeline. </dd><br />
+<dd><i>Example:</i></dd>
+<dd><pre>{`{ 
   [
     { $project: { tags: 1 } },
     { $unwind: "$tags" },
     { $group: { _id: "$tags", count: { $sum : 1 } } }
   ] 
 }`}</pre></dd>
-  <dd>The preceding example performs an aggregate operation on the <code>articles</code> collection to calculate the count of each distinct element in the <code>tags</code> array that appears in the collection.</dd><br />
+<dd>The preceding example performs an aggregate operation on the <code>articles</code> collection to calculate the count of each distinct element in the <code>tags</code> array that appears in the collection.</dd>
 
-  <dt><b>Limit</b></dt>
-  <dd>Specifies the maximum number of documents to return. The default value is 10. If this field isn't specified, the query returns 10 documents.
-  </dd>
-</dl>
+#### Limit
+<dd>Specifies the maximum number of documents to return. The default value is 10. If this field isn't specified, the query returns 10 documents.
+</dd>
 
 ### Raw
 

--- a/website/docs/connect-data/reference/querying-mssql.md
+++ b/website/docs/connect-data/reference/querying-mssql.md
@@ -24,40 +24,45 @@ The following section is a reference guide that provides a complete description 
   <figcaption align="center"><i>Configuring an MS SQL datasource.</i></figcaption>
 </figure>
 
-<dl>
-  <dt><b>Connection mode</b></dt>
-  <dd>Sets which permissions to grant to Appsmith when establishing a connection to the database.</dd><br />
-  <dd><i>Options:</i>
-    <ul>
-      <li><b>Read Only:</b> Gives Appsmith read-only permission on the database. Use this mode when you only need to fetch records, not write them.</li>
-      <li><b>Read / Write:</b> Gives Appsmith both read and write permissions on the database. This allows you to make changes to your data via all CRUD queries.</li>
-    </ul>
-  </dd><br />
+#### Connection mode
 
-  <dt><b>Host Address</b></dt>
-  <dd>The network location of your MS SQL database. This can be a domain name or an IP address. To connect to a local MS SQL database, see <a href="/connect-data/how-to-guides/how-to-work-with-local-apis-on-appsmith"><b>Connect Local Database</b></a> for directions. </dd><br />
+<dd>Sets which permissions to grant to Appsmith when establishing a connection to the database.</dd><br />
+<dd><i>Options:</i>
+  <ul>
+    <li><b>Read Only:</b> Gives Appsmith read-only permission on the database. Use this mode when you only need to fetch records, not write them.</li>
+    <li><b>Read / Write:</b> Gives Appsmith both read and write permissions on the database. This allows you to make changes to your data via all CRUD queries.</li>
+  </ul>
+</dd>
 
-  <dt><b>Port</b></dt>
-  <dd>The port number to connect to on the server. Appsmith connects to port <code>1433</code> by default if you do not specify one.</dd><br />
+#### Host Address
 
-  <dt><b>Database Name</b></dt>
-  <dd>The name of the database to connect.</dd><br />
+<dd>The network location of your MS SQL database. This can be a domain name or an IP address. To connect to a local MS SQL database, see <a href="/connect-data/how-to-guides/how-to-work-with-local-apis-on-appsmith"><b>Connect Local Database</b></a> for directions. </dd>
 
-  <dt><b>Username</b></dt>
-  <dd>The username that you want to use to authenticate with the database server.</dd><br />
+#### Port
 
-  <dt><b>Password</b></dt>
-  <dd>Password to use if the server demands password authentication.</dd><br />
+<dd>The port number to connect to on the server. Appsmith connects to port <code>1433</code> by default if you do not specify one.</dd>
 
-  <dt><b>SSL mode</b></dt>
-  <dd>Determines whether your queries use an SSL connection to communicate with the database.</dd><br />
-  <dd><i>Options:</i>
-    <ul>
-      <li><b>Enabled with no verify:</b> The connection is encrypted but no client verification is done.</li>
-      <li><b>Disabled:</b> Disables SSL completely, and all connections are established without encryption.</li>
-    </ul>
-  </dd>
-</dl>
+#### Database Name
+
+<dd>The name of the database to connect.</dd>
+
+#### Username
+
+<dd>The username that you want to use to authenticate with the database server.</dd>
+
+#### Password
+
+<dd>Password to use if the server demands password authentication.</dd>
+
+#### SSL mode
+
+<dd>Determines whether your queries use an SSL connection to communicate with the database.</dd><br />
+<dd><i>Options:</i>
+  <ul>
+    <li><b>Enabled with no verify:</b> The connection is encrypted but no client verification is done.</li>
+    <li><b>Disabled:</b> Disables SSL completely, and all connections are established without encryption.</li>
+  </ul>
+</dd>
 
 ## Query MS SQL
 

--- a/website/docs/connect-data/reference/querying-mysql.md
+++ b/website/docs/connect-data/reference/querying-mysql.md
@@ -23,47 +23,53 @@ The following section is a reference guide that provides a complete description 
   <figcaption align = "center"><i>MySQL Datasource configuration page</i></figcaption>
 </figure>
 
-<dl>
-  <dt><b>Connection mode</b></dt>
-  <dd>Sets which permissions to grant to Appsmith when establishing a connection to the database.</dd>
-  <dd><i>Options:</i>
-    <ul>
-      <li><b>Read Only:</b> Gives Appsmith read-only permission on the database. Use this mode when you only need to fetch records, not write them.</li>
-      <li><b>Read / Write:</b> Gives Appsmith both read and write permissions on the database. This allows you to make changes to your data via all CRUD queries.</li>
-    </ul>
-  </dd><br />
+#### Connection mode
 
-  <dt><b>Host address</b></dt>
-  <dd>The network location of your MySQL database. This could be a domain or IP address. For a guide about connecting to a local MySQL database, see <a href="/connect-data/how-to-guides/how-to-work-with-local-apis-on-appsmith"><b>Connect Local Database</b></a>.</dd><br />
+<dd>Sets which permissions to grant to Appsmith when establishing a connection to the database.</dd>
+<dd><i>Options:</i>
+  <ul>
+    <li><b>Read Only:</b> Gives Appsmith read-only permission on the database. Use this mode when you only need to fetch records, not write them.</li>
+    <li><b>Read / Write:</b> Gives Appsmith both read and write permissions on the database. This allows you to make changes to your data via all CRUD queries.</li>
+  </ul>
+</dd>
 
-  <dt><b>Port</b></dt>
-  <dd>The port number to connect to on the server. Appsmith connects to port <code>3306</code> by default if you do not specify one.</dd><br />
+#### Host address
 
-  <dt><b>Database name</b></dt>
-  <dd>The name of the database to connect.</dd><br />
+<dd>The network location of your MySQL database. This could be a domain or IP address. For a guide about connecting to a local MySQL database, see <a href="/connect-data/how-to-guides/how-to-work-with-local-apis-on-appsmith"><b>Connect Local Database</b></a>.</dd>
 
-  <dt><b>Username</b></dt>
-  <dd>The username for your MySQL user.
-  </dd><br />
+#### Port
 
-  <dt><b>Password</b></dt>
-  <dd>The password for your MySQL user.
-  </dd><br />
+<dd>The port number to connect to on the server. Appsmith connects to port <code>3306</code> by default if you do not specify one.</dd>
 
-  <dt><b>SSL mode</b></dt>
-  <dd>Determines whether your queries use an SSL connection to communicate with the database.</dd>
-  <dd><i>Options:</i>
-    <ul>
-      <li><b>Default:</b> SSL is used if the server supports it.</li>
-      <li><b>Required:</b> The connection is rejected if SSL isn't available.</li>
-      <li><b>Disabled:</b> Disallows all administrative requests over HTTPS. It uses a plain unencrypted connection.</li>
-    </ul>
-  </dd><br />
+#### Database name
 
-  <dt><b>Server Timezone Override</b></dt>
-  <dd>Sets a custom timezone, which is useful if Appsmith doesn't automatically recognize the MySQL server's timezone. Expects a valid timezone string (For example: <code>UTC</code>) to use for your queries.
-  </dd>
-</dl>
+<dd>The name of the database to connect.</dd>
+
+#### Username
+
+<dd>The username for your MySQL user.
+</dd>
+
+#### Password
+
+<dd>The password for your MySQL user.
+</dd>
+
+#### SSL mode
+
+<dd>Determines whether your queries use an SSL connection to communicate with the database.</dd>
+<dd><i>Options:</i>
+  <ul>
+    <li><b>Default:</b> SSL is used if the server supports it.</li>
+    <li><b>Required:</b> The connection is rejected if SSL isn't available.</li>
+    <li><b>Disabled:</b> Disallows all administrative requests over HTTPS. It uses a plain unencrypted connection.</li>
+  </ul>
+</dd>
+
+#### Server Timezone Override
+
+<dd>Sets a custom timezone, which is useful if Appsmith doesn't automatically recognize the MySQL server's timezone. Expects a valid timezone string (For example: <code>UTC</code>) to use for your queries.
+</dd>
 
 ## Create queries
 

--- a/website/docs/connect-data/reference/querying-oracle.md
+++ b/website/docs/connect-data/reference/querying-oracle.md
@@ -21,31 +21,35 @@ The following section is a reference guide that provides a complete description 
   <figcaption align="center"><i>Configuring an Oracle datasource.</i></figcaption>
 </figure>
 
-<dl>
-  <dt><b>Host Address</b></dt>
-  <dd>The network location of your Oracle database. This can be a domain name or an IP address. To connect to a local Oracle database, see <a href="/connect-data/how-to-guides/how-to-work-with-local-apis-on-appsmith"><b>Connect Local Database</b></a> for directions. </dd><br />
+#### Host Address
 
-  <dt><b>Port</b></dt>
-  <dd>The port number to connect to on the server. Appsmith connects to port `1521` by default if you do not specify one.</dd><br />
+<dd>The network location of your Oracle database. This can be a domain name or an IP address. To connect to a local Oracle database, see <a href="/connect-data/how-to-guides/how-to-work-with-local-apis-on-appsmith"><b>Connect Local Database</b></a> for directions. </dd>
 
-  <dt><b>Service Name</b></dt>
-  <dd>The service name for your database instance. </dd><br />
+#### Port
 
-  <dt><b>Username</b></dt>
-  <dd>The username that you want to use to authenticate with the Oracle server.</dd><br />
+<dd>The port number to connect to on the server. Appsmith connects to port `1521` by default if you do not specify one.</dd>
 
-  <dt><b>Password</b></dt>
-  <dd>Password to use if the server demands password authentication.</dd><br />
+#### Service Name
 
-  <dt><b>SSL Mode</b></dt>
-  <dd>Determines whether your queries use an SSL connection to communicate with the database.</dd><br />
-  <dd><i>Options:</i>
-    <ul>
-      <li><b>TLS:</b> Connection is encrypted but no client verification is done.</li>
-      <li><b>Disabled:</b> Disables SSL completely, and all connections are established without encryption.</li>
-    </ul>
-  </dd>
-</dl>
+<dd>The service name for your database instance. </dd>
+
+#### Username
+
+<dd>The username that you want to use to authenticate with the Oracle server.</dd>
+
+#### Password
+
+<dd>Password to use if the server demands password authentication.</dd>
+
+#### SSL Mode
+
+<dd>Determines whether your queries use an SSL connection to communicate with the database.</dd><br />
+<dd><i>Options:</i>
+  <ul>
+    <li><b>TLS:</b> Connection is encrypted but no client verification is done.</li>
+    <li><b>Disabled:</b> Disables SSL completely, and all connections are established without encryption.</li>
+  </ul>
+</dd>
 
 ## Query Oracle
 

--- a/website/docs/connect-data/reference/querying-postgres.md
+++ b/website/docs/connect-data/reference/querying-postgres.md
@@ -21,45 +21,49 @@ The following section is a reference guide that provides a complete description 
   <figcaption align = "center"><i>Connect PostgreSQL Database</i></figcaption>
 </figure>
 
-<dl>
-  <dt><b>Connection Mode</b></dt>
-  <dd> Specifies the mode in which the Appsmith application can interact with the database. </dd><br />
-  <dd><i>Options:</i>
-    <ul>
-     <li><b>Read Only:</b> This mode permits read-only transactions by default.</li>
-     <li><b>Read/Write:</b> This mode permits both read-write transactions by default.</li>
-    </ul>
-  </dd>  
+#### Connection Mode
 
-  <dt><b>Host Address</b></dt>
-  <dd>The network location of the PostgreSQL server that you want to connect. This can be a domain name or an IP address. To connect to a local PostgreSQL database, see <a href="/connect-data/how-to-guides/how-to-work-with-local-apis-on-appsmith"><b>Connect Local Database</b></a> for directions on configuring the connection parameters. </dd><br />
+<dd> Specifies the mode in which the Appsmith application can interact with the database. </dd><br />
+<dd><i>Options:</i>
+  <ul>
+    <li><b>Read Only:</b> This mode permits read-only transactions by default.</li>
+    <li><b>Read/Write:</b> This mode permits both read-write transactions by default.</li>
+  </ul>
+</dd>  
 
-  <dt><b>Port</b></dt>
-  <dd>The port number to connect to at the server host. Appsmith connects to port <code>5432</code> by default if you do not specify one. </dd><br />
+#### Host Address
 
-  <dt><b>Database Name</b></dt>
-  <dd>The name of the database you want to connect. </dd><br />
+<dd>The network location of the PostgreSQL server that you want to connect. This can be a domain name or an IP address. To connect to a local PostgreSQL database, see <a href="/connect-data/how-to-guides/how-to-work-with-local-apis-on-appsmith"><b>Connect Local Database</b></a> for directions on configuring the connection parameters. </dd>
 
-  <dt><b>Username</b></dt>
-  <dd>The username that you want to use to authenticate with the PostgreSQL server.</dd><br />
+#### Port
 
-  <dt><b>Password</b></dt>
-  <dd>Password to use if the server demands password authentication.</dd><br />
+<dd>The port number to connect to at the server host. Appsmith connects to port <code>5432</code> by default if you do not specify one. </dd>
 
-  <dt><b>SSL Mode</b></dt>
-  <dd>Determines with what priority a secure SSL TCP/IP connection is negotiated with the server.</dd><br />
-  <dd><i>Options:</i>
-    <ul>
-     <li><b>Default:</b> The default SSL Mode is <b>Prefer</b>.</li>
-     <li><b>Allow:</b> First try a non-SSL connection; if that fails, try an SSL connection. The client can connect with or without SSL.</li>
-     <li><b>Prefer:</b> First try an SSL connection; if that fails, try a non-SSL connection. The client tries to connect with SSL but falls back to an unencrypted connection if SSL is unavailable.</li>
-     <li><b>Require:</b> Only try an SSL connection. Rejects the connection if SSL is not available.</li>
-     <li><b>Disable:</b> Only try a non-SSL connection. Disallows all administrative requests over HTTPS. It uses a plain unencrypted connection.</li>
-    </ul>
-  </dd>  
-  <dd>For more information, see <a href="https://www.postgresql.org/docs/current/libpq-ssl.html"><b>SSL Support</b></a>.</dd>
-</dl>
+#### Database Name
 
+<dd>The name of the database you want to connect. </dd>
+
+#### Username
+
+<dd>The username that you want to use to authenticate with the PostgreSQL server.</dd>
+
+#### Password
+
+<dd>Password to use if the server demands password authentication.</dd>
+
+#### SSL Mode
+
+<dd>Determines with what priority a secure SSL TCP/IP connection is negotiated with the server.</dd><br />
+<dd><i>Options:</i>
+  <ul>
+    <li><b>Default:</b> The default SSL Mode is <b>Prefer</b>.</li>
+    <li><b>Allow:</b> First try a non-SSL connection; if that fails, try an SSL connection. The client can connect with or without SSL.</li>
+    <li><b>Prefer:</b> First try an SSL connection; if that fails, try a non-SSL connection. The client tries to connect with SSL but falls back to an unencrypted connection if SSL is unavailable.</li>
+    <li><b>Require:</b> Only try an SSL connection. Rejects the connection if SSL is not available.</li>
+    <li><b>Disable:</b> Only try a non-SSL connection. Disallows all administrative requests over HTTPS. It uses a plain unencrypted connection.</li>
+  </ul>
+</dd>  
+<dd>For more information, see <a href="https://www.postgresql.org/docs/current/libpq-ssl.html"><b>SSL Support</b></a>.</dd>
 
 ## Query PostgreSQL
 

--- a/website/docs/connect-data/reference/querying-redis.md
+++ b/website/docs/connect-data/reference/querying-redis.md
@@ -21,24 +21,27 @@ The following section is a reference guide that provides a complete description 
   <figcaption align="center"><i>Configuring a Redis datasource.</i></figcaption>
 </figure>
 
-<dl>
-  <dt><b>Host Address</b></dt>
-  <dd>The network location of your Redis database. This can be a domain name or an IP address.</dd><br />
+#### Host Address
 
-  <dt><b>Port</b></dt>
-  <dd>The port number to connect to on the server. Appsmith connects to port <code>6379</code> by default if you do not specify one.</dd><br />
+<dd>The network location of your Redis database. This can be a domain name or an IP address.</dd>
 
-  <dt><b>Database Number</b></dt>
-  <dd>The number that identifies which database on your Redis instance you're connecting to. This is a number between 0 and 15, and is 0 by default.</dd><br />
+#### Port
 
-  <dt><b>Username</b></dt>
-  <dd>The username for your Redis user.
-  </dd><br />
+<dd>The port number to connect to on the server. Appsmith connects to port <code>6379</code> by default if you do not specify one.</dd>
 
-  <dt><b>Password</b></dt>
-  <dd>The password for your Redis user.
-  </dd><br />
-</dl>
+#### Database Number
+
+<dd>The number that identifies which database on your Redis instance you're connecting to. This is a number between 0 and 15, and is 0 by default.</dd>
+
+#### Username
+
+<dd>The username for your Redis user.
+</dd>
+
+#### Password
+
+<dd>The password for your Redis user.
+</dd>
 
 ## Query Redis
 

--- a/website/docs/connect-data/reference/querying-redshift.md
+++ b/website/docs/connect-data/reference/querying-redshift.md
@@ -22,31 +22,35 @@ The following section is a reference guide that provides a complete description 
   <figcaption align="center"><i>Configuring a Redshift datasource.</i></figcaption>
 </figure>
 
-<dl>
-  <dt><b>Connection Mode</b></dt>
-  <dd>Determines which permissions your app has when querying the database.</dd><br />
-  <dd><i>Options:</i>
-    <ul>
-      <li><b>Read Only:</b> Gives Appsmith read-only permission on the database. This allows you to only fetch data from the database.</li>
-      <li><b>Read / Write:</b> Gives Appsmith both read and write permissions on the database. This allows you to execute all CRUD queries.</li>
-    </ul>
-  </dd><br/>
+#### Connection Mode
 
-  <dt><b>Host Address</b></dt>
-  <dd>The network location of your Redshift database. This can be a domain name or an IP address.</dd><br />
+<dd>Determines which permissions your app has when querying the database.</dd><br />
+<dd><i>Options:</i>
+  <ul>
+    <li><b>Read Only:</b> Gives Appsmith read-only permission on the database. This allows you to only fetch data from the database.</li>
+    <li><b>Read / Write:</b> Gives Appsmith both read and write permissions on the database. This allows you to execute all CRUD queries.</li>
+  </ul>
+</dd>
 
-  <dt><b>Port</b></dt>
-  <dd>The port number to connect to on the server. Appsmith connects to port <code>5439</code> by default if you do not specify one.</dd><br />
+#### Host Address
 
-  <dt><b>Database name</b></dt>
-  <dd>Name of the database you'd like to connect to.</dd><br />
+<dd>The network location of your Redshift database. This can be a domain name or an IP address.</dd>
 
-  <dt><b>Username</b></dt>
-  <dd>The username to use to authenticate your queries.</dd><br />
+#### Port
 
-  <dt><b>Password</b></dt>
-  <dd>The password to use to authenticate your queries.</dd><br />
-</dl>
+<dd>The port number to connect to on the server. Appsmith connects to port <code>5439</code> by default if you do not specify one.</dd>
+
+#### Database name
+
+<dd>Name of the database you'd like to connect to.</dd>
+
+#### Username
+
+<dd>The username to use to authenticate your queries.</dd>
+
+#### Password
+
+<dd>The password to use to authenticate your queries.</dd>
 
 ## Query Redshift
 

--- a/website/docs/connect-data/reference/querying-snowflake-db.md
+++ b/website/docs/connect-data/reference/querying-snowflake-db.md
@@ -19,35 +19,40 @@ The following section is a reference guide that provides a complete description 
   <figcaption align="center"><i>Configuring a Snowflake datasource.</i></figcaption>
 </figure>
 
-<dl>
-  <dt><b>Account Name</b></dt>
-  <dd>This field expects an identifier for your Snowflake account. This consists of your organization name and your account name separated by a hyphen: <code>orgName-accountName</code>. You can find your organization name and account name on the Snowflake dashboard at the bottom-left of the page; click the string next to the Snowflake logo to open an information box with your details.</dd><br />
+#### Account Name
 
-  <figure>
-    <img src="/img/snowflake-account-name.png" style={{width: "100%", height: "auto"}} alt="Find your account name on the Snowflake dashboard at the bottom-left of the page." />
-    <figcaption align="center"><i>Find your account name on the Snowflake dashboard at the bottom-left of the page.</i></figcaption>
-  </figure>
+<dd>This field expects an identifier for your Snowflake account. This consists of your organization name and your account name separated by a hyphen: <code>orgName-accountName</code>. You can find your organization name and account name on the Snowflake dashboard at the bottom-left of the page; click the string next to the Snowflake logo to open an information box with your details.</dd>
 
-  <dt><b>Warehouse</b></dt>
-  <dd>Specifies the virtual warehouse to use once connected.</dd><br />
+<figure>
+  <img src="/img/snowflake-account-name.png" style={{width: "100%", height: "auto"}} alt="Find your account name on the Snowflake dashboard at the bottom-left of the page." />
+  <figcaption align="center"><i>Find your account name on the Snowflake dashboard at the bottom-left of the page.</i></figcaption>
+</figure>
 
-  <dt><b>Database</b></dt>
-  <dd>Specifies the database to use once connected.</dd><br />
+#### Warehouse
 
-  <dt><b>Default Schema</b></dt>
-  <dd>Sets which database schema structure should appear as a preview in the Appsmith sidebar; when this is configured, you can see the tables and columns available under the specified schema. The field does not limit which schemas you are able to query.</dd><br />
-  
-  <dt><b>Role</b></dt>
-  <dd>The role to use for performing queries.</dd><br />
+<dd>Specifies the virtual warehouse to use once connected.</dd>
 
-  <dt><b>Username</b></dt>
-  <dd>The username for your Snowflake account.
-  </dd><br />
+#### Database
 
-  <dt><b>Password</b></dt>
-  <dd>The password for your Snowflake account.
-  </dd><br />
-</dl>
+<dd>Specifies the database to use once connected.</dd>
+
+#### Default Schema
+
+<dd>Sets which database schema structure should appear as a preview in the Appsmith sidebar; when this is configured, you can see the tables and columns available under the specified schema. The field does not limit which schemas you are able to query.</dd>
+
+#### Role
+
+<dd>The role to use for performing queries.</dd>
+
+#### Username
+
+<dd>The username for your Snowflake account.
+</dd>
+
+#### Password
+
+<dd>The password for your Snowflake account.
+</dd>
 
 ## Query Snowflake
 

--- a/website/docs/connect-data/reference/rest-api.md
+++ b/website/docs/connect-data/reference/rest-api.md
@@ -17,36 +17,32 @@ The following section is a reference guide that provides a description of the pa
   <figcaption align = "center"><i>Configuring a REST API query.</i></figcaption>
 </figure>
 
-<dl>  
-  <dt><b>Method</b></dt>
-  <dd>Sets the REST method (<code>GET</code>, <code>POST</code>, etc.) to use for the request.</dd>
-</dl>
+#### Method
 
-<dl>  
-  <dt><b>URL</b></dt>
-  <dd>Sets the endpoint to query.</dd>
-</dl>
+<dd>Sets the REST method (<code>GET</code>, <code>POST</code>, etc.) to use for the request.</dd>
 
-<dl>  
-  <dt><b>Headers</b></dt>
-  <dd>Sets key/value pairs to send in the request header.</dd>
-  <dd><em>To learn how to set up dynamic headers, visit and fork this <a href="https://app.appsmith.com/applications/6200ac292cd3d95ca414dc4f/pages/624eda0551a8863d6c406760">sample app</a></em>.</dd>
-</dl>
+#### URL
 
-<dl>
-  <dt><b>Params</b></dt>
-  <dd>Sets key/value pairs to send as query parameters in the request.</dd>
-</dl>
+<dd>Sets the endpoint to query.</dd>
 
-<dl>
-  <dt><b>Body</b></dt>
-  <dd>Appsmith supports a variety of encoding types for sending data in API queries. The encoding type can be selected via the Body dropdown on the API editor.<br/>
-  </dd>
-  <dd><i>Options:</i>
-    <ul>
-      <li><b>None:</b> Omits a body from the request.</li>
-      <li><b>JSON:</b> Expects a JSON object to send as the body.</li>
-    </ul>
+#### Headers
+
+<dd>Sets key/value pairs to send in the request header.</dd>
+<dd><em>To learn how to set up dynamic headers, visit and fork this <a href="https://app.appsmith.com/applications/6200ac292cd3d95ca414dc4f/pages/624eda0551a8863d6c406760">sample app</a></em>.</dd>
+
+#### Params
+
+<dd>Sets key/value pairs to send as query parameters in the request.</dd>
+
+#### Body
+
+<dd>Appsmith supports a variety of encoding types for sending data in API queries. The encoding type can be selected via the Body dropdown on the API editor.<br/>
+</dd>
+<dd><i>Options:</i>
+  <ul>
+    <li><b>None:</b> Omits a body from the request.</li>
+    <li><b>JSON:</b> Expects a JSON object to send as the body.</li>
+  </ul>
 
 <dd><pre>{` 
 {
@@ -103,24 +99,21 @@ Be sure to turn off **JSON Smart Substitution** for this query in the [query set
 :::
 </dd>
 
-  </dd>  
-</dl>
-
-<dl>
-  <dt><b>Pagination</b></dt>
-  <dd><i>Options:</i>
-    <ul>
-      <li><b>None:</b> Doesn't use any pagination.</li>
-      <li><b>Paginate with Table Page No:</b> Use when your API expects an offset or increment value to determine which set of records to return. Follow the instructions that appear on the platform, or see <a href="/reference/widgets/table?current-edition=Offset_edition#server-side-pagination">Offset-based pagination</a> for more information.</li>
-      <li><b>Paginate with Response URL:</b> Use when your API returns cursor values to page through data. The <b>Previous URL</b> and <b>Next URL</b> fields expect the cursor values from the query response. For more information, see <a href="/reference/widgets/table?current-edition=Cursor#server-side-pagination">Cursor-based pagination</a>.</li>
-    </ul>
   </dd>
-</dl>
 
-<dl>
-  <dt><b>Authentication</b></dt>
-  <dd><em>Click the button in this tab to turn this query into a new Authenticated API datasource where you can configure Authentication for your requests.</em></dd>
-</dl>
+#### Pagination
+
+<dd><i>Options:</i>
+  <ul>
+    <li><b>None:</b> Doesn't use any pagination.</li>
+    <li><b>Paginate with Table Page No:</b> Use when your API expects an offset or increment value to determine which set of records to return. Follow the instructions that appear on the platform, or see <a href="/reference/widgets/table?current-edition=Offset_edition#server-side-pagination">Offset-based pagination</a> for more information.</li>
+    <li><b>Paginate with Response URL:</b> Use when your API returns cursor values to page through data. The <b>Previous URL</b> and <b>Next URL</b> fields expect the cursor values from the query response. For more information, see <a href="/reference/widgets/table?current-edition=Cursor#server-side-pagination">Cursor-based pagination</a>.</li>
+  </ul>
+</dd>
+
+#### Authentication
+
+<dd><em>Click the button in this tab to turn this query into a new Authenticated API datasource where you can configure Authentication for your requests.</em></dd>
 
 ## Troubleshooting
 

--- a/website/docs/connect-data/reference/twilio.md
+++ b/website/docs/connect-data/reference/twilio.md
@@ -17,23 +17,23 @@ The following section is a reference guide that provides a complete description 
    <figcaption align = "center"><i>Configuring a Twilio datasource.</i></figcaption>
 </figure>
 
-<dl>
-  <dt><b>Authentication Type</b></dt>
-  <dd><i>Options:</i>
-    <ul>
-    <li><b>Basic auth:</b> Connect to Twilio using your <b>Account SID</b> and an <b>Auth token</b> issued by Twilio.</li>
-    </ul>
-  </dd><br />
+#### Authentication Type
 
-  <dt><b>Account SID</b></dt>
-  <dd>A unique ID string that identifies your Twilio account. You can find this on your <a href="https://console.twilio.com">Twilio Console</a> under the <b>Account Info</b> section. 
-  </dd><br />
+<dd><i>Options:</i>
+  <ul>
+  <li><b>Basic auth:</b> Connect to Twilio using your <b>Account SID</b> and an <b>Auth token</b> issued by Twilio.</li>
+  </ul>
+</dd>
 
-  <dt><b>Auth token</b></dt>
-  <dd>A token string used to authenticate your queries. You can find this on your <a href="https://console.twilio.com">Twilio Console</a> under the <b>Account Info</b> section. 
-  </dd>
+#### Account SID
 
-</dl>
+<dd>A unique ID string that identifies your Twilio account. You can find this on your <a href="https://console.twilio.com">Twilio Console</a> under the <b>Account Info</b> section. 
+</dd>
+
+#### Auth token
+
+<dd>A token string used to authenticate your queries. You can find this on your <a href="https://console.twilio.com">Twilio Console</a> under the <b>Account Info</b> section. 
+</dd>
 
 ## Query Twilio
 
@@ -48,57 +48,58 @@ The following section is a reference guide that provides a description of the av
 
 You can use this command to create and send a message to a specific phone number. The following section lists all the available parameters:
 
+#### Twilio account SID
 
+<dd>A unique ID string that identifies your Twilio account. You can find this on your <a href="https://console.twilio.com">Twilio Console</a> under the <b>Account Info</b> section. 
+</dd>
 
-<dl>
-  <dt><b>Twilio account SID</b></dt>
-  <dd>A unique ID string that identifies your Twilio account. You can find this on your <a href="https://console.twilio.com">Twilio Console</a> under the <b>Account Info</b> section. 
-  </dd><br />
+#### To
 
-  <dt><b>To</b></dt>
-  <dd>The phone number to which the message should be sent. Be sure to follow <a href="https://www.twilio.com/docs/glossary/what-e164">E.164 format</a>: <code>+15551234567</code>.
-  </dd><br />
+<dd>The phone number to which the message should be sent. Be sure to follow <a href="https://www.twilio.com/docs/glossary/what-e164">E.164 format</a>: <code>+15551234567</code>.
+</dd>
 
-  <dt><b>From</b></dt>
-  <dd>The Twilio phone number from which the message should be sent. Be sure to follow <a href="https://www.twilio.com/docs/glossary/what-e164">E.164 format</a>: <code>+15551234567</code>. Once you've created your Twilio phone number, you can find it in the Twilio console under the <b>Account Info</b> section.
-  </dd><br />
+#### From
+
+<dd>The Twilio phone number from which the message should be sent. Be sure to follow <a href="https://www.twilio.com/docs/glossary/what-e164">E.164 format</a>: <code>+15551234567</code>. Once you've created your Twilio phone number, you can find it in the Twilio console under the <b>Account Info</b> section.
+</dd>
 
 :::info
 To send a message to a WhatsApp phone number, see [Using Twilio Phone Numbers With WhatsApp](https://www.twilio.com/docs/whatsapp/api#using-twilio-phone-numbers-with-whatsapp).
 :::
 
-  <dt><b>Body</b></dt>
-  <dd>The text content of the message.
-  </dd>
+#### Body
 
-</dl>
+<dd>The text content of the message.
+</dd>
 
 ### Schedule message
 
 You can use this command to create and schedule a message for sending at a future date and time. The following section lists all the available parameters:
 
-<dl>
-  <dt><b>Twilio account SID</b></dt>
-  <dd>A unique ID string that identifies your Twilio account. You can find this on your <a href="https://console.twilio.com">Twilio Console</a> under the <b>Account Info</b> section. 
-  </dd><br />
+#### Twilio account SID
 
-  <dt><b>Messaging service SID</b></dt>
-  <dd>A unique ID string that identifies a messaging service that you create on your Twilio account. You can find or create the service in the Twilio Console under <b>Explore Products</b> &gt; <b>Messaging</b> &gt; <b>Services</b>.
-  </dd><br />
+<dd>A unique ID string that identifies your Twilio account. You can find this on your <a href="https://console.twilio.com">Twilio Console</a> under the <b>Account Info</b> section. 
+</dd>
 
-  <dt><b>To</b></dt>
-  <dd>The phone number to which the message should be sent. Be sure to follow <a href="https://www.twilio.com/docs/glossary/what-e164">E.164 format</a>: <code>+15551234567</code>.
-  </dd><br />
+#### Messaging service SID
 
-  <dt><b>Body</b></dt>
-  <dd>The text content of the message.
-  </dd><br />
+<dd>A unique ID string that identifies a messaging service that you create on your Twilio account. You can find or create the service in the Twilio Console under <b>Explore Products</b> &gt; <b>Messaging</b> &gt; <b>Services</b>.
+</dd>
 
-  <dt><b>Send at</b></dt>
-  <dd>A string that defines the date and time to send the message. The given date must be between 15 minutes and 7 days from the time of the request and must be in UTC format <code>YYYY-MM-DDTHH:MM:SSZ</code>.
-  </dd>
+#### To
 
-</dl>
+<dd>The phone number to which the message should be sent. Be sure to follow <a href="https://www.twilio.com/docs/glossary/what-e164">E.164 format</a>: <code>+15551234567</code>.
+</dd>
+
+#### Body
+
+<dd>The text content of the message.
+</dd>
+
+#### Send at
+
+<dd>A string that defines the date and time to send the message. The given date must be between 15 minutes and 7 days from the time of the request and must be in UTC format <code>YYYY-MM-DDTHH:MM:SSZ</code>.
+</dd>
 
 ### List message
 
@@ -108,75 +109,72 @@ You can use this command to fetch a list of past messages sent from a specified 
 To fetch scheduled messages that haven't been sent, leave the <b>To</b>, <b>From</b>, and <b>Date Sent</b> fields empty.
 :::
 
-<dl>
-  <dt><b>To</b></dt>
-  <dd>The phone number to which the message was sent. Be sure to follow <a href="https://www.twilio.com/docs/glossary/what-e164">E.164 format</a>: <code>+15551234567</code>.
-  </dd><br />
+#### To
 
-  <dt><b>From</b></dt>
-  <dd>The Twilio phone number from which the message was sent. Be sure to follow <a href="https://www.twilio.com/docs/glossary/what-e164">E.164 format</a>: <code>+15551234567</code>. Once you've created your Twilio phone number, you can find it in the Twilio console under the <b>Account Info</b> section.
-  </dd><br />
+<dd>The phone number to which the message was sent. Be sure to follow <a href="https://www.twilio.com/docs/glossary/what-e164">E.164 format</a>: <code>+15551234567</code>.
+</dd>
 
-  <dt><b>Date Sent</b></dt>
-  <dd>A string that defines which date to fetch records from. Must be in the format <code>YYYY-MM-DD</code>.
-  </dd><br />
+#### From
 
-  <dt><b>Page size</b></dt>
-  <dd>The maximum number of records to fetch in your query.
-  </dd><br />
+<dd>The Twilio phone number from which the message was sent. Be sure to follow <a href="https://www.twilio.com/docs/glossary/what-e164">E.164 format</a>: <code>+15551234567</code>. Once you've created your Twilio phone number, you can find it in the Twilio console under the <b>Account Info</b> section.
+</dd>
 
-  <dt><b>Twilio account SID</b></dt>
-  <dd>A unique ID string that identifies your Twilio account. You can find this on your <a href="https://console.twilio.com">Twilio Console</a> under the <b>Account Info</b> section. 
-  </dd>
+#### Date Sent
 
-</dl>
+<dd>A string that defines which date to fetch records from. Must be in the format <code>YYYY-MM-DD</code>.
+</dd>
 
+#### Page size
 
+<dd>The maximum number of records to fetch in your query.
+</dd>
+
+#### Twilio account SID
+
+<dd>A unique ID string that identifies your Twilio account. You can find this on your <a href="https://console.twilio.com">Twilio Console</a> under the <b>Account Info</b> section. 
+</dd>
 
 ### Fetch message
 
 You can use this command to fetch the body and send status of a specific message. The following section lists all the available parameters:
 
-<dl>
-  <dt><b>Twilio account SID</b></dt>
-  <dd>A unique ID string that identifies your Twilio account. You can find this on your <a href="https://console.twilio.com">Twilio Console</a> under the <b>Account Info</b> section. 
-  </dd><br />
+#### Twilio account SID
 
-  <dt><b>Message SID</b></dt>
-  <dd>A unique ID string that identifies the message. You can get the <b>Message SID</b> from a <a href="#list-message">List message</a> query on the <code>sid</code> property, or when you create a new message with a <a href="#create-message">Create message</a> query.
-  </dd>
+<dd>A unique ID string that identifies your Twilio account. You can find this on your <a href="https://console.twilio.com">Twilio Console</a> under the <b>Account Info</b> section. 
+</dd>
 
-</dl>
+#### Message SID
+
+<dd>A unique ID string that identifies the message. You can get the <b>Message SID</b> from a <a href="#list-message">List message</a> query on the <code>sid</code> property, or when you create a new message with a <a href="#create-message">Create message</a> query.
+</dd>
 
 ### Delete message
 
 You can use this command to delete a specific message. The following section lists all the available parameters:
 
-<dl>
-  <dt><b>Twilio account SID</b></dt>
-  <dd>A unique ID string that identifies your Twilio account. You can find this on your <a href="https://console.twilio.com">Twilio Console</a> under the <b>Account Info</b> section. 
-  </dd><br />
+#### Twilio account SID
 
-  <dt><b>Message SID</b></dt>
-  <dd>A unique ID string that identifies the message. You can get the <b>Message SID</b> from a <a href="#list-message">List message</a> query on the <code>sid</code> property, or when you create a new message with a <a href="#create-message">Create message</a> query.
-  </dd>
+<dd>A unique ID string that identifies your Twilio account. You can find this on your <a href="https://console.twilio.com">Twilio Console</a> under the <b>Account Info</b> section. 
+</dd>
 
-</dl>
+#### Message SID
+
+<dd>A unique ID string that identifies the message. You can get the <b>Message SID</b> from a <a href="#list-message">List message</a> query on the <code>sid</code> property, or when you create a new message with a <a href="#create-message">Create message</a> query.
+</dd>
 
 ### Cancel message
 
 You can use this command to cancel sending a specific scheduled message. The following section lists all the available parameters:
 
-<dl>
-  <dt><b>Twilio account SID</b></dt>
-  <dd>A unique ID string that identifies your Twilio account. You can find this on your <a href="https://console.twilio.com">Twilio Console</a> under the <b>Account Info</b> section. 
-  </dd><br />
+#### Twilio account SID
 
-  <dt><b>Message SID</b></dt>
-  <dd>A unique ID string that identifies the message. You can get the <b>Message SID</b> from a <a href="#list-message">List message</a> query on the <code>sid</code> property, or when you create a new message with a <a href="#create-message">Create message</a> query.
-  </dd>
+<dd>A unique ID string that identifies your Twilio account. You can find this on your <a href="https://console.twilio.com">Twilio Console</a> under the <b>Account Info</b> section. 
+</dd>
 
-</dl>
+#### Message SID
+
+<dd>A unique ID string that identifies the message. You can get the <b>Message SID</b> from a <a href="#list-message">List message</a> query on the <code>sid</code> property, or when you create a new message with a <a href="#create-message">Create message</a> query.
+</dd>
 
 ## Troubleshooting
 

--- a/website/docs/connect-data/reference/using-smtp.md
+++ b/website/docs/connect-data/reference/using-smtp.md
@@ -15,37 +15,37 @@ The following section is a reference guide that provides a complete description 
   <figcaption align = "center"><i>Configuring an SMTP datasource</i></figcaption>
 </figure>
 
-<dl>
-  <dt><b>Host Address</b></dt>
-  <dd>
-  
+#### Host Address
+
+<dd>
+
 The network location of your SMTP provider. This can be a domain name or an IP address.
 
-  </dd><br/>
+</dd>
 
-  <dt><b>Port</b></dt>
-  <dd>
-  
+#### Port
+
+<dd>
+
 The port number to connect to on the server.
 
-  </dd><br/>
+</dd>
 
-  <dt><b>Username</b></dt>
-  <dd>
-  
+#### Username
+
+<dd>
+
 The username for your email user.
 
-  </dd><br/>
+</dd>
 
-  <dt><b>Password</b></dt>
-  <dd>
-  
+#### Password
+
+<dd>
+
 The password for your email user's account.
 
-  </dd><br/>
-
-
-</dl>
+</dd>
 
 :::note
 Some SMTP providers use a multi-factor authentication flow and may require you to generate a special password specifically to authenticate your Appsmith app. For example, Gmail SMTP requires you to generate an app password to use instead of your usual password. For more details, see [Sign in with app passwords](https://support.google.com/mail/answer/185833?hl=en).
@@ -64,71 +64,77 @@ The following section is a reference guide that provides a complete description 
 
 This action sends an email through your SMTP server.
 
-<dl>
-  <dt><b>From email</b></dt>
-  <dd>
-  
+#### From email
+
+<dd>
+
 Sets the email address that appears as the message sender.
 
-  </dd><br/>
+</dd>
 
-  <dt><b>Set Reply To Email</b></dt>
-  <dd>
+#### Set Reply To Email
+
+<dd>
 
 Toggles the **Reply to email** field.
 
-  </dd>
+</dd>
 
-  <dt><b>Reply to email</b></dt>
-  <dd>
-  
+#### Reply to email
+
+<dd>
+
 Sets an email address that receives all replies to your email.
 
-  </dd><br/>
+</dd>
 
-  <dt><b>To email(s)</b></dt>
-  <dd>
-  
+#### To email(s)
+
+<dd>
+
 Sets the email addresses that receive your email. For multiple recipients, separate the addresses with commas.
 
-  </dd><br/>
+</dd>
 
-  <dt><b>CC email(s)</b></dt>
-  <dd>
-  
+#### CC email(s)
+
+<dd>
+
 Sets the email addresses that receive a CC (carbon copy). For multiple CC recipients, separate the addresses with commas.
 
-  </dd><br/>
+</dd>
 
-  <dt><b>BCC email(s)</b></dt>
-  <dd>
-  
+#### BCC email(s)
+
+<dd>
+
 Sets the email addresses that receive a BCC (blind carbon copy). For multiple BCC recipients, separate the addresses with commas.
 
-  </dd><br/>
+</dd>
 
-  <dt><b>Subject</b></dt>
-  <dd>
-  
+#### Subject
+
+<dd>
+
 Sets the email's subject line.
 
-  </dd><br/>
+</dd>
 
-  <dt><b>Body</b></dt>
-  <dd>
-  
+#### Body
+
+<dd>
+
 Sets the main body of the email. Supports rich text and HTML.
 
-  </dd><br/>
+</dd>
 
-  <dt><b>Attachment(s)</b></dt>
-  <dd>
-  
+#### Attachment(s)
+
+<dd>
+
 Attaches one or more files to the email. Expects an array of file objects.
 
-  </dd>
-
-</dl>
+</dd>
 
 ## Troubleshooting
 


### PR DESCRIPTION
Changes properties entries in datasource pages from <b> tags into h4 so that they are linkable.

Resolves #1620 

## Checklist
I have:
- [ ] run the content through Grammarly
- [ ] linked to sample apps when relevant
- [ ] added the meta description for each page in the PR
- [ ] minimized the callouts and added only when necessary
- [ ] added the `queryString` parameter to the Tabs (if used)
- [ ] masked PII in images. For example, login credentials, account details, and more
- [ ] added images only when necessary
- [ ] deleted the images that are no longer used for the updated pages in the PR
- [ ] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [ ] used the `<figure/>` tag instead of a markdown representation for images
- [ ] added the `<figcaption/>` tag to add a caption to the image
- [ ] added the `alt` attribute in the `<img/>` tag
- [ ] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [ ] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.