### PR TITLE
fix: Update landing page links 1708

### DIFF
--- a/website/docs/build-apps/how-to-guides/README.md
+++ b/website/docs/build-apps/how-to-guides/README.md
@@ -8,15 +8,12 @@
             <a href="/build-apps/how-to-guides/Server-side-pagination-in-table"><strong>Setup Server-side Pagination on Table</strong></a>
         </div> <hr/>
         <div class="containerDescription">Shows you how to set up server-side pagination on a Table widget, which allows you to manage and display large datasets.</div>
-        <div class="containerTutorialLink"></div>
     </div>
     <div class="containerColumnSampleApp columnGrid column-two">
         <div class="containerCol">
            <a href="/reference/widgets/table/inline-editing"><strong>Setup Table Inline Editing</strong></a>
         </div><hr/>
         <div class="containerDescription">Shows you how to add and edit Table data through inline editing. </div>
-         <div class="containerTutorialLink">
-         </div>
     </div>
 </div>
 <div class="containerGridSampleApp">
@@ -25,8 +22,6 @@
             <a href="/build-apps/how-to-guides/Server-side-filtering-table"><strong>Setup Server-side Filtering on Table</strong></a>
         </div> <hr/>
         <div class="containerDescription">Shows how to implement server-side filtering on the Table widget, which allows you to filter data directly at the server. </div>
-        <div class="containerTutorialLink">
-        <strong>View</strong></div>
     </div>
     <div class="containerColumnSampleApp columnGrid column-two">
         <div class="containerCol">
@@ -34,8 +29,6 @@
         </div><hr/>
         <div class="containerDescription">Shows how to implement server-side search on the Table widget, enabling effective search capability by performing searches directly on the server.
         </div>
-         <div class="containerTutorialLink"><strong>View</strong>
-         </div>
     </div>
 </div>
 
@@ -45,8 +38,6 @@
                 <a href="/build-apps/how-to-guides/Refresh-table-data"><strong>Refresh table data</strong></a>
         </div> <hr/>
         <div class="containerDescription">Shows you how to refresh table data based on specific actions. </div>
-        <div class="containerTutorialLink">
-        </div>
     </div>
      <div class="columnGrid column-two" style={{margin: "10px"}}>
     </div>
@@ -60,16 +51,12 @@
            <a href="/build-apps/how-to-guides/Setup-Server-side-Pagination-on-List"> <strong>Setup Server-side Pagination on List</strong></a>
         </div> <hr/>
         <div class="containerDescription">Shows how to implement server-side pagination on the List widget, enhancing performance by fetching and displaying data in manageable chunks directly from the server. </div>
-        <div class="containerTutorialLink">
-        </div>
     </div>
     <div class="containerColumnSampleApp columnGrid column-two">
         <div class="containerCol">
            <a href="/build-apps/how-to-guides/Create-nested-lists"><strong>Create Nested Lists</strong></a>
         </div><hr/>
         <div class="containerDescription">Shows how to create nested lists using the List widget, allows you to organize and present hierarchical data in a structured manner </div>
-         <div class="containerTutorialLink">
-         </div>
     </div>
 </div>
 
@@ -81,8 +68,6 @@
             <a href="/build-apps/how-to-guides/Filter-table-data-using-Datepicker"><strong>Filter table data using Datepicker</strong></a>
         </div> <hr/>
         <div class="containerDescription">Shows how to filter table data using the Datepicker widget, allows users to narrow down and view information based on specific date ranges. </div>
-        <div class="containerTutorialLink">
-        </div>
 </div>
      <div class="columnGrid column-two" style={{margin: "10px"}}>
     </div>
@@ -98,15 +83,12 @@
             <a href="/build-apps/how-to-guides/Upload-CSV-Data-to-Table"><strong>Upload CSV data in Table using Filepicker</strong></a>
         </div> <hr/>
         <div class="containerDescription">Shows how to upload CSV data into a Table widget using the Filepicker widget. </div>
-        <div class="containerTutorialLink"></div>
     </div>
     <div class="containerColumnSampleApp columnGrid column-two">
         <div class="containerCol">
            <a href="/build-apps/how-to-guides/Send-Filepicker-data-with-API-requests"><strong>Send Filepicker Data with API Requests</strong></a>
         </div><hr/>
         <div class="containerDescription">Shows how to send Filepicker data along with API requests, allows seamless transmission of chosen files to external services. </div>
-         <div class="containerTutorialLink">
-         </div>
     </div>
 </div>
 
@@ -119,16 +101,12 @@
             <a href="/build-apps/how-to-guides/Create-custom-widgets-using-Iframe"><strong>Create Custom Widgets Using Iframe</strong></a>
         </div> <hr/>
         <div class="containerDescription">Shows how to create custom widgets using Iframe, allowing you to embed external content and functionalities seamlessly within your app.</div>
-        <div class="containerTutorialLink">
-        </div>
     </div>
     <div class="containerColumnSampleApp columnGrid column-two">
         <div class="containerCol">
            <a href="/build-apps/how-to-guides/Communicate-Between-an-App-and-Iframe"><strong>Communicate Between an App and Iframe</strong></a>
         </div><hr/>
         <div class="containerDescription">Shows how to communicate between an app and Iframe, enabling seamless interaction and data exchange between the two.</div>
