### PR TITLE
fix: Widget landing page categorisation

### DIFF
--- a/website/docs/reference/widgets/README.md
+++ b/website/docs/reference/widgets/README.md
@@ -2,6 +2,105 @@
 
 Appsmith offers a powerful set of widgets to help you build dynamic and functional app layouts. You can simply drag and drop them onto the canvas and edit the properties of each widget to customize its data, style, and actions.
 
+### Suggested
+
+<div class="containerGrid">
+  <div class="columnGrid column-one" align="center">
+        <div class="containerCol">
+            <a href="/reference/widgets/Table">
+            <img class="containerImage" src="/img/table-icon.svg" alt="Table"/>
+            </a>     
+        </div> 
+         <b><a href="/reference/widgets/Table">Table</a></b>
+    </div>
+    <div class="columnGrid column-two" align="center">
+      <div class="containerCol">
+            <a href="/reference/widgets/json-form">
+            <img class="containerImage" src="/img/json-form-icon.svg" alt="JSON-form"/>
+            </a>   
+        </div> 
+            <b><a href="/reference/widgets/json-form">JSON form</a></b>
+     </div>
+     <div class="columnGrid column-three" align="center">
+        <div class="containerCol">
+            <a href="/reference/widgets/input">
+            <img class="containerImage" src="/img/input-icon.svg" alt="Input"/>
+            </a> 
+        </div> 
+        <b><a href="//reference/widgets/input">Input</a></b>
+    </div>
+
+
+</div>
+
+<div class="containerGrid">
+    <div class="columnGrid column-one" align="center">
+        <div class="containerCol">
+            <a href="/reference/widgets/Text">
+            <img class="containerImage" src="/img/text-icon.svg" alt="Text"/>
+            </a>     
+        </div> 
+         <b><a href="/reference/widgets/Text">Text</a></b>
+    </div>
+     <div class="columnGrid column-two" align="center">
+        <div class="containerCol">
+            <a href="/reference/widgets/select">
+            <img class="containerImage" src="/img/select-icon-.svg" alt="Select"/>
+            </a> 
+        </div> 
+        <b><a href="//reference/widgets/select">Select</a></b>
+     </div>
+    <div class="columnGrid column-three" align="center">
+        <div class="containerCol">
+            <a href="/reference/widgets/list">
+            <img class="containerImage" src="/img/list-icon.svg" alt="List"/>
+            </a>   
+        </div> 
+            <b><a href="/reference/widgets/list">List</a></b>
+   
+   </div>
+
+
+</div>
+
+### Inputs
+
+<div class="containerGrid">
+    <div class="columnGrid column-one" align="center">
+        <div class="containerCol">
+            <a href="/reference/widgets/Text">
+            <img class="containerImage" src="/img/text-icon.svg" alt="Text"/>
+            </a>     
+        </div> 
+         <b><a href="/reference/widgets/Text">Text</a></b>
+    </div>
+     <div class="columnGrid column-two" align="center">
+        <div class="containerCol">
+            <a href="/reference/widgets/select">
+            <img class="containerImage" src="/img/select-icon-.svg" alt="Select"/>
+            </a> 
+        </div> 
+        <b><a href="//reference/widgets/select">Select</a></b>
+     </div>
+    <div class="columnGrid column-three" align="center">
+        <div class="containerCol">
+            <a href="/reference/widgets/list">
+            <img class="containerImage" src="/img/list-icon.svg" alt="List"/>
+            </a>   
+        </div> 
+            <b><a href="/reference/widgets/list">List</a></b>
+   
+   </div>
+
+
+</div>
+
+
+----
+
+
+
+
 
 <div class="containerGrid">
     <div class="columnGrid column-one" align="center">
@@ -116,15 +215,6 @@ Appsmith offers a powerful set of widgets to help you build dynamic and function
             <b><a href="/reference/widgets/container">Container</a></b>
    
    </div>
-   <div class="columnGrid column-three" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/currency-input">
-            <img class="containerImage" src="/img/c-input.svg" alt="Currency-Input"/>
-            </a>   
-        </div> 
-            <b><a href="/reference/widgets/currency-input">Currency Input</a></b>
-   
-   </div>
 
 </div>
 
@@ -214,32 +304,7 @@ Appsmith offers a powerful set of widgets to help you build dynamic and function
 
 
 <div class="containerGrid">
