### PR TITLE
Table server side filtering changes

### DIFF
--- a/website/docs/reference/widgets/table/README.md
+++ b/website/docs/reference/widgets/table/README.md
@@ -189,6 +189,23 @@ Determines the search behavior of the search bar in the table header. When enabl
 
 </dd>
 
+#### Server side filtering `boolean`
+
+<dd>
+
+Determines the filter behavior of the filter panel in the table header. When enabled, after the filters are applied the event onTableFilterUpdate will be triggered, which can be used to filter the table's data by passing the reference property <tableName>.filters in the query to filter data. When disabled, the applied filters will only filter records currently loaded in the table.
+
+</dd>
+
+#### onTableFilterUpdate
+
+<dd>
+
+Allows you to specify the action to be executed when the user applies or clears filters in the filters panel of the table widget.
+
+</dd>
+
+
 #### Default search text `string`
 
 <dd>
@@ -810,6 +827,22 @@ Refers to an array of indices corresponding to the rows that have been updated.
 {{Table1.updatedRowIndices}}
 ```
 </dd>
+
+#### filters `array`
+
+<dd>
+
+Refers to an array of filters applied on the table along with the conditions of each filter. 
+
+*Example:*
+
+
+```js
+{{Table1.filters}}
+```
+</dd>
+
+
 
 ## Methods
 


### PR DESCRIPTION
Table widget now supports an early version of server side filtering, which can be then used to filter records from the server by using the existing filter functionality provided in tables. Solves #1783 

## Checklist
I have:
- [ ] run the content through Grammarly
- [ ] linked to sample apps when relevant
- [ ] added the meta description for each page in the PR
- [ ] minimized the callouts and added only when necessary
- [ ] added the `queryString` parameter to the Tabs (if used)
- [ ] masked PII in images. For example, login credentials, account details, and more
- [ ] added images only when necessary
- [ ] deleted the images that are no longer used for the updated pages in the PR
- [ ] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [ ] used the `<figure/>` tag instead of a markdown representation for images
- [ ] added the `<figcaption/>` tag to add a caption to the image
- [ ] added the `alt` attribute in the `<img/>` tag
- [ ] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [ ] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.