### PR TITLE
fix: Move Sample Apps to Build Apps

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -410,6 +410,7 @@ const sidebars = {
         },
         'core-concepts/building-ui/designing-an-application/app-theming',
         'core-concepts/building-ui/designing-an-application/application-layout',
+        'learning-and-resources/sample-apps'
       ],
     }, //Reference End
   ]
@@ -530,20 +531,6 @@ const sidebars = {
         'advanced-concepts/branding',
       ],
     }, //Advanced Concepts end
-    {
-      //Learning and Resources start
-      type: 'category',
-      collapsed: false,
-      label: 'Resources',
-      items: [
-        'learning-and-resources/sample-apps',
-        {
-          type: 'link',
-          label: 'Templates', // The link label
-          href: 'https://www.appsmith.com/templates', // The external URL
-        },
-      ],
-    }, //Learning and Resources end
     {
       // Help & Support start
       type: 'category',


### PR DESCRIPTION
- Moved sample apps to Refernce under Build Apps section
- Removed link to templates

## Checklist
I have:
- [ ] run the content through Grammarly
- [ ] linked to sample apps when relevant
- [ ] added the meta description for each page in the PR
- [ ] minimized the callouts and added only when necessary
- [ ] added the `queryString` parameter to the Tabs (if used)
- [ ] masked PII in images. For example, login credentials, account details, and more
- [ ] added images only when necessary
- [ ] deleted the images that are no longer used for the updated pages in the PR
- [ ] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [ ] used the `<figure/>` tag instead of a markdown representation for images
- [ ] added the `<figcaption/>` tag to add a caption to the image
- [ ] added the `alt` attribute in the `<img/>` tag
- [ ] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [ ] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.