-    <div class="columnGrid column-one" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/input">
-            <img class="containerImage" src="/img/input-icon.svg" alt="Input"/>
-            </a> 
-        </div> 
-        <b><a href="//reference/widgets/input">Input</a></b>
-    </div>
-   <div class="columnGrid column-two" align="center">
-      <div class="containerCol">
-            <a href="/reference/widgets/json-form">
-            <img class="containerImage" src="/img/json-form-icon.svg" alt="JSON-form"/>
-            </a>   
-        </div> 
-            <b><a href="/reference/widgets/json-form">JSON form</a></b>
-   </div>
 
-   <div class="columnGrid column-three" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/list">
-            <img class="containerImage" src="/img/list-icon.svg" alt="List"/>
-            </a>   
-        </div> 
-            <b><a href="/reference/widgets/list">List</a></b>
-   
-   </div>
    <div class="columnGrid column-three" align="center">
         <div class="containerCol">
             <a href="/reference/widgets/maps">
@@ -381,14 +446,6 @@ Appsmith offers a powerful set of widgets to help you build dynamic and function
 
 
 <div class="containerGrid">
-    <div class="columnGrid column-one" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/select">
-            <img class="containerImage" src="/img/select-icon-.svg" alt="Select"/>
-            </a> 
-        </div> 
-        <b><a href="//reference/widgets/select">Select</a></b>
-    </div>
    <div class="columnGrid column-two" align="center">
         <div class="containerCol">
             <a href="/reference/widgets/switch">
@@ -425,14 +482,6 @@ Appsmith offers a powerful set of widgets to help you build dynamic and function
 
 
 <div class="containerGrid">
-   <div class="columnGrid column-two" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/Table">
-            <img class="containerImage" src="/img/table-icon.svg" alt="Table"/>
-            </a>     
-        </div> 
-         <b><a href="/reference/widgets/Table">Table</a></b>
-    </div>
     <div class="columnGrid column-two" align="center">
         <div class="containerCol">
             <a href="/reference/widgets/tabs">
@@ -440,14 +489,6 @@ Appsmith offers a powerful set of widgets to help you build dynamic and function
             </a>     
         </div> 
          <b><a href="/reference/widgets/tabs">Tabs</a></b>
-    </div>
-    <div class="columnGrid column-two" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/Text">
-            <img class="containerImage" src="/img/text-icon.svg" alt="Text"/>
-            </a>     
-        </div> 
-         <b><a href="/reference/widgets/Text">Text</a></b>
     </div>
     <div class="columnGrid column-two" align="center">
         <div class="containerCol">

--- a/website/docs/reference/widgets/README.md
+++ b/website/docs/reference/widgets/README.md
@@ -2,227 +2,19 @@
 
 Appsmith offers a powerful set of widgets to help you build dynamic and functional app layouts. You can simply drag and drop them onto the canvas and edit the properties of each widget to customize its data, style, and actions.
 
-### Suggested
-
-<div class="containerGrid">
-  <div class="columnGrid column-one" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/Table">
-            <img class="containerImage" src="/img/table-icon.svg" alt="Table"/>
-            </a>     
-        </div> 
-         <b><a href="/reference/widgets/Table">Table</a></b>
-    </div>
-    <div class="columnGrid column-two" align="center">
-      <div class="containerCol">
-            <a href="/reference/widgets/json-form">
-            <img class="containerImage" src="/img/json-form-icon.svg" alt="JSON-form"/>
-            </a>   
-        </div> 
-            <b><a href="/reference/widgets/json-form">JSON form</a></b>
-     </div>
-     <div class="columnGrid column-three" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/input">
-            <img class="containerImage" src="/img/input-icon.svg" alt="Input"/>
-            </a> 
-        </div> 
-        <b><a href="//reference/widgets/input">Input</a></b>
-    </div>
-
-
-</div>
-
-<div class="containerGrid">
-    <div class="columnGrid column-one" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/Text">
-            <img class="containerImage" src="/img/text-icon.svg" alt="Text"/>
-            </a>     
-        </div> 
-         <b><a href="/reference/widgets/Text">Text</a></b>
-    </div>
-     <div class="columnGrid column-two" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/select">
-            <img class="containerImage" src="/img/select-icon-.svg" alt="Select"/>
-            </a> 
-        </div> 
-        <b><a href="//reference/widgets/select">Select</a></b>
-     </div>
-    <div class="columnGrid column-three" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/list">
-            <img class="containerImage" src="/img/list-icon.svg" alt="List"/>
-            </a>   
-        </div> 
-            <b><a href="/reference/widgets/list">List</a></b>
-   
-   </div>
-
-
-</div>
 
 ### Inputs
 
 <div class="containerGrid">
     <div class="columnGrid column-one" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/Text">
