### PR TITLE
fix: MongoDB Connection String URI format

### DIFF
--- a/website/docs/connect-data/reference/querying-mongodb/README.md
+++ b/website/docs/connect-data/reference/querying-mongodb/README.md
@@ -46,7 +46,7 @@ The following section is a reference guide that provides a complete description 
 </code></pre></dd>
 <dd><i>Example:</i></dd>
 <dd><pre><code>
-  mongodb+srv://exampleDatabaseUser:D1fficultP%40ssw0rd@cluster0.example.mongodb.net/?retryWrites=true&w=majority
+  mongodb+srv://mockdb-admin:****@mockdb.kce5o.mongodb.net/movies?retryWrites=true&w=majority&authSource=admin
 </code></pre></dd>
 
 ---

--- a/website/docs/connect-data/reference/querying-mongodb/README.md
+++ b/website/docs/connect-data/reference/querying-mongodb/README.md
@@ -40,9 +40,13 @@ The following section is a reference guide that provides a complete description 
 #### Connection String URI
 
 <dd>A MongoDB connection string URI (Uniform Resource Identifier) is a standardized way to specify the location and other details of a MongoDB database. This field is visible only if you select <b>Yes</b> in the <b>Use Mongo Connection String URI</b> list. See <a href="https://www.mongodb.com/docs/manual/reference/connection-string/#connection-string-uri-format"><b>Connection String URI Format</b></a> for details on how to specify the MongoDB connection string.</dd><br />
+<dd>Use the following syntax to specify the MongoDB connection string:</dd>
+<dd><pre><code>
+   mongodb+srv://&lt;USERNAME&gt;:&lt;PASSWORD&gt;@&lt;HOST&gt;/&lt;DATABASE_NAME&gt;
+</code></pre></dd>
 <dd><i>Example:</i></dd>
 <dd><pre><code>
-  mongodb+srv://&lt;USERNAME&gt;:&lt;PASSWORD&gt;@&lt;HOST&gt;/&lt;DATABASE_NAME&gt;
+  mongodb+srv://exampleDatabaseUser:D1fficultP%40ssw0rd@cluster0.example.mongodb.net/?retryWrites=true&w=majority
 </code></pre></dd>
 
 ---

--- a/website/docs/connect-data/reference/querying-mongodb/README.md
+++ b/website/docs/connect-data/reference/querying-mongodb/README.md
@@ -42,7 +42,7 @@ The following section is a reference guide that provides a complete description 
 <dd>A MongoDB connection string URI (Uniform Resource Identifier) is a standardized way to specify the location and other details of a MongoDB database. This field is visible only if you select <b>Yes</b> in the <b>Use Mongo Connection String URI</b> list. See <a href="https://www.mongodb.com/docs/manual/reference/connection-string/#connection-string-uri-format"><b>Connection String URI Format</b></a> for details on how to specify the MongoDB connection string.</dd><br />
 <dd><i>Example:</i></dd>
 <dd><pre><code>
-  mongodb+srv://mockdb-admin:****@mockdb.kce5o.mongodb.net/movies?retryWrites=true&w=majority&authSource=admin
+  mongodb+srv://&lt;USERNAME&gt;:&lt;PASSWORD&gt;@&lt;HOST&gt;/&lt;DATABASE_NAME&gt;
 </code></pre></dd>
 
 ---


### PR DESCRIPTION
closes #1710 
## Checklist
I have:
- [ ] run the content through Grammarly
- [ ] linked to sample apps when relevant
- [ ] added the meta description for each page in the PR
- [ ] minimized the callouts and added only when necessary
- [ ] added the `queryString` parameter to the Tabs (if used)
- [ ] masked PII in images. For example, login credentials, account details, and more
- [ ] added images only when necessary
- [ ] deleted the images that are no longer used for the updated pages in the PR
- [ ] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [ ] used the `<figure/>` tag instead of a markdown representation for images
- [ ] added the `<figcaption/>` tag to add a caption to the image
- [ ] added the `alt` attribute in the `<img/>` tag
- [ ] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [ ] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.