-         <div class="containerTutorialLink">
-         </div>
     </div>
 </div>
 
@@ -141,8 +119,6 @@
             <a href="/build-apps/how-to-guides/Setup-Server-side-Filtering-on-Select"><strong>Setup Server-side Filtering on Select</strong></a>
         </div> <hr/>
         <div class="containerDescription">Shows how to implement server-side filtering on the Select widget, enabling data filtering directly at the server level. </div>
-        <div class="containerTutorialLink">
-        </div>
 </div>
      <div class="columnGrid column-two" style={{margin: "10px"}}>
     </div>
@@ -156,8 +132,6 @@
             <a href="/build-apps/how-to-guides/Multi-step-Form-or-Wizard-Using-Tabs"><strong>Create a Multi-step Form or Wizard Using Tabs</strong></a>
         </div> <hr/>
         <div class="containerDescription">Shows how to create a multi-step form or wizard using the Tabs widget, allowing users to navigate through different sections of a form in a structured and organized manner. </div>
-        <div class="containerTutorialLink">
-        </div>
 </div>
      <div class="columnGrid column-two" style={{margin: "10px"}}>
     </div>

--- a/website/docs/build-apps/how-to-guides/README.md
+++ b/website/docs/build-apps/how-to-guides/README.md
@@ -5,37 +5,36 @@
 <div class="containerGridSampleApp">
   <div class="containerColumnSampleApp columnGrid column-one">
         <div class="containerCol">
-            <strong>Setup Server-side Pagination on Table</strong>
+            <a href="/build-apps/how-to-guides/Server-side-pagination-in-table"><strong>Setup Server-side Pagination on Table</strong></a>
         </div> <hr/>
         <div class="containerDescription">Shows you how to set up server-side pagination on a Table widget, which allows you to manage and display large datasets.</div>
-        <div class="containerTutorialLink"><a href="/build-apps/how-to-guides/Server-side-pagination-in-table">
-        <strong >View </strong></a></div>
+        <div class="containerTutorialLink"></div>
     </div>
     <div class="containerColumnSampleApp columnGrid column-two">
         <div class="containerCol">
-           <strong>Setup Table Inline Editing</strong>
+           <a href="/reference/widgets/table/inline-editing"><strong>Setup Table Inline Editing</strong></a>
         </div><hr/>
         <div class="containerDescription">Shows you how to add and edit Table data through inline editing. </div>
-         <div class="containerTutorialLink"><a href="/reference/widgets/table/inline-editing"><strong>View</strong></a>
+         <div class="containerTutorialLink">
          </div>
     </div>
 </div>
 <div class="containerGridSampleApp">
     <div class="containerColumnSampleApp columnGrid column-one">
         <div class="containerCol">
-            <strong>Setup Server-side Filtering on Table</strong>
+            <a href="/build-apps/how-to-guides/Server-side-filtering-table"><strong>Setup Server-side Filtering on Table</strong></a>
         </div> <hr/>
         <div class="containerDescription">Shows how to implement server-side filtering on the Table widget, which allows you to filter data directly at the server. </div>
-        <div class="containerTutorialLink"><a href="/build-apps/how-to-guides/Server-side-filtering-table">
-        <strong>View</strong></a></div>
+        <div class="containerTutorialLink">
+        <strong>View</strong></div>
     </div>
     <div class="containerColumnSampleApp columnGrid column-two">
         <div class="containerCol">
-           <strong>Setup Server-side Searching on Table</strong>
+           <a href="/build-apps/how-to-guides/Setup-Server-side-Searching-on-Table"><strong>Setup Server-side Searching on Table</strong></a>
         </div><hr/>
         <div class="containerDescription">Shows how to implement server-side search on the Table widget, enabling effective search capability by performing searches directly on the server.
         </div>
-         <div class="containerTutorialLink"><a href="/build-apps/how-to-guides/Setup-Server-side-Searching-on-Table"><strong>View</strong></a>
+         <div class="containerTutorialLink"><strong>View</strong>
          </div>
     </div>
 </div>
@@ -43,11 +42,11 @@
 <div class="containerGridSampleApp">
     <div class="containerColumnSampleApp columnGrid column-one">
         <div class="containerCol">
-                <strong>Refresh table data</strong>
+                <a href="/build-apps/how-to-guides/Refresh-table-data"><strong>Refresh table data</strong></a>
         </div> <hr/>
         <div class="containerDescription">Shows you how to refresh table data based on specific actions. </div>
-        <div class="containerTutorialLink"><a href="/build-apps/how-to-guides/Refresh-table-data">
-        <strong >View </strong></a></div>
+        <div class="containerTutorialLink">
+        </div>
     </div>
      <div class="columnGrid column-two" style={{margin: "10px"}}>
     </div>
@@ -58,18 +57,18 @@
 <div class="containerGridSampleApp">
     <div class="containerColumnSampleApp columnGrid column-one">
         <div class="containerCol">
-            <strong>Setup Server-side Pagination on List</strong>
+           <a href="/build-apps/how-to-guides/Setup-Server-side-Pagination-on-List"> <strong>Setup Server-side Pagination on List</strong></a>
         </div> <hr/>
         <div class="containerDescription">Shows how to implement server-side pagination on the List widget, enhancing performance by fetching and displaying data in manageable chunks directly from the server. </div>