-            <img class="containerImage" src="/img/text-icon.svg" alt="Text"/>
-            </a>     
+           <div class="containerCol">
+            <a href="/reference/widgets/currency-input">
+            <img class="containerImage" src="/img/c-input.svg" alt="Currency-Input"/>
+            </a>   
         </div> 
-         <b><a href="/reference/widgets/Text">Text</a></b>
-    </div>
+            <b><a href="/reference/widgets/currency-input">Currency Input</a></b>
+   </div>
      <div class="columnGrid column-two" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/select">
-            <img class="containerImage" src="/img/select-icon-.svg" alt="Select"/>
-            </a> 
-        </div> 
-        <b><a href="//reference/widgets/select">Select</a></b>
-     </div>
-    <div class="columnGrid column-three" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/list">
-            <img class="containerImage" src="/img/list-icon.svg" alt="List"/>
-            </a>   
-        </div> 
-            <b><a href="/reference/widgets/list">List</a></b>
-   
-   </div>
-
-
-</div>
-
-
-----
-
-
-
-
-
-<div class="containerGrid">
-    <div class="columnGrid column-one" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/audio">
-            <img class="containerImage" src="/img/audio-icon.svg" alt="Audio"/>
-            </a> 
-        </div> 
-        <b><a href="/reference/widgets/audio">Audio</a></b>
-    </div>
-   <div class="columnGrid column-two" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/audio-recorder">
-            <img class="containerImage" src="/img/ar-icon.svg" alt="Audio-Recorder"/>
-            </a>     
-        </div> 
-         <b><a href="/reference/widgets/audio-recorder">Audio Recorder</a></b>
-    </div>
-
-   <div class="columnGrid column-three" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/button-group">
-            <img class="containerImage" src="/img/btn-gro.svg" alt="button-group"/>
-            </a>     
-        </div> 
-         <b><a href="/reference/widgets/button-group">Button Group</a></b>
-    </div>
-      <div class="columnGrid column-two" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/button">
-            <img class="containerImage" src="/img/button-icon.svg" alt="Button"/>
-            </a>     
-        </div> 
-         <b><a href="/reference/widgets/button">Button</a></b>
-    </div>
-
-</div>
-
-
-
-
-
-<div class="containerGrid">
-     <div class="columnGrid column-one" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/camera">
-            <img class="containerImage" src="/img/cam-icon.svg" alt="Camera"/>
-            </a>   
-        </div> 
-            <b><a href="/reference/widgets/camera">Camera</a></b>
-   
-   </div>
-   <div class="columnGrid column-three" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/category-slider">
-            <img class="containerImage" src="/img/cat-icon.svg" alt="Category-Slider"/>
-            </a>   
-        </div> 
-            <b><a href="/reference/widgets/category-slider">Category Slider</a></b>
-   
-   </div>
-
-   <div class="columnGrid column-three" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/chart">
-            <img class="containerImage" src="/img/chart-icon.svg" alt="Chart"/>
-            </a>   
-        </div> 
-            <b><a href="/reference/widgets/chart">Chart</a></b>
-   
-   </div>
-   <div class="columnGrid column-three" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/checkbox">
-            <img class="containerImage" src="/img/checkbox-icon.svg" alt="Checkbox"/>
-            </a>   
-        </div> 
-            <b><a href="/reference/widgets/checkbox">Checkbox</a></b>
-   
-   </div>
-
-</div>
-
-
-
-<div class="containerGrid">
-     <div class="columnGrid column-one" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/checkbox-group">
-            <img class="containerImage" src="/img/check-grp.svg" alt="Checkbox-Group"/>
-            </a>   
-        </div> 
-            <b><a href="/reference/widgets/checkbox-group">Checkbox Group</a></b>
-   
-   </div>
-<div class="columnGrid column-three" align="center">
-    <div class="containerCol">
-        <a href="/reference/widgets/code-scanner">
-            <img class="containerImage" src="/img/code-scan.svg" alt="Code-Scanner"/>
-        </a>   
-    </div> 
-    <b><a href="/reference/widgets/code-scanner">Code Scanner</a></b>
-   
-</div>
-
-   <div class="columnGrid column-three" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/container">
-            <img class="containerImage" src="/img/con-icon.svg" alt="Container"/>
-            </a>   
-        </div> 
-            <b><a href="/reference/widgets/container">Container</a></b>
-   
-   </div>
-
-</div>
-
-
-
-
-<div class="containerGrid">
-    <div class="columnGrid column-one" align="center">
         <div class="containerCol">
             <a href="/reference/widgets/datepicker">
             <img class="containerImage" src="/img/date-pick.svg" alt="Datepicker"/>
