### PR TITLE
fix: Enable map types property

### DIFF
--- a/website/docs/reference/widgets/maps.md
+++ b/website/docs/reference/widgets/maps.md
@@ -168,6 +168,14 @@ To access the searched location, use the ``center`` reference property. This ret
 
 </dd>
 
+#### Enable map types `boolean`
+
+<dd>
+
+When enabled, this property allows users to switch between the default map view and satellite view.
+
+</dd>
+
 ### Create marker
 
 #### Create new marker `boolean`


### PR DESCRIPTION
## Checklist
I have:
- [ ] run the content through Grammarly
- [ ] linked to sample apps when relevant
- [ ] added the meta description for each page in the PR
- [ ] minimized the callouts and added only when necessary
- [ ] added the `queryString` parameter to the Tabs (if used)
- [ ] masked PII in images. For example, login credentials, account details, and more
- [ ] added images only when necessary
- [ ] deleted the images that are no longer used for the updated pages in the PR
- [ ] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [ ] used the `<figure/>` tag instead of a markdown representation for images
- [ ] added the `<figcaption/>` tag to add a caption to the image
- [ ] added the `alt` attribute in the `<img/>` tag
- [ ] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [ ] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.