-        <div class="containerTutorialLink"><a href="/build-apps/how-to-guides/Setup-Server-side-Pagination-on-List">
-        <strong>View</strong></a></div>
+        <div class="containerTutorialLink">
+        </div>
     </div>
     <div class="containerColumnSampleApp columnGrid column-two">
         <div class="containerCol">
-           <strong>Create Nested Lists</strong>
+           <a href="/build-apps/how-to-guides/Create-nested-lists"><strong>Create Nested Lists</strong></a>
         </div><hr/>
         <div class="containerDescription">Shows how to create nested lists using the List widget, allows you to organize and present hierarchical data in a structured manner </div>
-         <div class="containerTutorialLink"><a href="/build-apps/how-to-guides/Create-nested-lists"><strong>View</strong></a>
+         <div class="containerTutorialLink">
          </div>
     </div>
 </div>
@@ -79,11 +78,11 @@
 <div class="containerGridSampleApp">
     <div class="containerColumnSampleApp columnGrid column-one">
         <div class="containerCol">
-            <strong>Filter table data using Datepicker</strong>
+            <a href="/build-apps/how-to-guides/Filter-table-data-using-Datepicker"><strong>Filter table data using Datepicker</strong></a>
         </div> <hr/>
         <div class="containerDescription">Shows how to filter table data using the Datepicker widget, allows users to narrow down and view information based on specific date ranges. </div>
-        <div class="containerTutorialLink"><a href="/build-apps/how-to-guides/Filter-table-data-using-Datepicker">
-        <strong>View</strong></a></div>
+        <div class="containerTutorialLink">
+        </div>
 </div>
      <div class="columnGrid column-two" style={{margin: "10px"}}>
     </div>
@@ -96,18 +95,17 @@
 <div class="containerGridSampleApp">
     <div class="containerColumnSampleApp columnGrid column-one">
         <div class="containerCol">
-            <strong>Upload CSV data in Table using Filepicker</strong>
+            <a href="/build-apps/how-to-guides/Upload-CSV-Data-to-Table"><strong>Upload CSV data in Table using Filepicker</strong></a>
         </div> <hr/>
         <div class="containerDescription">Shows how to upload CSV data into a Table widget using the Filepicker widget. </div>
-        <div class="containerTutorialLink"><a href="/build-apps/how-to-guides/Upload-CSV-Data-to-Table">
-        <strong>View</strong></a></div>
+        <div class="containerTutorialLink"></div>
     </div>
     <div class="containerColumnSampleApp columnGrid column-two">
         <div class="containerCol">
-           <strong>Send Filepicker Data with API Requests</strong>
+           <a href="/build-apps/how-to-guides/Send-Filepicker-data-with-API-requests"><strong>Send Filepicker Data with API Requests</strong></a>
         </div><hr/>
         <div class="containerDescription">Shows how to send Filepicker data along with API requests, allows seamless transmission of chosen files to external services. </div>
-         <div class="containerTutorialLink"><a href="/build-apps/how-to-guides/Send-Filepicker-data-with-API-requests"><strong>View</strong></a>
+         <div class="containerTutorialLink">
          </div>
     </div>
 </div>
@@ -118,18 +116,18 @@
 <div class="containerGridSampleApp">
     <div class="containerColumnSampleApp columnGrid column-one">
         <div class="containerCol">
-            <strong>Create Custom Widgets Using Iframe</strong>
+            <a href="/build-apps/how-to-guides/Create-custom-widgets-using-Iframe"><strong>Create Custom Widgets Using Iframe</strong></a>
         </div> <hr/>
         <div class="containerDescription">Shows how to create custom widgets using Iframe, allowing you to embed external content and functionalities seamlessly within your app.</div>
-        <div class="containerTutorialLink"><a href="/build-apps/how-to-guides/Create-custom-widgets-using-Iframe">
-        <strong>View</strong></a></div>
+        <div class="containerTutorialLink">
+        </div>
     </div>
     <div class="containerColumnSampleApp columnGrid column-two">
         <div class="containerCol">
-           <strong>Communicate Between an App and Iframe</strong>
+           <a href="/build-apps/how-to-guides/Communicate-Between-an-App-and-Iframe"><strong>Communicate Between an App and Iframe</strong></a>
         </div><hr/>
         <div class="containerDescription">Shows how to communicate between an app and Iframe, enabling seamless interaction and data exchange between the two.</div>
-         <div class="containerTutorialLink"><a href="/build-apps/how-to-guides/Communicate-Between-an-App-and-Iframe"><strong>View</strong></a>
+         <div class="containerTutorialLink">
          </div>
     </div>
 </div>
@@ -140,11 +138,11 @@
 <div class="containerGridSampleApp">
     <div class="containerColumnSampleApp columnGrid column-one">
         <div class="containerCol">
-            <strong>Setup Server-side Filtering on Select</strong>
+            <a href="/build-apps/how-to-guides/Setup-Server-side-Filtering-on-Select"><strong>Setup Server-side Filtering on Select</strong></a>
         </div> <hr/>
         <div class="containerDescription">Shows how to implement server-side filtering on the Select widget, enabling data filtering directly at the server level. </div>