@@ -230,25 +22,7 @@ Appsmith offers a powerful set of widgets to help you build dynamic and function
         </div> 
         <b><a href="//reference/widgets/datepicker">Datepicker</a></b>
     </div>
-   <div class="columnGrid column-two" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/divider">
-            <img class="containerImage" src="/img/div-icon.svg" alt="Divider"/>
-            </a>     
-        </div> 
-         <b><a href="/reference/widgets/divider">Divider</a></b>
-    </div>
-
-   <div class="columnGrid column-three" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/document-viewer">
-            <img class="containerImage" src="/img/doc-view.svg" alt="Document-Viewer"/>
-            </a>   
-        </div> 
-            <b><a href="/reference/widgets/document-viewer">Document Viewer</a></b>
-   
-   </div>
-   <div class="columnGrid column-three" align="center">
+    <div class="columnGrid column-three" align="center">
         <div class="containerCol">
             <a href="/reference/widgets/filepicker">
             <img class="containerImage" src="/img/file-pick.svg" alt="Filepicker"/>
@@ -258,20 +32,62 @@ Appsmith offers a powerful set of widgets to help you build dynamic and function
    
    </div>
 
-</div>
 
+</div>
 
 
 <div class="containerGrid">
     <div class="columnGrid column-one" align="center">
         <div class="containerCol">
-            <a href="/reference/widgets/form">
-            <img class="containerImage" src="/img/form-icon.svg" alt="Form"/>
+            <a href="/reference/widgets/input">
+            <img class="containerImage" src="/img/input-icon.svg" alt="Input"/>
             </a> 
         </div> 
-        <b><a href="//reference/widgets/form">Form</a></b>
+        <b><a href="/reference/widgets/input">Input</a></b>
     </div>
+     <div class="columnGrid column-two" align="center">
+        <div class="containerCol">
+            <a href="/reference/widgets/phone-input">
+            <img class="containerImage" src="/img/p-input.svg" alt="Phone-input"/>
+            </a>   
+        </div> 
+            <b><a href="/reference/widgets/phone-input">Phone Input</a></b>
+   
+   </div>
+    <div class="columnGrid column-three" align="center">
+        <div class="containerCol">
+            <a href="/reference/widgets/rich-text-editor">
+            <img class="containerImage" src="/img/r-text.svg" alt="Rich-Text"/>
+            </a>   
+        </div> 
+            <b><a href="/reference/widgets/rich-text-editor">Rich Text Editor</a></b>
+   
+   </div>
+
+</div>
+
+
+### Buttons
+
+<div class="containerGrid">
+   
    <div class="columnGrid column-two" align="center">
+        <div class="containerCol">
+            <a href="/reference/widgets/button-group">
+            <img class="containerImage" src="/img/btn-gro.svg" alt="button-group"/>
+            </a>     
+        </div> 
+         <b><a href="/reference/widgets/button-group">Button Group</a></b>
+    </div>
+      <div class="columnGrid column-one" align="center">
+        <div class="containerCol">
+            <a href="/reference/widgets/button">
+            <img class="containerImage" src="/img/button-icon.svg" alt="Button"/>
+            </a>     
+        </div> 
+         <b><a href="/reference/widgets/button">Button</a></b>
+    </div>
+   <div class="columnGrid column-three" align="center">
       <div class="containerCol">
             <a href="/reference/widgets/icon-button">
             <img class="containerImage" src="/img/icon-button.svg" alt="Icon-Button"/>
@@ -280,13 +96,213 @@ Appsmith offers a powerful set of widgets to help you build dynamic and function
             <b><a href="/reference/widgets/icon-button">Icon Button</a></b>
    </div>
 
