### PR TITLE
fix: Rehaul ansible installation guide

### DIFF
--- a/website/docs/getting-started/setup/installation-guides/ansible.md
+++ b/website/docs/getting-started/setup/installation-guides/ansible.md
@@ -51,9 +51,4 @@ This page provides instructions to install Appsmith on a remote host using Ansib
 
 ## Troubleshooting
 
-Some common errors that you may face during installation:
-* [Ports unavailable](/help-and-support/troubleshooting-guide/deployment-errors#ports-unavailable)
-* [Containers failed to restart](/help-and-support/troubleshooting-guide/deployment-errors#containers-failed-to-start)
-* [Unable to access Appsmith](/help-and-support/troubleshooting-guide/deployment-errors#unable-to-access-appsmith) 
-
-If you continue to face issues, contact the support team using the chat widget at the bottom right of this page.
+If you face issues, contact the support team using the chat widget at the bottom right of this page.

--- a/website/docs/getting-started/setup/installation-guides/ansible.md
+++ b/website/docs/getting-started/setup/installation-guides/ansible.md
@@ -16,7 +16,7 @@ This page provides instructions to install Appsmith on a remote host using Ansib
     ```bash
     git clone https://github.com/appsmithorg/appsmith.git
     ```
-    This command clones the `appsmith` repository into a folder (`appsmith`) that serves as your installation directory.
+    The above command copies the `appsmith` repository into a `appsmith` folder, which serves as your installation directory.
 
 2. Go to the _ansible_playbook_ folder:
     ```bash
@@ -26,28 +26,28 @@ This page provides instructions to install Appsmith on a remote host using Ansib
     ```bash
     touch inventory
     ```
-    An Ansible inventory file defines the list of target hosts you want to manage with Ansible.
+    An Ansible inventory file specifies the target hosts you want to manage with Ansible.
 
 4.  Open the `inventory` file and add the server details on which you want to deploy Appsmith:
-    * If you are using an SSH key pair for authenticating your server then add the hostname or Fully Qualified Domain Name (FQDN), port, and the SSH Key in the below format:
+    * If you are using an SSH key pair for authenticating your server, then add the hostname or Fully Qualified Domain Name (FQDN), port, and the SSH Key in the below format:
         ```txt
         appsmith ansible_host=<SERVER_HOST> ansible_port=<SERVER_PORT> ansible_user=<SERVER_USER> ansible_ssh_private_key_file=<PATH_TO_SSH_PRIVATE_KEY_FILE>
         ```
-    * **Or** if you are using a username to log into your server then add the hostname or Fully Qualified Domain Name (FQDN), port, and username in the below format:
+    * **Or** if you are using a username to log into your server, then add the hostname or Fully Qualified Domain Name (FQDN), port, and username in the below format:
         ```txt
         appsmith ansible_host=<SERVER_HOST> ansible_port=<SERVER_PORT> ansible_user=<SERVER_USER>
         ```
 5. Run the Ansible playbook with:
 
-   If your default installation folder is not `appsmith` then add the absolute path of your installation folder to the `install_dir` property in the `appsmith-vars.yml` file.
+   If your default installation folder is not `appsmith`, then add the absolute path of your installation folder to the `install_dir` property in the `appsmith-vars.yml` file.
 
     ```bash
     ansible-playbook -i inventory appsmith-playbook.yml --extra-vars "@appsmith-vars.yml"
     ```
 
-    The command above uses the host information from the `inventory` file & reads the configuration variables from `appsmith-vars.yml` before running the playbook.
+    The command above uses the host information from the `inventory` file and the configuration from the `appsmith-vars.yml` file before running the playbook.
 
-6. Access Appsmith using your custom domain or host. You will see a _Please wait_ screen while the server is initializing, which may take up to 5 minutes. Once the server is up and running, you can access Appsmith using your custom domain or host.
+6. Access Appsmith using your custom domain or host. You will see a _Please wait_ screen while the server is starting, which may take up to 5 minutes. Once the server is up and running, you can access Appsmith using your custom domain or host.
 
 ## Troubleshooting
 

--- a/website/docs/getting-started/setup/installation-guides/ansible.md
+++ b/website/docs/getting-started/setup/installation-guides/ansible.md
@@ -1,87 +1,59 @@
 ---
-description: Deploy Appsmith to a remote host using Ansible
+description: This page provides instructions to deploy Appsmith on a remote host using Ansible.
 ---
 
 # Ansible
 
-## Deployment steps:
+This page provides instructions to install Appsmith on a remote host using Ansible.
 
-* [Install Ansible](ansible.md#step-1-install-ansible)
-* [Ansible inventory setup](ansible.md#step-2-ansible-inventory-setup)
-* [Ansible configuration vars setup for Appsmith](ansible.md#step-3-ansible-configuration-vars-setup-for-appsmith)
-* [Run the Ansible playbook](ansible.md#step-4-run-the-ansible-playbook)
+## Prerequisites
+* Install Ansible on your local machine. See the official Ansible documentation for your [operating system](https://docs.ansible.com/ansible/latest/installation_guide/installation_distros.html#installing-ansible-on-specific-operating-systems).
+* An Ubuntu server for hosting.
 
-## Step 1: Install Ansible
+## Install Appsmith
 
-> You can skip this step if you already have Ansible installed.
-
-There are two options for installing Ansible:
-
-* Option 1: Using OS-specific Package Managers.
-  *   To install on Ubuntu, you can run the following commands:
-
-      ```
-      $ sudo apt update
-      $ sudo apt install software-properties-common
-      $ sudo add-apt-repository --yes --update ppa:ansible/ansible
-      $ sudo apt install ansible
-      ```
-  * Please refer to [Ansible's official installation guide](https://docs.ansible.com/ansible/latest/installation\_guide/intro\_installation.html#installing-ansible-on-specific-operating-systems) for other operating systems.
-*   Option 2: Using `pip`:
-
+1. Clone the Appsmith repository to your machine with:
+    ```bash
+    git clone https://github.com/appsmithorg/appsmith.git
     ```
-    $ sudo pip install ansible
+    This command clones the `appsmith` repository into a folder (`appsmith`) that serves as your installation directory.
+
+2. Go to the _ansible_playbook_ folder:
+    ```bash
+    cd appsmith/deploy/ansible/appsmith_playbook
     ```
-
-    * If you do not have pip installed on your system, please refer to [Ansible's official guide on installing with pip.](https://docs.ansible.com/ansible/latest/installation\_guide/intro\_installation.html#installing-and-upgrading-ansible-with-pip)
-
-## Step 2: Ansible inventory setup
-
-1.  Clone the Appsmith repository to your machine & move it to the Ansible playbook folder.
-
+3.  Create an Ansible inventory file with:
+    ```bash
+    touch inventory
     ```
-    $ git clone https://github.com/appsmithorg/appsmith.git
-    $ cd ./appsmith/deploy/ansible/appsmith_playbook
-    ```
-2.  Create the `inventory` file.
+    An Ansible inventory file defines the list of target hosts you want to manage with Ansible.
 
-    ```
-        $ touch inventory
-    ```
-3.  To configure the `inventory` file, open it with your editor and add the hostname or FQDN of the server on which you want to deploy Appsmith, along with the Ansible port and Ansible user.
+4.  Open the `inventory` file and add the server details on which you want to deploy Appsmith:
+    * If you are using an SSH key pair for authenticating your server then add the hostname or Fully Qualified Domain Name (FQDN), port, and the SSH Key in the below format:
+        ```txt
+        appsmith ansible_host=<SERVER_HOST> ansible_port=<SERVER_PORT> ansible_user=<SERVER_USER> ansible_ssh_private_key_file=<PATH_TO_SSH_PRIVATE_KEY_FILE>
+        ```
+    * **Or** if you are using a username to log into your server then add the hostname or Fully Qualified Domain Name (FQDN), port, and username in the below format:
+        ```txt
+        appsmith ansible_host=<SERVER_HOST> ansible_port=<SERVER_PORT> ansible_user=<SERVER_USER>
+        ```
+5. Run the Ansible playbook with:
 
-    The inventory file should follow the given format:
+   If your default installation folder is not `appsmith` then add the absolute path of your installation folder to the `install_dir` property in the `appsmith-vars.yml` file.
 
-    ```
-    appsmith ansible_host={{ SERVER_HOST }} ansible_port={{ SERVER_PORT }} ansible_user={{ SERVER_USER }}
+    ```bash
+    ansible-playbook -i inventory appsmith-playbook.yml --extra-vars "@appsmith-vars.yml"
     ```
 
-    If you are using SSH key pairs for authenticating your SSH connections to your server. You can specify your ssh private key file in the `inventory` file using `ansible_ssh_private_key_file`
+    The command above uses the host information from the `inventory` file & reads the configuration variables from `appsmith-vars.yml` before running the playbook.
 
-    ```
-    appsmith ansible_host={{ SERVER_HOST }} ansible_port={{ SERVER_PORT }} ansible_user={{ SERVER_USER }} ansible_ssh_private_key_file={{ SSH_PRIVATE_KEY_FILE }}
-    ```
-
-## Step 3: Ansible configuration vars setup for Appsmith
-
-1. Open `appsmith-vars.yml` file with your editor.<br/>
-Some variables need input from you to start the application correctly.
-   * `install_dir`: The absolute path of your app's installation folder on the server (required). Default value: `~/appsmith`
-
-## Step 4: Run the Ansible playbook
-
-You can run the Ansible playbook with the following command:
-
-```
-$ ansible-playbook -i inventory appsmith-playbook.yml --extra-vars "@appsmith-vars.yml"
-```
-
-The command above uses the host information from the `inventory` file & feeds your configuration vars from `appsmith-vars.yml` before running the playbook
-
-When it's all done, provided all went well and no parameters were changed, you should be able to visit your app on the browser using your `custom_domain` or by your `SERVER_HOST` (if you didn't provide value for `custom_domain` variable)
-
-> **Note**: You can put your `inventory` file in other folder and then specify its path with the `-i` flag, for more detail, please check [Ansible Inventory documentation](https://docs.ansible.com/ansible/latest/user\_guide/intro\_inventory.html)
+6. Access Appsmith using your custom domain or host. You will see a _Please wait_ screen while the server is initializing, which may take up to 5 minutes. Once the server is up and running, you can access Appsmith using your custom domain or host.
 
 ## Troubleshooting
 
-If you encounter any errors during this process, check out the guide on [debugging deployment errors](/help-and-support/troubleshooting-guide/deployment-errors), if you are still facing an issue please reach out to [support@appsmith.com](mailto:support@appsmith.com)
+Some common errors that you may face during installation:
+* [Ports unavailable](/help-and-support/troubleshooting-guide/deployment-errors#ports-unavailable)
+* [Containers failed to restart](/help-and-support/troubleshooting-guide/deployment-errors#containers-failed-to-start)
+* [Unable to access Appsmith](/help-and-support/troubleshooting-guide/deployment-errors#unable-to-access-appsmith) 
+
+If you continue to face issues, contact the support team using the chat widget at the bottom right of this page.

--- a/website/docs/getting-started/setup/installation-guides/ansible.md
+++ b/website/docs/getting-started/setup/installation-guides/ansible.md
@@ -28,7 +28,7 @@ This page provides instructions to install Appsmith on a remote host using Ansib
     ```
     An Ansible inventory file specifies the target hosts you want to manage with Ansible.
 
-4.  Open the `inventory` file and add the server details on which you want to deploy Appsmith:
+4.  Open the `inventory` file and add the server details:
     * If you are using an SSH key pair for authenticating your server, then add the hostname or Fully Qualified Domain Name (FQDN), port, and the SSH Key in the below format:
         ```txt
         appsmith ansible_host=<SERVER_HOST> ansible_port=<SERVER_PORT> ansible_user=<SERVER_USER> ansible_ssh_private_key_file=<PATH_TO_SSH_PRIVATE_KEY_FILE>

--- a/website/docs/getting-started/setup/installation-guides/google-cloud-run.mdx
+++ b/website/docs/getting-started/setup/installation-guides/google-cloud-run.mdx
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 # Google Cloud Run
 
-This page provides steps to install Appsmith Appsmith on Google Cloud Run.
+This page provides steps to install Appsmith on Google Cloud Run.
 
 ## Prerequisites
 

--- a/website/docs/getting-started/setup/installation-guides/google-cloud-run.mdx
+++ b/website/docs/getting-started/setup/installation-guides/google-cloud-run.mdx
@@ -7,7 +7,8 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 # Google Cloud Run
-This guide shows you how to deploy Appsmith on Google Cloud Run.
+
+This page provides steps to install Appsmith Appsmith on Google Cloud Run.
 
 ## Prerequisites
 
@@ -61,74 +62,9 @@ This guide shows you how to deploy Appsmith on Google Cloud Run.
 
 7. Click **Create**. A green check mark will appear next to the connector's name when it is ready to use.
 
+## Install Appsmith
 
-## Deploy Appsmith on Cloud Run
-
-<Tabs queryString="current-edition">
-<TabItem label="Community Edition" value="community_edition">
-
-This section shows how to install Appsmith on the Community edition. If you want to install Appsmith on the Business edition, see [Business Edition](?current-edition=business_edition).
-
-1. Go to [Cloud Run](https://console.cloud.google.com/run).
-
-2. Click **Create service**.
-
-3. In the form, select **Deploy one revision from an existing container image**.
-    - In the **Container image URL** box, enter `docker.io/appsmith/appsmith-ce`.
-
-4. Enter a desired name in the **Service name** field.
-
-5. Set **CPU allocation and pricing** to **CPU is always allocated**.
-
-6. Under **Autoscaling**:
-    - Set **Minimum number of instances** to `1`.
-    - Select **All** to allow direct access to your service from the Internet.
-
-7. Under **Authentication**, select **Allow unauthenticated invocations**.
-
-8. Click **Container, Networking, Security** to expand the service configuration page.
-
-9. Click the **Container** tab.
-    - In the **Container port** box, enter `80` to specify the port you want requests to be sent to.
-    - Under **Capacity**:
-        - Set the memory size to **4 GiB** in the **Memory** dropdown list. 
-        - Set the CPU limit as **2** in the **CPU** dropdown list.
-    - Under **Execution environment**, select **Second generation**.
-    - Under **Environment variables**, click **Add Variable** to add each variable in the **Name** and **Value** text boxes as shown below: <br/>
-
-    | Name | Value |
-    |------------------------|------------------------------------------| 
-    | **FILESTORE_IP_ADDRESS** | The IP address you noted down in step 4 of [Create a Filestore instance](#create-a-filestore-instance). |
-    | **FILE_SHARE_NAME** | The file share name you noted down in step 4 of [Create a Filestore instance](#create-a-filestore-instance). |
-    | **APPSMITH_MONGODB_URI** | Specify the connection string of the external MongoDB instance required for Appsmith data storage. <br/><br/> <i>Format</i>: <br/>`mongodb://<USERNAME>:<PASSWORD>@<HOST>:<PORT>/?authSource=<DATABASE_NAME>&replicaSet=<REPLICA_SET_NAME>[&options]`|
-    | **APPSMITH_ENCRYPTION_SALT** | Specify an encryption salt to encrypt values in the database.|
-    | **APPSMITH_ENCRYPTION_PASSWORD** | Specify an encryption password to encrypt values in the database.|
-    | **owner** | `appsmith`|
-    | **APPSMITH_ENABLE_EMBEDDED_DB** |`0`|
-
-10. Click the **Networking** tab.
-    - In the **VPC Network** field, choose the name of the *Serverless VPC Access connector* you created in the preceding [section](#create-a-serverless-vpc-access-connector).
-    - Keep the default **Route only requests to private IPs through the VPC connector** option.
-
-11. Click the **Security** tab. Note that Cloud Run services or jobs run as the **Compute Engine default service account**.
-
-12. Click the **Create** button at the bottom of the page to deploy the image to Cloud Run and wait for the deployment to finish. A green check mark will appear next to the deployed service name when it is ready.
-
-13. Click the **Logs** tab to verify everything works fine. Click the open icon to the right of the screen to open the **Logs Explorer**. Wait a few minutes until you see the message `Appsmith is running` in the logs. 
-
-14. Click the displayed URL link to open the unique and stable endpoint of the Appsmith instance.
-
-<figure>
-  <img src="/img/deply-gcp-community.png" style= {{width:"100%", height:"auto"}} alt="URL of Appsmith deployed on Cloud Run"/>
-  <figcaption align = "center"><i>URL of Appsmith deployed on Cloud Run</i></figcaption>
-</figure>
-
-15. Enter the details on the signup form to create an Appsmith account.
-    
-</TabItem>
-<TabItem label="Business Edition" value="business_edition">
-
-This section shows how to install Appsmith on the Business edition. If you want to install Appsmith on the Community edition, see [Community Edition](?current-edition=community_edition).
+Follow these steps to install Appsmith on Cloud Run:
 
 ### Assign roles to account
 
@@ -308,7 +244,69 @@ This guide is optional, and you can skip to [Create Service](#create-service). F
   <figcaption align = "center"><i>URL of Appsmith deployed on Cloud Run</i></figcaption>
 </figure>
 
-15. Sign up on [customer.appsmith.com](https://customer.appsmith.com/) and generate a trial license key. Enter your license key to activate the instance.
+15. Fill in your details to create an administrator account.
+
+16. Once you've created an account, you can either start with the free plan or activate your instance with a license key. If you want to generate a license key, sign up on [customer.appsmith.com](https://customer.appsmith.com) to create one, and then proceed to activate your instance using the newly generated license key.
+
+## Install Appsmith Community
+
+Follow these steps to install Appsmith open source (Community) on Cloud Run:
+
+1. Go to [Cloud Run](https://console.cloud.google.com/run).
+
+2. Click **Create service**.
+
+3. In the form, select **Deploy one revision from an existing container image**.
+    - In the **Container image URL** box, enter `docker.io/appsmith/appsmith-ce`.
+
+4. Enter a desired name in the **Service name** field.
+
+5. Set **CPU allocation and pricing** to **CPU is always allocated**.
+
+6. Under **Autoscaling**:
+    - Set **Minimum number of instances** to `1`.
+    - Select **All** to allow direct access to your service from the Internet.
+
+7. Under **Authentication**, select **Allow unauthenticated invocations**.
+
+8. Click **Container, Networking, Security** to expand the service configuration page.
+
+9. Click the **Container** tab.
+    - In the **Container port** box, enter `80` to specify the port you want requests to be sent to.
+    - Under **Capacity**:
+        - Set the memory size to **4 GiB** in the **Memory** dropdown list. 
+        - Set the CPU limit as **2** in the **CPU** dropdown list.
+    - Under **Execution environment**, select **Second generation**.
+    - Under **Environment variables**, click **Add Variable** to add each variable in the **Name** and **Value** text boxes as shown below: <br/>
+
+    | Name | Value |
+    |------------------------|------------------------------------------| 
+    | **FILESTORE_IP_ADDRESS** | The IP address you noted down in step 4 of [Create a Filestore instance](#create-a-filestore-instance). |
+    | **FILE_SHARE_NAME** | The file share name you noted down in step 4 of [Create a Filestore instance](#create-a-filestore-instance). |
+    | **APPSMITH_MONGODB_URI** | Specify the connection string of the external MongoDB instance required for Appsmith data storage. <br/><br/> <i>Format</i>: <br/>`mongodb://<USERNAME>:<PASSWORD>@<HOST>:<PORT>/?authSource=<DATABASE_NAME>&replicaSet=<REPLICA_SET_NAME>[&options]`|
+    | **APPSMITH_ENCRYPTION_SALT** | Specify an encryption salt to encrypt values in the database.|
+    | **APPSMITH_ENCRYPTION_PASSWORD** | Specify an encryption password to encrypt values in the database.|
+    | **owner** | `appsmith`|
+    | **APPSMITH_ENABLE_EMBEDDED_DB** |`0`|
+
+10. Click the **Networking** tab.
+    - In the **VPC Network** field, choose the name of the *Serverless VPC Access connector* you created in the preceding [section](#create-a-serverless-vpc-access-connector).
+    - Keep the default **Route only requests to private IPs through the VPC connector** option.
+
+11. Click the **Security** tab. Note that Cloud Run services or jobs run as the **Compute Engine default service account**.
+
+12. Click the **Create** button at the bottom of the page to deploy the image to Cloud Run and wait for the deployment to finish. A green check mark will appear next to the deployed service name when it is ready.
+
+13. Click the **Logs** tab to verify everything works fine. Click the open icon to the right of the screen to open the **Logs Explorer**. Wait a few minutes until you see the message `Appsmith is running` in the logs. 
+
+14. Click the displayed URL link to open the unique and stable endpoint of the Appsmith instance.
+
+<figure>
+  <img src="/img/deply-gcp-community.png" style= {{width:"100%", height:"auto"}} alt="URL of Appsmith deployed on Cloud Run"/>
+  <figcaption align = "center"><i>URL of Appsmith deployed on Cloud Run</i></figcaption>
+</figure>
+
+15. Enter the details on the signup form to create an Appsmith account.
 
 ### Manage traffic between revisions
 
@@ -331,8 +329,6 @@ Follow the steps below if you have created a Redis instance in the steps above t
   <figcaption align = "center"><i>Manage traffic between revisions</i></figcaption>
 </figure>
 
-</TabItem>
-</Tabs>
 
 ## See also
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -79,9 +79,7 @@ const sidebars = {
                 'getting-started/setup/installation-guides/google-cloud-run',
                 'getting-started/setup/installation-guides/digitalocean',
                 'getting-started/setup/installation-guides/heroku',
-                'getting-started/setup/installation-guides/cloudjiffy',
                 'getting-started/setup/installation-guides/ansible',
-                'getting-started/setup/installation-guides/restack',
               ],
             },
             {

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,6 +1,6 @@
 {
   "cleanUrls": true,
-  "trailingSlash" : false,
+  "trailingSlash": false,
   "redirects": [
     {
       "source": "/v/:path*",
@@ -310,7 +310,7 @@
       "source": "/core-concepts/capturing-data-write/capture-form-data",
       "destination": "/core-concepts/data-access-and-binding/capturing-data-write/capture-form-data"
     },
-   {
+    {
       "source": "/core-concepts/designing-an-application",
       "destination": "/core-concepts/building-ui/designing-an-application"
     },
@@ -821,7 +821,7 @@
     {
       "source": "/reference/datasources/querying-elasticsearch",
       "destination": "/connect-data/reference/querying-elasticsearch"
-    }, 
+    },
     {
       "source": "/reference/datasources/querying-firestore",
       "destination": "/connect-data/reference/querying-firestore"
@@ -866,7 +866,6 @@
       "source": "/reference/datasources/querying-redis",
       "destination": "/connect-data/reference/querying-redis"
     },
-
     {
       "source": "/reference/datasources/querying-redshift",
       "destination": "/connect-data/reference/querying-redshift"
@@ -891,7 +890,6 @@
       "source": "/learning-and-resources/how-to-guides/how-to-upload-to-s3",
       "destination": "/connect-data/how-to-guides/how-to-upload-to-s3"
     },
-
     {
       "source": "/learning-and-resources/how-to-guides/how-to-use-the-camera-image-widget-to-upload-download-images",
       "destination": "/connect-data/how-to-guides/how-to-use-the-camera-image-widget-to-upload-download-images"
@@ -970,7 +968,7 @@
     },
     {
       "source": "/advanced-co",
-      "destination": "/advanced-concepts"   
+      "destination": "/advanced-concepts"
     },
     {
       "source": "/core-concepts/application-layout",
@@ -1028,12 +1026,10 @@
       "source": "../data-access-and-binding/querying-a-database",
       "destination": "/connect-data/how-to-guides/query-data"
     },
-  
     {
       "source": "/core-concepts/data-access-and-binding",
       "destination": "/build-apps/overview"
     },
-  
     {
       "source": "/core-concepts/building-ui/designing-an-application",
       "destination": "/build-apps/overview"
@@ -1042,7 +1038,6 @@
       "source": "/core-concepts/building-ui",
       "destination": "/build-apps/overview"
     },
-  
     {
       "source": "/core-concepts/building-ui/dynamic-ui/widget-visibility",
       "destination": "/reference/widgets"
@@ -1051,12 +1046,10 @@
       "source": "/core-concepts/data-access-and-binding/displaying-data-read",
       "destination": "/build-apps/overview"
     },
-  
     {
       "source": "/core-concepts/data-access-and-binding/capturing-data-write",
       "destination": "/build-apps/overview"
     },
-  
     {
       "source": "/core-concepts/data-access-and-binding/capturing-data-write/capture-form-data",
       "destination": "/reference/widgets/form"
@@ -1068,6 +1061,14 @@
     {
       "source": "/reference/appsmith-framework",
       "destination": "/write-code/reference"
+    },
+    {
+      "source": "/getting-started/setup/installation-guides/cloudjiffy",
+      "destination": "https://cloudjiffy.com/blog/solutions/one-click-solutions/install-appsmith-in-cloudjiffy-with-one-click/"
+    },
+    {
+      "source": "/getting-started/setup/installation-guides/restack",
+      "destination": "https://www.restack.io/docs/deploy-appsmith-on-kubernetes"
     }
   ]
 }


### PR DESCRIPTION
# Changes
* Updated doc structure 
* Rewritten the instructions
* Removed CloudJiffy and Restack from sidebar
* Added redirect rules for CloudJiffy and Restack

# Doc Ticket
Fixes #1743 

## Checklist
I have:
- [x] run the content through Grammarly
- [ ] linked to sample apps when relevant
- [x] added the meta description for each page in the PR
- [ ] minimized the callouts and added only when necessary
- [ ] added the `queryString` parameter to the Tabs (if used)
- [ ] masked PII in images. For example, login credentials, account details, and more
- [ ] added images only when necessary
- [ ] deleted the images that are no longer used for the updated pages in the PR
- [ ] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [ ] used the `<figure/>` tag instead of a markdown representation for images
- [ ] added the `<figcaption/>` tag to add a caption to the image
- [ ] added the `alt` attribute in the `<img/>` tag
- [x] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [ ] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.