-        <div class="containerTutorialLink"><a href="/build-apps/how-to-guides/Setup-Server-side-Filtering-on-Select">
-        <strong>View</strong></a></div>
+        <div class="containerTutorialLink">
+        </div>
 </div>
      <div class="columnGrid column-two" style={{margin: "10px"}}>
     </div>
@@ -155,11 +153,11 @@
 <div class="containerGridSampleApp">
     <div class="containerColumnSampleApp columnGrid column-one">
         <div class="containerCol">
-            <strong>Create a Multi-step Form or Wizard Using Tabs</strong>
+            <a href="/build-apps/how-to-guides/Multi-step-Form-or-Wizard-Using-Tabs"><strong>Create a Multi-step Form or Wizard Using Tabs</strong></a>
         </div> <hr/>
         <div class="containerDescription">Shows how to create a multi-step form or wizard using the Tabs widget, allowing users to navigate through different sections of a form in a structured and organized manner. </div>
-        <div class="containerTutorialLink"><a href="/build-apps/how-to-guides/Multi-step-Form-or-Wizard-Using-Tabs">
-        <strong>View</strong></a></div>
+        <div class="containerTutorialLink">
+        </div>
 </div>
      <div class="columnGrid column-two" style={{margin: "10px"}}>
     </div>

--- a/website/docs/build-apps/how-to-guides/README.md
+++ b/website/docs/build-apps/how-to-guides/README.md
@@ -5,7 +5,8 @@
 <div class="containerGridSampleApp">
   <div class="containerColumnSampleApp columnGrid column-one">
         <div class="containerCol">
-            <a href="/build-apps/how-to-guides/Server-side-pagination-in-table"><strong>Setup Server-side Pagination on Table</strong></a>
+            <a href="/build-apps/how-to-guides/Server-side-pagination-in-table"><strong>Setup Server-side Pagination on Table</strong>
+            </a>
         </div> <hr/>
         <div class="containerDescription">Shows you how to set up server-side pagination on a Table widget, which allows you to manage and display large datasets.</div>
     </div>

--- a/website/docs/build-apps/reference/README.md
+++ b/website/docs/build-apps/reference/README.md
@@ -11,19 +11,15 @@ Technical descriptions and information about widgets and app settings.
 <div class="containerGridSampleApp">
   <div class="containerColumnSampleApp columnGrid column-one">
         <div class="containerCol">
-            <strong>Widgets</strong>
+            <a href="/reference/widgets"><strong>Widgets</strong></a>
         </div> <hr/>
         <div class="containerDescription">Appsmith offers a powerful set of widgets to help you build dynamic and functional app layouts. You can simply drag and drop them onto the canvas and edit the properties of each widget to customize its data, style, and actions.</div>
-        <div class="containerTutorialLink"><a href="/reference/widgets">
-        <strong >View </strong></a></div>
     </div>
     <div class="containerColumnSampleApp columnGrid column-two">
         <div class="containerCol">
-           <strong>Theme</strong>
+           <a href="/core-concepts/building-ui/designing-an-application/app-theming"><strong>Theme</strong></a>
         </div><hr/>
         <div class="containerDescription">Theme allows you to style your pages and widgets using global controls, making it easy to change the visual layout with a single click. </div>
-         <div class="containerTutorialLink"><a href="/core-concepts/building-ui/designing-an-application/app-theming"><strong>View</strong></a>
-         </div>
     </div>
 </div>
 
@@ -31,11 +27,9 @@ Technical descriptions and information about widgets and app settings.
 <div class="containerGridSampleApp">
     <div class="containerColumnSampleApp columnGrid column-one">
         <div class="containerCol">
-                <strong>Canvas Size</strong>
+                <a href="/core-concepts/building-ui/designing-an-application/application-layout"><strong>Canvas Size</strong></a>
         </div> <hr/>
         <div class="containerDescription">You can choose the application layout to align with the device size for which the app is intended. </div>
-        <div class="containerTutorialLink"><a href="/core-concepts/building-ui/designing-an-application/application-layout">
-        <strong >View </strong></a></div>
     </div>
      <div class="columnGrid column-two" style={{margin: "10px"}}>
     </div>

--- a/website/docs/connect-data/concepts/README.md
+++ b/website/docs/connect-data/concepts/README.md
@@ -1,8 +1,37 @@
 # Concepts
 
-The explanation guides in this section provides a deeper understanding and clarifies the following topics:
+<div class="containerGridSampleApp">
+  <div class="containerColumnSampleApp columnGrid column-one">
+        <div class="containerCol">
+            <a href="/connect-data/concepts/connection-pooling"><strong>Connection Pooling</strong></a>
+        </div> <hr/>
+        <div class="containerDescription">The first time you connect a database to your application, Appsmith creates a new connection with the database server.</div>
+        <div class="containerTutorialLink"></div>
+    </div>
+    <div class="containerColumnSampleApp columnGrid column-two">
+        <div class="containerCol">
+           <a href="/connect-data/concepts/Datasource-Environments"><strong>Datasource Environments</strong></a>
+        </div><hr/>
+        <div class="containerDescription">Datasource environments let you separate staging and production configurations of the same datasource. This gives you control and isolation for different tasks at different stages of the datasource's lifecycle. </div>
+         <div class="containerTutorialLink">
+         </div>
+    </div>
+</div>
 