-   <div class="columnGrid column-three" align="center">
+
+
+</div>
+
+<div class="containerGrid">
+
+   <div class="columnGrid column-one" align="center">
+         <div class="containerCol">
+            <a href="/reference/widgets/menu">
+            <img class="containerImage" src="/img/menu-btn.svg" alt="Menu"/>
+            </a>   
+        </div> 
+            <b><a href="/reference/widgets/menu">Menu Button</a></b>
+   </div>
+   <div class="columnGrid column-two" align="center">
+    </div>
+    <div class="columnGrid column-three" align="center">
+    </div>
+
+</div>
+
+### Select
+
+<div class="containerGrid">
+        <div class="columnGrid column-two" align="center">
+        <div class="containerCol">
+            <a href="/reference/widgets/multiselect">
+            <img class="containerImage" src="/img/multi-select.svg" alt="multi-select"/>
+            </a> 
+        </div> 
+        <b><a href="//reference/widgets/multiselect">Multi Select</a></b>
+    </div>
+      <div class="columnGrid column-one" align="center">
+        <div class="containerCol">
+            <a href="/reference/widgets/multi-tree-select">
+            <img class="containerImage" src="/img/multi-tree.svg" alt="multi-tree"/>
+            </a>   
+        </div> 
+            <b><a href="/reference/widgets/multi-tree-select">Multi-Treeselect</a></b>
+   
+   </div>
+     <div class="columnGrid column-three" align="center">
+        <div class="containerCol">
+            <a href="/reference/widgets/select">
+            <img class="containerImage" src="/img/select-icon-.svg" alt="Select"/>
+            </a> 
+        </div> 
+        <b><a href="/reference/widgets/select">Select</a></b>
+     </div>
+
+</div>
+
+<div class="containerGrid">
+
+   <div class="columnGrid column-one" align="center">
+            <div class="containerCol">
+            <a href="/reference/widgets/tree-select">
+            <img class="containerImage" src="/img/tree-select.svg" alt="Treeselect"/>
+            </a>     
+        </div> 
+         <b><a href="/reference/widgets/tree-select">Treeselect</a></b>
+   </div>
+   <div class="columnGrid column-two" align="center">
+    </div>
+    <div class="columnGrid column-three" align="center">
+    </div>
+
+</div>
+
+###  Display 
+
+<div class="containerGrid">
+   <div class="columnGrid column-one" align="center">
+        <div class="containerCol">
+            <a href="/reference/widgets/chart">
+            <img class="containerImage" src="/img/chart-icon.svg" alt="Chart"/>
+            </a>   
+        </div> 
+            <b><a href="/reference/widgets/chart">Chart</a></b>
+   
+   </div>
+   <div class="columnGrid column-two" align="center">
         <div class="containerCol">
             <a href="/reference/widgets/iframe">
             <img class="containerImage" src="/img/iframe-icon.svg" alt="Iframe"/>
             </a>   
         </div> 
             <b><a href="/reference/widgets/iframe">Iframe</a></b>
+   
+   </div>
+    <div class="columnGrid column-three" align="center">
+        <div class="containerCol">
+            <a href="/reference/widgets/list">
+            <img class="containerImage" src="/img/list-icon.svg" alt="List"/>
+            </a>   
+        </div> 
+            <b><a href="/reference/widgets/list">List</a></b>
+   
+   </div>
+   </div>
+   
+   <div class="containerGrid">
+    <div class="columnGrid column-one" align="center">
+        <div class="containerCol">
+            <a href="/reference/widgets/map-chart">
+            <img class="containerImage" src="/img/mapchart.svg" alt="Map-Chart"/>
+            </a> 
+        </div> 
+        <b><a href="/reference/widgets/map-chart">Map Chart</a></b>
+    </div>
+   <div class="columnGrid column-two" align="center">
+        <div class="containerCol">
+            <a href="/reference/widgets/stat-box">
+            <img class="containerImage" src="/img/stats-logo.svg" alt="Stats-Box"/>
+            </a>   
+        </div> 
+            <b><a href="/reference/widgets/stat-box">Stats Box</a></b>
+   
+   </div>
+  <div class="columnGrid column-three" align="center">
+        <div class="containerCol">
+            <a href="/reference/widgets/Table">
+            <img class="containerImage" src="/img/table-icon.svg" alt="Table"/>
+            </a>     
+        </div> 
+         <b><a href="/reference/widgets/Table">Table</a></b>
+    </div>
+   </div>
+
+
+###  Layout 
+
+<div class="containerGrid">
+   <div class="columnGrid column-one" align="center">
+        <div class="containerCol">
+            <a href="/reference/widgets/container">
+            <img class="containerImage" src="/img/con-icon.svg" alt="Container"/>
+            </a>   
+        </div> 
+            <b><a href="/reference/widgets/container">Container</a></b>
+   
+   </div>
+   <div class="columnGrid column-two" align="center">
+        <div class="containerCol">
+            <a href="/reference/widgets/divider">
+            <img class="containerImage" src="/img/div-icon.svg" alt="Divider"/>
+            </a>     
+        </div> 
+         <b><a href="/reference/widgets/divider">Divider</a></b>
+    </div>
+      <div class="columnGrid column-three" align="center">
+        <div class="containerCol">
+            <a href="/reference/widgets/form">
+            <img class="containerImage" src="/img/form-icon.svg" alt="Form"/>
+            </a> 
+        </div> 
+        <b><a href="//reference/widgets/form">Form</a></b>
+    </div>
+   </div>
+
+   <div class="containerGrid">
+    <div class="columnGrid column-one" align="center">
+             <div class="containerCol">
+            <a href="/reference/widgets/json-form">
+            <img class="containerImage" src="/img/json-form-icon.svg" alt="JSON-form"/>
+            </a>   
+        </div> 
+            <b><a href="/reference/widgets/json-form">JSON form</a></b>
+     </div>
+
+   <div class="columnGrid column-two" align="center">
+        <div class="containerCol">
+            <a href="/reference/widgets/modal">
+            <img class="containerImage" src="/img/modal-icon.svg" alt="Modal"/>
+            </a>   
+        </div> 
+            <b><a href="/reference/widgets/modal">Modal</a></b>
+   
+   </div>
+    <div class="columnGrid column-three" align="center">
+        <div class="containerCol">
+            <a href="/reference/widgets/tabs">
+            <img class="containerImage" src="/img/tabs-icon.svg" alt="Tabs"/>
+            </a>     
+        </div> 
+         <b><a href="/reference/widgets/tabs">Tabs</a></b>
+    </div>
+   </div>
+
+### Media
+
+<div class="containerGrid">
+        <div class="columnGrid column-one" align="center">
+        <div class="containerCol">
+            <a href="/reference/widgets/audio">
+            <img class="containerImage" src="/img/audio-icon.svg" alt="Audio"/>
+            </a> 
+        </div> 
+        <b><a href="/reference/widgets/audio">Audio</a></b>
+    </div>
+        <div class="columnGrid column-three" align="center">
+        <div class="containerCol">
+            <a href="/reference/widgets/document-viewer">
+            <img class="containerImage" src="/img/doc-view.svg" alt="Document-Viewer"/>
+            </a>   
+        </div> 
+            <b><a href="/reference/widgets/document-viewer">Document Viewer</a></b>
    
    </div>
    <div class="columnGrid column-three" align="center">
