### PR TITLE
fix: Removed fast xml parser from the default libraries

### DIFF
--- a/website/docs/write-code/reference/Built-in-JS-Libraries.md
+++ b/website/docs/write-code/reference/Built-in-JS-Libraries.md
@@ -28,17 +28,6 @@ simplifies working with dates and times in JavaScript by providing functions for
 
 </dd>
 
-#### [Fast XML Parser](https://github.com/NaturalIntelligence/fast-xml-parser#readme)
-
-<dd>
-Fast XML Parser can be used to work with cryptographic algorithms and protocols in JavaScript.
-
-```
-{{ xmlParser.parse(xmlAPI.data) }}
-```
-
-</dd>
-
 #### [Forge](https://github.com/digitalbazaar/forge)
 
 <dd>


### PR DESCRIPTION
## Checklist
I have:
- [X] run the content through Grammarly
- [X] linked to sample apps when relevant
- [X] added the meta description for each page in the PR
- [X] minimized the callouts and added only when necessary
- [X] added the `queryString` parameter to the Tabs (if used)
- [X] masked PII in images. For example, login credentials, account details, and more
- [X] added images only when necessary
- [X] deleted the images that are no longer used for the updated pages in the PR
- [X] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [X] used the `<figure/>` tag instead of a markdown representation for images
- [X] added the `<figcaption/>` tag to add a caption to the image
- [X] added the `alt` attribute in the `<img/>` tag
- [X] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [X] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.