-* [Connection Pooling](/connect-data/concepts/connection-pooling)
-* [Datasource Environments](/connect-data/concepts/Datasource-Environments)
-* [Prepared Statements](/connect-data/concepts/how-to-use-prepared-statements)
-* [Stored Procedures](/connect-data/concepts/returning-data-from-a-stored-procedure)
+<div class="containerGridSampleApp">
+  <div class="containerColumnSampleApp columnGrid column-one">
+        <div class="containerCol">
+            <a href="/connect-data/concepts/how-to-use-prepared-statements"><strong>Prepared Statements</strong></a>
+        </div> <hr/>
+        <div class="containerDescription">Database Management Systems (DBMS) provide prepared statements to enable the execution of SQL statements with parameterized data bindings.</div>
+        <div class="containerTutorialLink"></div>
+    </div>
+    <div class="containerColumnSampleApp columnGrid column-two">
+        <div class="containerCol">
+           <a href="/connect-data/concepts/returning-data-from-a-stored-procedure"><strong>Stored Procedures</strong></a>
+        </div><hr/>
+        <div class="containerDescription">Stored procedures are SQL statements that can be defined and called as reusable pieces of code. </div>
+         <div class="containerTutorialLink">
+         </div>
+    </div>
+</div>

--- a/website/docs/connect-data/how-to-guides/README.md
+++ b/website/docs/connect-data/how-to-guides/README.md
@@ -1,11 +1,85 @@
 # How-To Guides
 
-* [Connect Datasource](/connect-data/how-to-guides/connect-datasource)
-* [Query Data](/connect-data/how-to-guides/query-data)
-* [Connect Datasource on Local Machine](/connect-data/how-to-guides/how-to-work-with-local-apis-on-appsmith)
-* [Pass Parameters to Queries](/connect-data/how-to-guides/how-to-pass-params-to-an-api)
-* [Upload or Download Files to and from S3](/connect-data/how-to-guides/how-to-upload-to-s3)
-* [Upload Images to and from S3](/connect-data/how-to-guides/how-to-use-the-camera-image-widget-to-upload-download-images)
-* [Upload Files to Dropbox](/connect-data/how-to-guides/how-to-integrate-dropbox)
-* [Create Campaigns with Zoho](/connect-data/how-to-guides/how-to-integrate-zoho)
-* [Integrate With Third-Party Tools](/connect-data/integrations)
+<div class="containerGridSampleApp">
+  <div class="containerColumnSampleApp columnGrid column-one">
+        <div class="containerCol">
+            <a href="/connect-data/how-to-guides/connect-datasource"><strong>Connect Datasource</strong></a>
+        </div> <hr/>
+        <div class="containerDescription">Shows you how to connect to a datasource on Appsmith.</div>
+        <div class="containerTutorialLink"></div>
+    </div>
+    <div class="containerColumnSampleApp columnGrid column-two">
+        <div class="containerCol">
+           <a href="/connect-data/how-to-guides/query-data"><strong>Query Data</strong></a>
+        </div><hr/>
+        <div class="containerDescription">Shows you how to create queries on Appsmith. </div>
+         <div class="containerTutorialLink">
+         </div>
+    </div>
+</div>
+
+<div class="containerGridSampleApp">
+  <div class="containerColumnSampleApp columnGrid column-one">
+        <div class="containerCol">
+            <a href="/connect-data/how-to-guides/how-to-work-with-local-apis-on-appsmith"><strong>Connect Datasource on Local Machine</strong></a>
+        </div> <hr/>
+        <div class="containerDescription">Shows you how to connect a database or API that is hosted locally on the same machine as your Appsmith instance.</div>
+        <div class="containerTutorialLink"></div>
+    </div>
+    <div class="containerColumnSampleApp columnGrid column-two">
+        <div class="containerCol">
+           <a href="/connect-data/how-to-guides/how-to-pass-params-to-an-api"><strong>Pass Parameters to Queries</strong></a>
+        </div><hr/>
+        <div class="containerDescription">Shows you how to use the run() function in a loop to pass different parameters to your query each time it runs. </div>
+         <div class="containerTutorialLink">
+         </div>
+    </div>
+</div>
+
+<div class="containerGridSampleApp">
+  <div class="containerColumnSampleApp columnGrid column-one">
+        <div class="containerCol">
+            <a href="/connect-data/how-to-guides/how-to-upload-to-s3"><strong>Upload or Download Files to and from S3</strong></a>
+        </div> <hr/>
+        <div class="containerDescription">Shows you how to upload files to Amazon S3 using the S3 plugin and the FilePicker Widget.</div>
+        <div class="containerTutorialLink"></div>
+    </div>
+    <div class="containerColumnSampleApp columnGrid column-two">
+        <div class="containerCol">
+           <a href="/connect-data/how-to-guides/how-to-use-the-camera-image-widget-to-upload-download-images"><strong>Upload Images to and from S3</strong></a>
+        </div><hr/>
+        <div class="containerDescription">Shows you how to connect and configure the S3 datasource, use the Image and Camera widget, upload/download images using S3. </div>
+         <div class="containerTutorialLink">
+         </div>
+    </div>
+</div>
+
+<div class="containerGridSampleApp">
+  <div class="containerColumnSampleApp columnGrid column-one">
+        <div class="containerCol">
+            <a href="/connect-data/how-to-guides/how-to-integrate-dropbox"><strong>Upload Files to Dropbox</strong></a>
+        </div> <hr/>
+        <div class="containerDescription">Shows you how to configure an Authenticated API datasource for Dropbox with OAuth 2.0 and create a query that uploads a file to Dropbox from your Appsmith app.</div>
+        <div class="containerTutorialLink"></div>
+    </div>
+    <div class="containerColumnSampleApp columnGrid column-two">
+        <div class="containerCol">
+           <a href="/connect-data/how-to-guides/how-to-integrate-zoho"><strong>Create Campaigns with Zoho</strong></a>
+        </div><hr/>
+        <div class="containerDescription">Shows you how to configure an Authenticated API datasource for Zoho with OAuth 2.0 and create a query that creates a campaign from your Appsmith app. </div>
+         <div class="containerTutorialLink">
+         </div>
+    </div>
+</div>
+
+<div class="containerGridSampleApp">
+  <div class="containerColumnSampleApp columnGrid column-one">
+        <div class="containerCol">
+            <a href="/connect-data/integrations"><strong>Integrate With Third-Party Tools</strong></a>
+        </div> <hr/>
+        <div class="containerDescription">Shows you how to connect Appsmith to many third-party tools via API.</div>
+        <div class="containerTutorialLink"></div>
+    </div>
+     <div class="columnGrid column-two" style={{margin: "10px"}}>
+    </div>
+</div>

