### PR TITLE
fix: Reference Sidebar

### DIFF
--- a/website/docs/connect-data/reference/overview.md
+++ b/website/docs/connect-data/reference/overview.md
@@ -1,0 +1,23 @@
+# Reference
+
+Technical descriptions and information about widgets and app settings.
+
+
+
+
+<div class="containerGridSampleApp">
+  <div class="containerColumnSampleApp columnGrid column-one">
+        <div class="containerCol">
+            <a href="/connect-data/reference"><strong>Datasource</strong></a>
+        </div> <hr/>
+        <div class="containerDescription">Appsmith offers plug-and-play support for many databases and the RESTful API interface for seamless integration with other tools. Appsmith supports the following databases and APIs.</div>
+    </div>
+    <div class="containerColumnSampleApp columnGrid column-two">
+        <div class="containerCol">
+           <a href="/connect-data/reference/query-settings"><strong>Query Settings</strong></a>
+        </div><hr/>
+        <div class="containerDescription">This page is a reference guide that provides a description of all the settings available for configuring your queries. </div>
+    </div>
+</div>
+
+

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -236,8 +236,16 @@ const sidebars = {
           ]
         },
         {
+          //Reference start
           type: 'category',
+          collapsed: false,
           label: 'Reference',
+          link: { type: 'doc', id: 'connect-data/reference/overview' },
+          items: [
+             {
+          type: 'category',
+          collapsed: true,
+          label: 'Datasources',
           link: { type: 'doc', id: 'connect-data/reference/README' },
           items: [
             'connect-data/reference/airtable',
@@ -272,9 +280,12 @@ const sidebars = {
             'connect-data/reference/querying-snowflake-db',
             'connect-data/reference/using-smtp',
             'connect-data/reference/twilio',
-            'connect-data/reference/query-settings',
+
           ],
         },
+        'connect-data/reference/query-settings',
+      ],
+    }, //Reference End
         {
           type: 'category',
           collapsed: true,
@@ -326,6 +337,7 @@ const sidebars = {
           //Reference start
           type: 'category',
           label: 'Reference',
+          collapsed: false,
           link: { type: 'doc', id: 'build-apps/reference/README' },
           items: [
             {


### PR DESCRIPTION
## Checklist
I have:
- [ ] run the content through Grammarly
- [ ] linked to sample apps when relevant
- [ ] added the meta description for each page in the PR
- [ ] minimized the callouts and added only when necessary
- [ ] added the `queryString` parameter to the Tabs (if used)
- [ ] masked PII in images. For example, login credentials, account details, and more
- [ ] added images only when necessary
- [ ] deleted the images that are no longer used for the updated pages in the PR
- [ ] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [ ] used the `<figure/>` tag instead of a markdown representation for images
- [ ] added the `<figcaption/>` tag to add a caption to the image
- [ ] added the `alt` attribute in the `<img/>` tag
- [ ] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [ ] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.