### PR TITLE
fix: link hash tags overlap

### DIFF
--- a/website/docs/advanced-concepts/invite-users.md
+++ b/website/docs/advanced-concepts/invite-users.md
@@ -49,7 +49,7 @@ The table below shows the permissions available for each role when you share a w
 
 <div className="tag-wrapper">
 
-## Share application## Share application
+## Share application
 
 <Tags
   tags={[

--- a/website/docs/advanced-concepts/version-control-with-git/environments-with-git.md
+++ b/website/docs/advanced-concepts/version-control-with-git/environments-with-git.md
@@ -15,7 +15,9 @@ Follow the steps below to setup the pipeline:
 
 <dd>
 
+:::info 
 If you are an enterprise user, you can choose a different branch as the default, offering customization based on specific project requirements or preferences. Learn more about [Default branch](/advanced-concepts/version-control-with-git/working-with-branches#default-branch).
+:::
 
 </dd>
 

--- a/website/docs/write-code/reference/Built-in-JS-Libraries.md
+++ b/website/docs/write-code/reference/Built-in-JS-Libraries.md
@@ -58,4 +58,4 @@ export default {
 
 ## External JS Libraries
 
-You can also [follow this guide](core-concepts/writing-code/ext-libraries) to install external javascript libraries that are not loaded by default into your application.
+You can also [follow this guide](/core-concepts/writing-code/ext-libraries) to install external javascript libraries that are not loaded by default into your application.

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -665,12 +665,10 @@ a.appsmithtag.enterprise:hover {
 
 h2+.tags,
 h3+.tags {
-  margin-left: -26px;
   top: -6px !important;
 }
 
 h4+.tags {
-  margin-left: -18px;
   top: -6px !important;
 }
 


### PR DESCRIPTION
## Checklist
I have:
- [ ] run the content through Grammarly
- [ ] linked to sample apps when relevant
- [ ] added the meta description for each page in the PR
- [ ] minimized the callouts and added only when necessary
- [ ] added the `queryString` parameter to the Tabs (if used)
- [ ] masked PII in images. For example, login credentials, account details, and more
- [ ] added images only when necessary
- [ ] deleted the images that are no longer used for the updated pages in the PR
- [ ] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [ ] used the `<figure/>` tag instead of a markdown representation for images
- [ ] added the `<figcaption/>` tag to add a caption to the image
- [ ] added the `alt` attribute in the `<img/>` tag
- [ ] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [ ] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.