--- a/website/docs/write-code/how-to-guides/README.md
+++ b/website/docs/write-code/how-to-guides/README.md
@@ -6,37 +6,36 @@ import DocCardList from '@theme/DocCardList';
 <div class="containerGridSampleApp">
   <div class="containerColumnSampleApp columnGrid column-one">
         <div class="containerCol">
-            <strong>Write Code in Appsmith</strong>
+            <a href="/core-concepts/writing-code"><strong>Write Code in Appsmith</strong></a>
         </div> <hr/>
         <div class="containerDescription">Allows you to write JavaScript code almost everywhere on the GUI inside widget properties, events listeners, queries, and other settings.</div>
-        <div class="containerTutorialLink"><a href="/core-concepts/writing-code">
-        <strong >View </strong></a></div>
+        <div class="containerTutorialLink"></div>
     </div>
     <div class="containerColumnSampleApp columnGrid column-two">
         <div class="containerCol">
-           <strong>Create JS Objects</strong>
+           <a href="/core-concepts/writing-code/javascript-editor-beta"><strong>Create JS Objects</strong></a>
         </div><hr/>
         <div class="containerDescription">The JavaScript Editor in Appsmith enables you to create JS Objects with a page-level scope. </div>
-         <div class="containerTutorialLink"><a href="/core-concepts/writing-code/javascript-editor-beta"><strong>View</strong></a>
+         <div class="containerTutorialLink">
          </div>
     </div>
 </div>
 <div class="containerGridSampleApp">
     <div class="containerColumnSampleApp columnGrid column-one">
         <div class="containerCol">
-            <strong>Display Data from Functions</strong>
+            <a href="/write-code/how-to-guides/display-data-from-functions"><strong>Display Data from Functions</strong></a>
         </div> <hr/>
         <div class="containerDescription">Functions are blocks of code that can be defined and executed when needed. Functions within a JavaScript object can either be synchronous or asynchronous. </div>
-        <div class="containerTutorialLink"><a href="/write-code/how-to-guides/display-data-from-functions">
-        <strong>View</strong></a></div>
+        <div class="containerTutorialLink">
+        </div>
     </div>
     <div class="containerColumnSampleApp columnGrid column-two">
         <div class="containerCol">
-           <strong>Use JavaScript promises</strong>
+           <a href="/core-concepts/writing-code/javascript-promises"><strong>Use JavaScript promises</strong></a>
         </div><hr/>
         <div class="containerDescription">Explains how to write asynchronous Javascript code in Appsmith.
         </div>
-         <div class="containerTutorialLink"><a href="/core-concepts/writing-code/javascript-promises"><strong>View</strong></a>
+         <div class="containerTutorialLink">
          </div>
     </div>
 </div>
@@ -44,37 +43,37 @@ import DocCardList from '@theme/DocCardList';
 <div class="containerGridSampleApp">
   <div class="containerColumnSampleApp columnGrid column-one">
         <div class="containerCol">
-            <strong>Share Data Across Pages</strong>
+            <a href="/advanced-concepts/sharing-data-across-pages"><strong>Share Data Across Pages</strong></a>
         </div> <hr/>
         <div class="containerDescription">Allows easy data sharing between different pages.</div>
-        <div class="containerTutorialLink"><a href="/advanced-concepts/sharing-data-across-pages">
-        <strong >View </strong></a></div>
+        <div class="containerTutorialLink">
+        </div>
     </div>
     <div class="containerColumnSampleApp columnGrid column-two">
         <div class="containerCol">
