### PR TITLE
fix: Added card for S3 file download on landing page

### DIFF
--- a/website/docs/connect-data/how-to-guides/README.md
+++ b/website/docs/connect-data/how-to-guides/README.md
@@ -38,14 +38,23 @@
 </div>
 
 <div class="containerGridSampleApp">
-  <div class="containerColumnSampleApp columnGrid column-one">
+ <div class="containerColumnSampleApp columnGrid column-one">
+        <div class="containerCol">
+            <a href="/connect-data/how-to-guides/download-files-from-s3"><strong>Download Files from S3 </strong></a>
+        </div><hr/>
+        <div class="containerDescription">Shows you how to download a file from an S3 datasource. </div>
+    </div>
+  <div class="containerColumnSampleApp columnGrid column-two">
         <div class="containerCol">
             <a href="/connect-data/how-to-guides/how-to-integrate-dropbox"><strong>Upload Files to Dropbox</strong></a>
         </div> <hr/>
         <div class="containerDescription">Shows you how to configure an Authenticated API datasource for Dropbox with OAuth 2.0 and create a query that uploads a file to Dropbox from your Appsmith app.</div>
         <div class="containerTutorialLink"></div>
     </div>
-    <div class="containerColumnSampleApp columnGrid column-two">
+</div>
+
+<div class="containerGridSampleApp">
+<div class="containerColumnSampleApp columnGrid column-one">
         <div class="containerCol">
            <a href="/connect-data/how-to-guides/how-to-integrate-zoho"><strong>Create Campaigns with Zoho</strong></a>
         </div><hr/>
@@ -53,16 +62,11 @@
          <div class="containerTutorialLink">
          </div>
     </div>
-</div>
-
-<div class="containerGridSampleApp">
-  <div class="containerColumnSampleApp columnGrid column-one">
+  <div class="containerColumnSampleApp columnGrid column-two">
         <div class="containerCol">
             <a href="/connect-data/integrations"><strong>Integrate With Third-Party Tools</strong></a>
         </div> <hr/>
         <div class="containerDescription">Shows you how to connect Appsmith to many third-party tools via API.</div>
         <div class="containerTutorialLink"></div>
-    </div>
-     <div class="columnGrid column-two" style={{margin: "10px"}}>
     </div>
 </div>

--- a/website/docs/connect-data/how-to-guides/download-files-from-s3.md
+++ b/website/docs/connect-data/how-to-guides/download-files-from-s3.md
@@ -7,7 +7,7 @@ This page shows you steps to download a file from an S3 datasource.
 - An [Amazon S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html) in one of the AWS Regions.
 - App connected to [S3](https://docs.appsmith.com/connect-data/reference/querying-amazon-s3) datasource.
 - A [Table](https://docs.appsmith.com/reference/widgets/table) widget to bind data and download files.
-- Make sure the server from which the file is retrieved is CORS-enabled and returns the required headers. To prevent download blocks, files must be served over HTTPS.
+- Make sure the server from which the file is retrieved is CORS-enabled and returns the required headers. To prevent download blocks, files must be served over HTTPS. For instructions to add a CORS configuration to your S3 bucket, see [CORS configuration](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ManageCorsUsing.html).
 
 ## Download a file using the file URL
 
@@ -30,7 +30,7 @@ To configure the S3 query to fetch all the files from a bucket and download a fi
 
 To configure the S3 query to read a file corresponding to a selected row, follow these steps:
 
-1. In **Queries/JS**, click **+ Add a new query/JS Object** and rename it to `read_files`.
+1. In **Queries/JS**, click **+ Add a new query/JS Object** and rename it to `read_file`.
 2. Select your S3 datasource.
 3. Select [Read file](https://docs.appsmith.com/connect-data/reference/querying-amazon-s3#read-file) from **Commands.**
 4. In **File path**, enter the path of the file to read the data. You can set this to the file path corresponding to the selected row using the JS expression `{{s3_files_details.selectedRow.filePath}}` where `s3_files_details` is the name of the Table widget.


### PR DESCRIPTION
## Checklist
I have:
- [ ] run the content through Grammarly
- [ ] linked to sample apps when relevant
- [ ] added the meta description for each page in the PR
- [ ] minimized the callouts and added only when necessary
- [ ] added the `queryString` parameter to the Tabs (if used)
- [ ] masked PII in images. For example, login credentials, account details, and more
- [ ] added images only when necessary
- [ ] deleted the images that are no longer used for the updated pages in the PR
- [ ] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [ ] used the `<figure/>` tag instead of a markdown representation for images
- [ ] added the `<figcaption/>` tag to add a caption to the image
- [ ] added the `alt` attribute in the `<img/>` tag
- [ ] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [ ] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.