@@ -301,76 +317,93 @@ Appsmith offers a powerful set of widgets to help you build dynamic and function
 
 </div>
 
-
-
 <div class="containerGrid">
 
-   <div class="columnGrid column-three" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/maps">
-            <img class="containerImage" src="/img/map-icon.svg" alt="Map"/>
+   <div class="columnGrid column-one" align="center">
+           <div class="containerCol">
+            <a href="/reference/widgets/video">
+            <img class="containerImage" src="/img/video-icon.svg" alt="Video"/>
             </a>   
         </div> 
-            <b><a href="/reference/widgets/maps">Map</a></b>
-   
+            <b><a href="/reference/widgets/video">Video</a></b>
    </div>
-
-</div>
-
-
-
-
-
-<div class="containerGrid">
-    <div class="columnGrid column-one" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/map-chart">
-            <img class="containerImage" src="/img/mapchart.svg" alt="Map-Chart"/>
-            </a> 
-        </div> 
-        <b><a href="//reference/widgets/map-chart">Map Chart</a></b>
-    </div>
    <div class="columnGrid column-two" align="center">
-      <div class="containerCol">
-            <a href="/reference/widgets/menu">
-            <img class="containerImage" src="/img/menu-btn.svg" alt="Menu"/>
-            </a>   
-        </div> 
-            <b><a href="/reference/widgets/menu">Menu Button</a></b>
-   </div>
-
-   <div class="columnGrid column-three" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/modal">
-            <img class="containerImage" src="/img/modal-icon.svg" alt="Modal"/>
-            </a>   
-        </div> 
-            <b><a href="/reference/widgets/modal">Modal</a></b>
-   
-   </div>
-   <div class="columnGrid column-three" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/multi-tree-select">
-            <img class="containerImage" src="/img/multi-tree.svg" alt="multi-tree"/>
-            </a>   
-        </div> 
-            <b><a href="/reference/widgets/multi-tree-select">Multi-Treeselect</a></b>
-   
-   </div>
+    </div>
+    <div class="columnGrid column-three" align="center">
+    </div>
 
 </div>
 
 
+### Toggles
 
 <div class="containerGrid">
-    <div class="columnGrid column-one" align="center">
+        <div class="columnGrid column-one" align="center">
         <div class="containerCol">
-            <a href="/reference/widgets/multiselect">
-            <img class="containerImage" src="/img/multi-select.svg" alt="multi-select"/>
+            <a href="/reference/widgets/checkbox">
+            <img class="containerImage" src="/img/checkbox-icon.svg" alt="Checkbox"/>
+            </a>   
+        </div> 
+            <b><a href="/reference/widgets/checkbox">Checkbox</a></b>
+   
+   </div>
+           <div class="columnGrid column-two" align="center">
+        <div class="containerCol">
+            <a href="/reference/widgets/checkbox-group">
+            <img class="containerImage" src="/img/check-grp.svg" alt="Checkbox-Group"/>
+            </a>   
+        </div> 
+            <b><a href="/reference/widgets/checkbox-group">Checkbox Group</a></b>
+   
+   </div>
+    <div class="columnGrid column-three" align="center">
+        <div class="containerCol">
+            <a href="/reference/widgets/radio-group">
+            <img class="containerImage" src="/img/radio-icon.svg" alt="radio-icon"/>
             </a> 
         </div> 
