### PR TITLE
fix: Added details for triple braces to query parameters

### DIFF
--- a/website/docs/reference/appsmith-framework/widget-actions/navigate-to.md
+++ b/website/docs/reference/appsmith-framework/widget-actions/navigate-to.md
@@ -29,7 +29,13 @@ Page name or URL to which you would like to be transported. `PageName` is case-s
 
 <dd>
 
-Query parameters passed via the URL. Used to share information with the destination page. It is important to use triple braces ({{{ }}}) to ensure that the parameters are encoded correctly as a part of the URL. Even if the value is a static string, the triple braces are required to include the parameter in the navigation. See [Sharing data via query params](/advanced-concepts/sharing-data-across-pages#sharing-data-via-query-params).
+Query parameters passed via the URL. Used to share information with the destination page. 
+To bind an object with key-value pairs into a query parameter, use the following syntax in **Query params**:
+
+```jsx
+{{{ "key": "value" }}}
+```
+See [Sharing data via query params](/advanced-concepts/sharing-data-across-pages#sharing-data-via-query-params).
 
 </dd>
 

--- a/website/docs/reference/appsmith-framework/widget-actions/navigate-to.md
+++ b/website/docs/reference/appsmith-framework/widget-actions/navigate-to.md
@@ -29,7 +29,7 @@ Page name or URL to which you would like to be transported. `PageName` is case-s
 
 <dd>
 
-Query parameters passed via the URL. Used to share information with the destination page. See [Sharing data via query params](/advanced-concepts/sharing-data-across-pages#sharing-data-via-query-params).
+Query parameters passed via the URL. Used to share information with the destination page. It is important to use triple braces ({{{ }}}) to ensure that the parameters are encoded correctly as a part of the URL. Even if the value is a static string, the triple braces are required to include the parameter in the navigation. See [Sharing data via query params](/advanced-concepts/sharing-data-across-pages#sharing-data-via-query-params).
 
 </dd>
 

--- a/website/docs/reference/appsmith-framework/widget-actions/navigate-to.md
+++ b/website/docs/reference/appsmith-framework/widget-actions/navigate-to.md
@@ -33,7 +33,9 @@ Query parameters passed via the URL. Used to share information with the destinat
 To bind an object with key-value pairs into a query parameter, use the following syntax in **Query params**:
 
 ```jsx
-{{{ "key": "value" }}}
+{{
+{ "key": "value" }
+}}
 ```
 See [Sharing data via query params](/advanced-concepts/sharing-data-across-pages#sharing-data-via-query-params).
 


### PR DESCRIPTION
closes #949 
## Checklist
I have:
- [ ] run the content through Grammarly
- [ ] linked to sample apps when relevant
- [ ] added the meta description for each page in the PR
- [ ] minimized the callouts and added only when necessary
- [ ] added the `queryString` parameter to the Tabs (if used)
- [ ] masked PII in images. For example, login credentials, account details, and more
- [ ] added images only when necessary
- [ ] deleted the images that are no longer used for the updated pages in the PR
- [ ] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [ ] used the `<figure/>` tag instead of a markdown representation for images
- [ ] added the `<figcaption/>` tag to add a caption to the image
- [ ] added the `alt` attribute in the `<img/>` tag
- [ ] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [ ] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.