### PR TITLE
fix: Use http scheme in the community installation guide using docker

### DIFF
--- a/website/docs/getting-started/setup/installation-guides/docker/README.mdx
+++ b/website/docs/getting-started/setup/installation-guides/docker/README.mdx
@@ -35,7 +35,7 @@ This command saves the file in the current directory.
    ```
 If the image doesn't exist locally, this command downloads the necessary Docker image and starts the container.
 
-3. Open [https://localhost](https://localhost) and wait for the server to come up. This can take up to 5 minutes. Once the server is up and running, you can access Appsmith at [https://localhost](https://localhost).
+3. Open [http://localhost](http://localhost) and wait for the server to come up. This can take up to 5 minutes. Once the server is up and running, you can access Appsmith at [http://localhost](http://localhost).
 
 </TabItem>
 <TabItem label="Business Edition" value="business_edition">


### PR DESCRIPTION
## Checklist
I have:
- [x] run the content through Grammarly
- [x] linked to sample apps when relevant
- [x] added the meta description for each page in the PR
- [x] minimized the callouts and added only when necessary
- [x] added the `queryString` parameter to the Tabs (if used)
- [x] masked PII in images. For example, login credentials, account details, and more
- [x] added images only when necessary
- [x] deleted the images that are no longer used for the updated pages in the PR
- [x] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [x] used the `<figure/>` tag instead of a markdown representation for images
- [x] added the `<figcaption/>` tag to add a caption to the image
- [x] added the `alt` attribute in the `<img/>` tag
- [x] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [x] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.