-        <b><a href="//reference/widgets/multiselect">Multi Select</a></b>
+        <b><a href="//reference/widgets/radio-group">Radio Group</a></b>
     </div>
+
+</div>
+
+<div class="containerGrid">
+
+   <div class="columnGrid column-one" align="center">
+            <div class="containerCol">
+            <a href="/reference/widgets/switch">
+            <img class="containerImage" src="/img/switch-icon.svg" alt="Switch"/>
+            </a>   
+        </div> 
+            <b><a href="/reference/widgets/switch">Switch</a></b>
+   </div>
+   <div class="columnGrid column-two" align="center">
+    <div class="containerCol">
+         <a href="/reference/widgets/switch-group">
+            <img class="containerImage" src="/img/s-grp.svg" alt="Switch-group"/>
+            </a>   
+        </div> 
+            <b><a href="/reference/widgets/switch-group">Switch Group</a></b>
+    </div>
+    <div class="columnGrid column-three" align="center">
+    </div>
+
+</div>
+
+### Sliders
+
+<div class="containerGrid">
+      
+   <div class="columnGrid column-one" align="center">
+        <div class="containerCol">
+            <a href="/reference/widgets/category-slider">
+            <img class="containerImage" src="/img/cat-icon.svg" alt="Category-Slider"/>
+            </a>   
+        </div> 
+            <b><a href="/reference/widgets/category-slider">Category Slider</a></b>
+   
+   </div>
+
    <div class="columnGrid column-two" align="center">
       <div class="containerCol">
             <a href="/reference/widgets/number-slider">
@@ -379,16 +412,31 @@ Appsmith offers a powerful set of widgets to help you build dynamic and function
         </div> 
             <b><a href="/reference/widgets/number-slider">Number Slider</a></b>
    </div>
-
-   <div class="columnGrid column-three" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/phone-input">
-            <img class="containerImage" src="/img/p-input.svg" alt="Phone-input"/>
+    
+   <div class="columnGrid column-two" align="center">
+      <div class="containerCol">
+            <a href="/reference/widgets/range-slider">
+            <img class="containerImage" src="/img/range-icon.svg" alt="range-icon"/>
             </a>   
         </div> 
-            <b><a href="/reference/widgets/phone-input">Phone Input</a></b>
+            <b><a href="/reference/widgets/range-slider">Range Slider</a></b>
+   </div>
+</div>
+
+### Content
+
+<div class="containerGrid">
+        <div class="columnGrid column-three" align="center">
+        <div class="containerCol">
+            <a href="/reference/widgets/maps">
+            <img class="containerImage" src="/img/map-icon.svg" alt="Map"/>
+            </a>   
+        </div> 
+            <b><a href="/reference/widgets/maps">Map</a></b>
    
    </div>
+     
+ 
    <div class="columnGrid column-three" align="center">
         <div class="containerCol">
             <a href="/reference/widgets/progress">
@@ -398,30 +446,7 @@ Appsmith offers a powerful set of widgets to help you build dynamic and function
             <b><a href="/reference/widgets/progress">Progress</a></b>
    
    </div>
-
-</div>
-
-
-
-
-<div class="containerGrid">
-    <div class="columnGrid column-one" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/radio-group">
-            <img class="containerImage" src="/img/radio-icon.svg" alt="radio-icon"/>
-            </a> 
-        </div> 
-        <b><a href="//reference/widgets/radio-group">Radio Group</a></b>
-    </div>
-   <div class="columnGrid column-two" align="center">
-      <div class="containerCol">
-            <a href="/reference/widgets/range-slider">
-            <img class="containerImage" src="/img/range-icon.svg" alt="range-icon"/>
-            </a>   
-        </div> 
-            <b><a href="/reference/widgets/range-slider">Range Slider</a></b>
-   </div>
-
+     
    <div class="columnGrid column-three" align="center">
         <div class="containerCol">
             <a href="/reference/widgets/rating">
@@ -431,98 +456,62 @@ Appsmith offers a powerful set of widgets to help you build dynamic and function
             <b><a href="/reference/widgets/rating">Rating</a></b>
    
    </div>
