### PR TITLE
fix: Remove Canvas Size page

### DIFF
--- a/website/docs/build-apps/reference/README.md
+++ b/website/docs/build-apps/reference/README.md
@@ -24,14 +24,3 @@ Technical descriptions and information about widgets and app settings.
 </div>
 
 
-<div class="containerGridSampleApp">
-    <div class="containerColumnSampleApp columnGrid column-one">
-        <div class="containerCol">
-                <a href="/core-concepts/building-ui/designing-an-application/application-layout"><strong>Canvas Size</strong></a>
-        </div> <hr/>
-        <div class="containerDescription">You can choose the application layout to align with the device size for which the app is intended. </div>
-    </div>
-     <div class="columnGrid column-two" style={{margin: "10px"}}>
-    </div>
-</div>
-

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -419,7 +419,6 @@ const sidebars = {
               ],
             },
             'core-concepts/building-ui/designing-an-application/app-theming',
-            'core-concepts/building-ui/designing-an-application/application-layout',
             'learning-and-resources/sample-apps'
           ],
         }, //Reference End

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1103,7 +1103,7 @@
       "destination": "/getting-started/setup/upgrade-to-business-edition/kubernetes"
     },
     {
-      "source": "core-concepts/building-ui/designing-an-application/application-layout",
+      "source": "/core-concepts/building-ui/designing-an-application/application-layout",
       "destination": "/build-apps/overview"
     }
   ]

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1101,6 +1101,10 @@
     {
       "source": "/getting-started/setup/upgrade-to-business-edition/upgrade-k8s-to-business-edition",
       "destination": "/getting-started/setup/upgrade-to-business-edition/kubernetes"
+    },
+    {
+      "source": "core-concepts/building-ui/designing-an-application/application-layout",
+      "destination": "/build-apps/overview"
     }
   ]
 }


### PR DESCRIPTION
## Checklist
I have:
- [ ] run the content through Grammarly
- [ ] linked to sample apps when relevant
- [ ] added the meta description for each page in the PR
- [ ] minimized the callouts and added only when necessary
- [ ] added the `queryString` parameter to the Tabs (if used)
- [ ] masked PII in images. For example, login credentials, account details, and more
- [ ] added images only when necessary
- [ ] deleted the images that are no longer used for the updated pages in the PR
- [ ] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [ ] used the `<figure/>` tag instead of a markdown representation for images
- [ ] added the `<figcaption/>` tag to add a caption to the image
- [ ] added the `alt` attribute in the `<img/>` tag
- [ ] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [ ] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.