-           <strong>Chain Functions and Promises</strong>
+           <a href="/core-concepts/writing-code/workflows"><strong>Chain Functions and Promises</strong></a>
         </div><hr/>
         <div class="containerDescription">Create Complex Workflows by Chaining Functions and Promises. </div>
-         <div class="containerTutorialLink"><a href="/core-concepts/writing-code/workflows"><strong>View</strong></a>
+         <div class="containerTutorialLink">
          </div>
     </div>
 </div>
 <div class="containerGridSampleApp">
     <div class="containerColumnSampleApp columnGrid column-one">
         <div class="containerCol">
-            <strong>Use external JS libraries</strong>
+            <a href="/core-concepts/writing-code/ext-libraries"><strong>Use external JS libraries</strong></a>
         </div> <hr/>
         <div class="containerDescription">Shows hwo to install external libraries for additional data manipulation or transformation capabilities.</div>
-        <div class="containerTutorialLink"><a href="/core-concepts/writing-code/ext-libraries">
-        <strong>View</strong></a></div>
+        <div class="containerTutorialLink">
+        </div>
     </div>
     <div class="containerColumnSampleApp columnGrid column-two">
         <div class="containerCol">
-           <strong>Debug JS Errors</strong>
+           <a href="/write-code/how-to-guides/debug-js-errors"><strong>Debug JS Errors</strong></a>
         </div><hr/>
         <div class="containerDescription">Allows you to check the state of your code and step through it line by line to help identify and fix any errors.
         </div>
-         <div class="containerTutorialLink"><a href="/write-code/how-to-guides/debug-js-errors"><strong>View</strong></a>
+         <div class="containerTutorialLink">
          </div>
     </div>
 </div>

--- a/website/docs/write-code/how-to-guides/README.md
+++ b/website/docs/write-code/how-to-guides/README.md
@@ -9,15 +9,12 @@ import DocCardList from '@theme/DocCardList';
             <a href="/core-concepts/writing-code"><strong>Write Code in Appsmith</strong></a>
         </div> <hr/>
         <div class="containerDescription">Allows you to write JavaScript code almost everywhere on the GUI inside widget properties, events listeners, queries, and other settings.</div>
-        <div class="containerTutorialLink"></div>
     </div>
     <div class="containerColumnSampleApp columnGrid column-two">
         <div class="containerCol">
            <a href="/core-concepts/writing-code/javascript-editor-beta"><strong>Create JS Objects</strong></a>
         </div><hr/>
         <div class="containerDescription">The JavaScript Editor in Appsmith enables you to create JS Objects with a page-level scope. </div>
-         <div class="containerTutorialLink">
-         </div>
     </div>
 </div>
 <div class="containerGridSampleApp">
@@ -26,8 +23,6 @@ import DocCardList from '@theme/DocCardList';
             <a href="/write-code/how-to-guides/display-data-from-functions"><strong>Display Data from Functions</strong></a>
         </div> <hr/>
         <div class="containerDescription">Functions are blocks of code that can be defined and executed when needed. Functions within a JavaScript object can either be synchronous or asynchronous. </div>
-        <div class="containerTutorialLink">
-        </div>
     </div>
     <div class="containerColumnSampleApp columnGrid column-two">
         <div class="containerCol">
@@ -35,8 +30,6 @@ import DocCardList from '@theme/DocCardList';
         </div><hr/>
         <div class="containerDescription">Explains how to write asynchronous Javascript code in Appsmith.
         </div>
-         <div class="containerTutorialLink">
-         </div>
     </div>
 </div>
 
@@ -46,16 +39,12 @@ import DocCardList from '@theme/DocCardList';
             <a href="/advanced-concepts/sharing-data-across-pages"><strong>Share Data Across Pages</strong></a>
         </div> <hr/>
         <div class="containerDescription">Allows easy data sharing between different pages.</div>
-        <div class="containerTutorialLink">
-        </div>
     </div>
     <div class="containerColumnSampleApp columnGrid column-two">
         <div class="containerCol">
            <a href="/core-concepts/writing-code/workflows"><strong>Chain Functions and Promises</strong></a>
         </div><hr/>
         <div class="containerDescription">Create Complex Workflows by Chaining Functions and Promises. </div>
-         <div class="containerTutorialLink">
-         </div>
     </div>
 </div>
 <div class="containerGridSampleApp">
@@ -64,8 +53,6 @@ import DocCardList from '@theme/DocCardList';
             <a href="/core-concepts/writing-code/ext-libraries"><strong>Use external JS libraries</strong></a>
         </div> <hr/>
         <div class="containerDescription">Shows hwo to install external libraries for additional data manipulation or transformation capabilities.</div>
-        <div class="containerTutorialLink">
-        </div>
     </div>
     <div class="containerColumnSampleApp columnGrid column-two">
         <div class="containerCol">
@@ -73,8 +60,6 @@ import DocCardList from '@theme/DocCardList';
         </div><hr/>
         <div class="containerDescription">Allows you to check the state of your code and step through it line by line to help identify and fix any errors.
         </div>
-         <div class="containerTutorialLink">
-         </div>
     </div>
 </div>
 

