### PR TITLE
fix: Download files from S3

### DIFF
--- a/website/docs/connect-data/how-to-guides/download-files-from-s3.md
+++ b/website/docs/connect-data/how-to-guides/download-files-from-s3.md
@@ -1,34 +1,64 @@
 # Download Files from S3 
 
+This page shows you steps to download a file from an S3 datasource.
 
-To download a file
+## Prerequisites
 
-1. Drag a Table onto the canvas and name it **s3\_files.**
-2. Create a new S3 query named **`fetch\_files`** to fetch all the files in your bucket.
-   * Configure it with the [List Files](/connect-data/reference/querying-amazon-s3#list-files) action.
-   * Set the bucket name from where to fetch the files and run the query
-   *   Bind the response of the query to the Table using JavaScript in the Table Data Property `{{fetch_files.data}}`.
+- An [Amazon S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html) in one of the AWS Regions.
+- App connected to [S3](https://docs.appsmith.com/connect-data/reference/querying-amazon-s3) datasource.
+- A [Table](https://docs.appsmith.com/reference/widgets/table) widget to bind data and download files.
 
-       Now your table should list all the files present in your S3 bucket.
+## Configure query to fetch files
 
-![Click to expand](/img/bind-list-files-to-table.png)
+To configure the S3 query to fetch all the files from a bucket, follow these steps:
 
-1. Create a new S3 query named **read\_file** to read file data from S3 bucket.
-   * Configure it with the [Read File](/connect-data/reference/querying-amazon-s3#read-file) action.
-   * Set the bucket name from where to fetch the file
-   * Set `path` to the file path selected in the table using the JS expression `{{s3_files.selectedRow.fileName}}`
+1. In **Queries/JS**, click the **+ Add a new query/JS Object** and rename it to `list_files`.
+2. Select your S3 datasource.
+3. Select [List files in bucket](https://docs.appsmith.com/connect-data/reference/querying-amazon-s3#list-files-in-bucket) from **Commands.**
+4. In **Generate signed URL**, select **Yes**.
 
-![Click to expand](/img/s3-read-file-query.png)
+## Configure query to read a file
 
-1.  To download the file selected in the table
+To configure the S3 query to read a file corresponding to a selected row, follow these steps:
 
-    *   Click the `JS` button next to `onRowSelected` Action and write the
+1. In **Queries/JS**, click the **+ Add a new query/JS Object** and rename it to `read_files`.
+2. Select your S3 datasource.
+3. Select [Read file](https://docs.appsmith.com/connect-data/reference/querying-amazon-s3#read-file) from **Commands.**
+4. In **File path**, enter the path of the file to read the data. You can set this to the file path selected in the table using the JS expression `{{s3_files_details.selectedRow.filePath}}` where `s3_files_details` is the name of the Table widget.
+5. In **Base64 encode file**, select **Yes** to encode the incoming file data to Base64 format. To decode the file content, use the [JavaScript `atob()` method](https://developer.mozilla.org/en-US/docs/Web/API/atob).
 
-        following JavaScript query:
+## Configure the Table widget to download a file
 
-    ```javascript
-    {{read_file.run(
-    ()=>{download(atob(read_file.data.fileData),s3_files.selectedRow.fileName.split("/").pop())})}}
-    ```
+To bind the data from the S3 query to the Table widget, and download them, follow these steps:
 
-    * Click any row in table `s3_files` to download the corresponding file from your S3 bucket.
+1. Configure the [Table data](https://docs.appsmith.com/reference/widgets/table#table-data-arrayobject) property of the widget to bind the response of the `list_files` query using  `{{list_files.data}}`.
+2. You can download files using the following:
+   - Object
+   - URL
+   
+   ### Download using object
+   Set the widget's [onRowSelected](https://docs.appsmith.com/reference/widgets/table#onrowselected) event to read and download a file corresponding to a selected row by pasting the following code:
+
+      Base64 encoded file:
+      ```jsx
+      {{read_file.run(
+      ()=>{download(atob(read_file.data.fileData),s3_files_details.selectedRow.fileName.split("/").pop())})}}
+      ```
+
+      File with no encoding:
+
+      ```jsx
+      {{read_file.run(
+      ()=>{download(read_file.data.fileData),s3_files_details.selectedRow.fileName.split("/").pop()})}}
+      ```
+
+   ### Download using URL
+   Set the widget's [onRowSelected](https://docs.appsmith.com/reference/widgets/table#onrowselected) event to read and download a file corresponding to a selected row by pasting the following code:
+
+   ```jsx
+   {{download(s3_files_details.selectedRow.signedUrl,s3_files_details.selectedRow.fileName.split("/").pop())}}}
+   ```
+
+   Make sure the server from which the file is retrieved is CORS-enabled and returns the required headers. To prevent download blocks, files must be served over HTTPS.
+
+3. To test the download, click on any row on the table.


### PR DESCRIPTION
## Checklist
I have:
- [ ] run the content through Grammarly
- [ ] linked to sample apps when relevant
- [ ] added the meta description for each page in the PR
- [ ] minimized the callouts and added only when necessary
- [ ] added the `queryString` parameter to the Tabs (if used)
- [ ] masked PII in images. For example, login credentials, account details, and more
- [ ] added images only when necessary
- [ ] deleted the images that are no longer used for the updated pages in the PR
- [ ] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [ ] used the `<figure/>` tag instead of a markdown representation for images
- [ ] added the `<figcaption/>` tag to add a caption to the image
- [ ] added the `alt` attribute in the `<img/>` tag
- [ ] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [ ] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.