-   <div class="columnGrid column-three" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/rich-text-editor">
-            <img class="containerImage" src="/img/r-text.svg" alt="Rich-Text"/>
-            </a>   
-        </div> 
-            <b><a href="/reference/widgets/rich-text-editor">Rich Text Editor</a></b>
-   
-   </div>
 
 </div>
 
-
-
 <div class="containerGrid">
-   <div class="columnGrid column-two" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/switch">
-            <img class="containerImage" src="/img/switch-icon.svg" alt="Switch"/>
-            </a>   
-        </div> 
-            <b><a href="/reference/widgets/switch">Switch</a></b>
-   
-   </div>
 
-   <div class="columnGrid column-three" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/stat-box">
-            <img class="containerImage" src="/img/stats-logo.svg" alt="Stats-Box"/>
-            </a>   
-        </div> 
-            <b><a href="/reference/widgets/stat-box">Stats Box</a></b>
-   
-   </div>
-
-   <div class="columnGrid column-three" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/switch-group">
-            <img class="containerImage" src="/img/s-grp.svg" alt="Switch-group"/>
-            </a>   
-        </div> 
-            <b><a href="/reference/widgets/switch-group">Switch Group</a></b>
-   
-   </div>
-
-
-</div>
-
-
-
-<div class="containerGrid">
-    <div class="columnGrid column-two" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/tabs">
-            <img class="containerImage" src="/img/tabs-icon.svg" alt="Tabs"/>
+   <div class="columnGrid column-one" align="center">
+             <div class="containerCol">
+            <a href="/reference/widgets/Text">
+            <img class="containerImage" src="/img/text-icon.svg" alt="Text"/>
             </a>     
         </div> 
-         <b><a href="/reference/widgets/tabs">Tabs</a></b>
-    </div>
-    <div class="columnGrid column-two" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/tree-select">
-            <img class="containerImage" src="/img/tree-select.svg" alt="Treeselect"/>
-            </a>     
-        </div> 
-         <b><a href="/reference/widgets/tree-select">Treeselect</a></b>
-    </div>
-</div>
-
-
-
-
-
-<div class="containerGrid">
-
-   <div class="columnGrid column-three" align="center">
-        <div class="containerCol">
-            <a href="/reference/widgets/video">
-            <img class="containerImage" src="/img/video-icon.svg" alt="Video"/>
-            </a>   
-        </div> 
-            <b><a href="/reference/widgets/video">Video</a></b>
-   
+         <b><a href="/reference/widgets/Text">Text</a></b>
    </div>
    <div class="columnGrid column-two" align="center">
     </div>
     <div class="columnGrid column-three" align="center">
     </div>
-    <div class="columnGrid column-four" align="center">
-    </div>
+
 </div>
 
+### External
 
+<div class="containerGrid">
+        
+   <div class="columnGrid column-one" align="center">
+        <div class="containerCol">
+            <a href="/reference/widgets/audio-recorder">
+            <img class="containerImage" src="/img/ar-icon.svg" alt="Audio-Recorder"/>
+            </a>     
+        </div> 
+         <b><a href="/reference/widgets/audio-recorder">Audio Recorder</a></b>
+    </div>
+
+     
+   <div class="columnGrid column-two" align="center">
+        <div class="containerCol">
+            <a href="/reference/widgets/camera">
+            <img class="containerImage" src="/img/cam-icon.svg" alt="Camera"/>
+            </a>   
+        </div> 
+            <b><a href="/reference/widgets/camera">Camera</a></b>
+   
+   </div>
+
+     
+
+<div class="columnGrid column-three" align="center">
+    <div class="containerCol">
+        <a href="/reference/widgets/code-scanner">
+            <img class="containerImage" src="/img/code-scan.svg" alt="Code-Scanner"/>
+        </a>   
+    </div> 
+    <b><a href="/reference/widgets/code-scanner">Code Scanner</a></b>
+   
+</div>
+
+</div>
 
 


### PR DESCRIPTION
## Checklist
I have:
- [ ] run the content through Grammarly
- [ ] linked to sample apps when relevant
- [ ] added the meta description for each page in the PR
- [ ] minimized the callouts and added only when necessary
- [ ] added the `queryString` parameter to the Tabs (if used)
- [ ] masked PII in images. For example, login credentials, account details, and more
- [ ] added images only when necessary
- [ ] deleted the images that are no longer used for the updated pages in the PR
- [ ] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [ ] used the `<figure/>` tag instead of a markdown representation for images
- [ ] added the `<figcaption/>` tag to add a caption to the image
- [ ] added the `alt` attribute in the `<img/>` tag
- [x] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [ ] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.