--- a/website/docs/write-code/reference/README.md
+++ b/website/docs/write-code/reference/README.md
@@ -9,67 +9,54 @@ To know more about the objects and functions, refer to the resources below:
 <div class="containerGridSampleApp">
   <div class="containerColumnSampleApp columnGrid column-one">
         <div class="containerCol">
-            <strong>Appsmith Object</strong>
+            <a href="/reference/appsmith-framework/context-object"><strong>Appsmith Object</strong>
+            </a>
         </div> <hr/>
         <div class="containerDescription">The Appsmith object is a global object that provides access to information and functionalities within an application through objects and utility functions.</div>
-        <div class="containerTutorialLink"><a href="/reference/appsmith-framework/context-object">
-        <strong >View </strong></a></div>
     </div>
     <div class="containerColumnSampleApp columnGrid column-two">
         <div class="containerCol">
-           <strong>Console Object</strong>
+           <a href="/reference/appsmith-framework/console-object"><strong>Console Object</strong></a>
         </div><hr/>
         <div class="containerDescription">The console object provides an easy way to send logging messages from the browser to the development console or to display messages in the browser when an error occurs.</div>
-         <div class="containerTutorialLink"><a href="/reference/appsmith-framework/console-object"><strong>View</strong></a>
-         </div>
     </div>
 </div>
 <div class="containerGridSampleApp">
     <div class="containerColumnSampleApp columnGrid column-one">
         <div class="containerCol">
-            <strong>Query Object</strong>
+            <a href="/reference/appsmith-framework/query-object"><strong>Query Object</strong></a>
         </div> <hr/>
         <div class="containerDescription">The query object contains the parameters required to run queries and access the query data.</div>
-        <div class="containerTutorialLink"><a href="/reference/appsmith-framework/query-object">
-        <strong>View</strong></a></div>
     </div>
     <div class="containerColumnSampleApp columnGrid column-two">
         <div class="containerCol">
-           <strong>Built-in functions</strong>
+           <a href="/reference/appsmith-framework/widget-actions"><strong>Built-in functions</strong></a>
         </div><hr/>
         <div class="containerDescription">The Appsmith framework allows triggering actions for widget events and inside JS Objects. There are functions to navigate to another page, show alert messages, open/close modals, and store data in local storage. </div>
-         <div class="containerTutorialLink"><a href="/reference/appsmith-framework/widget-actions"><strong>View</strong></a>
-         </div>
     </div>
 </div>
 
 <div class="containerGridSampleApp">
     <div class="containerColumnSampleApp columnGrid column-one">
         <div class="containerCol">
-            <strong>Built-in JS Libraries</strong>
+            <a href="/write-code/reference/Built-in-JS-Libraries"><strong>Built-in JS Libraries</strong></a>
         </div> <hr/>
         <div class="containerDescription">Built-in JavaScript libraries provide a comprehensive array of capabilities for common tasks such as data manipulation, numeric operations, date and time handling, and more. </div>
-        <div class="containerTutorialLink"><a href="/write-code/reference/Built-in-JS-Libraries">
-        <strong>View</strong></a></div>
     </div>
     <div class="containerColumnSampleApp columnGrid column-two">
         <div class="containerCol">
-           <strong>Fetch API</strong>
+           <a href="/write-code/reference/Fetch-API"><strong>Fetch API</strong></a>
         </div><hr/>
         <div class="containerDescription">The Fetch API provides an interface for executing network calls programmatically. You can use fetch() to programmatically configure and execute a REST API.</div>
-         <div class="containerTutorialLink"><a href="/write-code/reference/Fetch-API"><strong>View</strong></a>
-         </div>
     </div>
 </div>
 
 <div class="containerGridSampleApp">
     <div class="containerColumnSampleApp columnGrid column-one">
         <div class="containerCol">
-            <strong>Function Settings</strong>
+            <a href="/core-concepts/writing-code/javascript-editor-beta/asynchronous-javascript-function-settings"><strong>Function Settings</strong></a>
         </div> <hr/>
         <div class="containerDescription">Provides information on how to configure settings for functions </div>
-        <div class="containerTutorialLink"><a href="/core-concepts/writing-code/javascript-editor-beta/asynchronous-javascript-function-settings">
-        <strong>View</strong></a></div>
 </div>
      <div class="columnGrid column-two" style={{margin: "10px"}}>
     </div>


### PR DESCRIPTION
- Changed the title to a link under the Build Apps and Write Code sections.
- Removed the View link at the bottom of the card
- Added cards in the sections under Connect Datasource in the landing page.

## Checklist
I have:
- [ ] run the content through Grammarly
- [ ] linked to sample apps when relevant
- [ ] added the meta description for each page in the PR
- [ ] minimized the callouts and added only when necessary
- [ ] added the `queryString` parameter to the Tabs (if used)
- [ ] masked PII in images. For example, login credentials, account details, and more
- [ ] added images only when necessary
- [ ] deleted the images that are no longer used for the updated pages in the PR
- [ ] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [ ] used the `<figure/>` tag instead of a markdown representation for images
- [ ] added the `<figcaption/>` tag to add a caption to the image
- [ ] added the `alt` attribute in the `<img/>` tag
- [ ] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [ ] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.