### PR TITLE
fix: Insert data guide

### DIFF
--- a/website/docs/build-apps/how-to-guides/insert-data.md
+++ b/website/docs/build-apps/how-to-guides/insert-data.md
@@ -9,15 +9,8 @@ This page shows you how to insert data using a Form widget.
 ## Insert data using a new page
 
 To insert data in a new page, follow these steps:
-1. Add a Button widget and set it's onClick event to open a new page to insert data using the following code where `insertDetails` is the name of the page:
-   ```jsx
-   {{navigateTo("insertDetails")}}
-   ```
-   You can also pass parameters to the new page. For example, to send the data of a selected table row, use the following code:
-
-   ```jsx
-   {{navigateTo("insertDetails", table.selectedRow)}}
-   ```
+1. Add a Button widget. Set the widget's **onClick** event to open a new page by selecting the **Navigate to** action and selecting the appropriate page.
+   You can also pass parameters to the new page in the action selection pane.
    For more information, see [navigateTo](/reference/appsmith-framework/widget-actions/navigate-to).
 2. Add a Form Widget to the `insertDetails` page. 
 3. Add Input widgets for each data field you want to capture. Set the **Data type** of each widget.
@@ -47,32 +40,23 @@ To insert data in a new page, follow these steps:
 
 ## Insert data using a Modal
 To insert data using a Modal, follow these steps:
-1. Add a Button widget and set it's onClick event to show a modal to insert data using the following code where `insertDetails` is the name of the modal:
-   ```jsx
-   showModal("insertDetails")
-   ```
-2. Add a Form Widget to the modal and design the modal to add Input widgets for each data field you want to capture.
-3. Drag and drop a Button widget into the modal and set its `onClick` property to insert data using the following code:
+1. Add a Button widget. Set the widget's **onClick** event to show a Modal by selecting the **Show modal** action and then selecting the Modal name.
+2. Add a Form Widget to the Modal and design the Modal to add Input widgets for each data field you want to capture.
+3. Drag and drop a Button widget into the Modal and set its `onClick` property to insert data using the following code:
    ```jsx
    {{insertDataQuery.run(() => closeModal('insertDetails'))}}
    ```
-   To reset the modal, use the following code where `insertDetails` is the name of the Modal widget:
-   ```jsx
-   {{resetWidget("insertDetails")}}
-   ```
+   To reset the Modal, select the **Reset widget** action and then select the Modal name.
    For more information, see [resetWidget](/reference/appsmith-framework/widget-actions/reset-widget).
-   Alternatively, you can enable the Reset on submit property of the Form widget and use the **Reset** button on the form to reset value.
+   Alternatively, you can enable the **Reset on submit** property of the Form widget and use the **Reset** button on the form to reset the value.
 4. To validate data before inserting, Scroll to the **Validation** section in the property pane of the Form widget. Enter the validation criteria, such as **Required**, **Max Characters**, **Regex**, etc. The submit button remains disabled until all widgets meet the defined validation criteria. For more information, see [Validation](/reference/widgets/input#regex-string).
-5. Add a Button widget to the page and set it's onClick event to open the modal using the following code:
-   ```jsx
-   showModal("insertDetails")
-   ```
+5. Add a Button widget to the page. Set its **onClick** event to open the Modal by selecting the **Show modal** action and then selecting the Modal name.
 
 ## Update form fields dynamically
 
 To update fields dynamically, follow these steps:
 Set the `onTextChange`, `onSelect`, or other event properties of your widgets to set up the properties of other form fields as needed.
-For example to set the `offerCode` based on the selection of `location` for a new offer use the following code:
+For example, to set the `offerCode` based on the selection of `location` for a new offer use the following code:
 
 ```jsx
 {{ offerCode.setText(location.selectedOptionValue + code) }}

--- a/website/docs/build-apps/how-to-guides/insert-data.md
+++ b/website/docs/build-apps/how-to-guides/insert-data.md
@@ -2,23 +2,27 @@
 description: This page shows you how to insert data in Appsmith. 
 
 ---
-# Insert Data Using Form
+# Insert Data
 
-This page shows you how to insert data using a Form widget.
+This guide shows you how to insert data into a datasource using the Form widget in a new page and a Modal. It explains steps to bind data to widgets, validate user input, and configure query.
 
-## Insert data using a new page
-
+## Using new page
 To insert data in a new page, follow these steps:
 1. Add a Button widget. Set the widget's **onClick** event to open a new page by selecting the **Navigate to** action and selecting the appropriate page.
-   You can also pass parameters to the new page in the action selection pane.
    For more information, see [navigateTo](/reference/appsmith-framework/widget-actions/navigate-to).
-2. Add a Form Widget to the `insertDetails` page. 
-3. Add Input widgets for each data field you want to capture. Set the **Data type** of each widget.
-4. Drag and drop a Button Widget inside the form and set its `onClick` property to insert data using the following code:
+2. In the new page, create a Form widget to capture the details you want to insert.
+3. You can update fields dynamically by setting the events of the widgets to bind data to other fields in the Form.
+   For example, to set the `offerCode` based on the selection of `location` for a new offer use the following code:
+
    ```jsx
-   {{insertDataQuery.run()}}
+   {{ offerCode.setText(location.selectedOptionValue + code) }}
    ```
-   Here is an example to create a new offer using the `insertDataQuery` where `offers` is the datasource, and `offer_details` is the form name:
+   For more information, see [Dynamic data mapping](/reference/widgets/list#dynamic-data-mapping).
+
+4. To validate data before inserting, scroll to the **Validation** section in the property pane of the Form widget. Enter the validation criteria, such as **Required**, **Max Characters**, **Regex**, etc. The submit button remains disabled until all widgets meet the defined validation criteria. For more information, see [Validation](/reference/widgets/input#regex-string).
+5. Select the **Submit** button on the Form, and add an **Action** to the **onClick** property. Select **Execute a query**, and then select your insert query.
+
+   Here is an example where `offers` is the datasource, and `offer_details` is the form name:
    ```sql
       INSERT INTO offers 
       (id, title, description, valid_from, valid_till, offer_type, product_type, discount_type, discount_value) 
@@ -35,31 +39,17 @@ To insert data in a new page, follow these steps:
       {{ offer_details.data.discount_value }}
      );
    ```
-   To format dates, use [Moment](https://momentjs.com/docs/).
-5. Click the **Reset** button on the form to clear values.
+6. In **Callbacks** for the Form's **Submit** button, add an action in **On success**, select **Reset widget** in **Action**, and then select your Form in **Widget**.
 
-## Insert data using a Modal
+## Using Modal
 To insert data using a Modal, follow these steps:
 1. Add a Button widget. Set the widget's **onClick** event to show a Modal by selecting the **Show modal** action and then selecting the Modal name.
-2. Add a Form Widget to the Modal and design the Modal to add Input widgets for each data field you want to capture.
-3. Drag and drop a Button widget into the Modal and set its `onClick` property to insert data using the following code:
-   ```jsx
-   {{insertDataQuery.run(() => closeModal('insertDetails'))}}
-   ```
-   To reset the Modal, select the **Reset widget** action and then select the Modal name.
-   For more information, see [resetWidget](/reference/appsmith-framework/widget-actions/reset-widget).
-   Alternatively, you can enable the **Reset on submit** property of the Form widget and use the **Reset** button on the form to reset the value.
+2. In the Modal, create a Form widget to capture the details you want to insert.
+3. You can update fields dynamically by setting the events of the widgets to bind data to other fields in the Form.
+   For an example, refer to step 5 of [Using new page](#using-new-page).
+   For more information, see [Dynamic data mapping](/reference/widgets/list#dynamic-data-mapping).
 4. To validate data before inserting, Scroll to the **Validation** section in the property pane of the Form widget. Enter the validation criteria, such as **Required**, **Max Characters**, **Regex**, etc. The submit button remains disabled until all widgets meet the defined validation criteria. For more information, see [Validation](/reference/widgets/input#regex-string).
-5. Add a Button widget to the page. Set its **onClick** event to open the Modal by selecting the **Show modal** action and then selecting the Modal name.
+5. Select the **Submit** button on the Form, and add an **Action** to the **onClick** property. Select **Execute a query**, and then select your insert query. For an example, refer to step 5 of [Using new page](#using-new-page).
+6. Add a Button widget to the page. Set its **onClick** event to open the Modal by selecting the **Show modal** action and then selecting the Modal name.
+7. In **Callbacks** for the Form's **Submit** button, add an action in **On success**, select **Reset widget** in **Action**, and then select your Modal in **Widget**.
 
-## Update form fields dynamically
-
-To update fields dynamically, follow these steps:
-Set the `onTextChange`, `onSelect`, or other event properties of your widgets to set up the properties of other form fields as needed.
-For example, to set the `offerCode` based on the selection of `location` for a new offer use the following code:
-
-```jsx
-{{ offerCode.setText(location.selectedOptionValue + code) }}
-```
-
-For more information, see [Dynamic data mapping](/reference/widgets/list#dynamic-data-mapping).

--- a/website/docs/build-apps/how-to-guides/insert-data.md
+++ b/website/docs/build-apps/how-to-guides/insert-data.md
@@ -4,7 +4,7 @@ description: This page shows you how to insert data in Appsmith.
 ---
 # Insert Data
 
-This guide shows you how to insert data into a datasource using the Form widget in a new page and a Modal. It explains steps to bind data to widgets, validate user input, and configure query.
+This guide shows you how to insert data into a datasource using the Form widget on a new page and a Modal. It explains steps to bind data to widgets, validate user input, and configure queries.
 
 ## Using new page
 To insert data in a new page, follow these steps:
@@ -12,11 +12,13 @@ To insert data in a new page, follow these steps:
    For more information, see [navigateTo](/reference/appsmith-framework/widget-actions/navigate-to).
 2. In the new page, create a Form widget to capture the details you want to insert.
 3. You can update fields dynamically by setting the events of the widgets to bind data to other fields in the Form.
-   For example, to set the `offerCode` based on the selection of `location` for a new offer use the following code:
+   Example:
 
    ```jsx
    {{ offerCode.setText(location.selectedOptionValue + code) }}
    ```
+   Here, the selection of `location` sets the selection of `offerCode`.
+
    For more information, see [Bind Data to Wdigets](/core-concepts/building-ui/dynamic-ui).
 
 4. To validate data before inserting, scroll to the **Validation** section in the property pane of the Form widget. Enter the validation criteria, such as **Required**, **Max Characters**, **Regex**, etc. The submit button remains disabled until all widgets meet the defined validation criteria. For more information, see [Validation](/reference/widgets/input#regex-string).

--- a/website/docs/build-apps/how-to-guides/insert-data.md
+++ b/website/docs/build-apps/how-to-guides/insert-data.md
@@ -1,0 +1,81 @@
+---
+description: This page shows you how to insert data in Appsmith. 
+
+---
+# Insert Data Using Form
+
+This page shows you how to insert data using a Form widget.
+
+## Insert data using a new page
+
+To insert data in a new page, follow these steps:
+1. Add a Button widget and set it's onClick event to open a new page to insert data using the following code where `insertDetails` is the name of the page:
+   ```jsx
+   {{navigateTo("insertDetails")}}
+   ```
+   You can also pass parameters to the new page. For example, to send the data of a selected table row, use the following code:
+
+   ```jsx
+   {{navigateTo("insertDetails", table.selectedRow)}}
+   ```
+   For more information, see [navigateTo](/reference/appsmith-framework/widget-actions/navigate-to).
+2. Add a Form Widget to the `insertDetails` page. 
+3. Add Input widgets for each data field you want to capture. Set the **Data type** of each widget.
+4. Drag and drop a Button Widget inside the form and set its `onClick` property to insert data using the following code:
+   ```jsx
+   {{insertDataQuery.run()}}
+   ```
+   Here is an example to create a new offer using the `insertDataQuery` where `offers` is the datasource, and `offer_details` is the form name:
+   ```sql
+      INSERT INTO offers 
+      (id, title, description, valid_from, valid_till, offer_type, product_type, discount_type, discount_value) 
+      VALUES 
+      (
+      {{ offer_details.data.id }},
+      {{ offer_details.data.title }},
+      {{ offer_details.data.description }},
+      {{ offer_details.data.valid_from }},
+      {{ offer_details.data.valid_till }},
+      {{ offer_details.data.offer_type }},
+      {{ offer_details.data.product_type }},
+      {{ offer_details.data.discount_type }},
+      {{ offer_details.data.discount_value }}
+     );
+   ```
+   To format dates, use [Moment](https://momentjs.com/docs/).
+5. Click the **Reset** button on the form to clear values.
+
+## Insert data using a Modal
+To insert data using a Modal, follow these steps:
+1. Add a Button widget and set it's onClick event to show a modal to insert data using the following code where `insertDetails` is the name of the modal:
+   ```jsx
+   showModal("insertDetails")
+   ```
+2. Add a Form Widget to the modal and design the modal to add Input widgets for each data field you want to capture.
+3. Drag and drop a Button widget into the modal and set its `onClick` property to insert data using the following code:
+   ```jsx
+   {{insertDataQuery.run(() => closeModal('insertDetails'))}}
+   ```
+   To reset the modal, use the following code where `insertDetails` is the name of the Modal widget:
+   ```jsx
+   {{resetWidget("insertDetails")}}
+   ```
+   For more information, see [resetWidget](/reference/appsmith-framework/widget-actions/reset-widget).
+   Alternatively, you can enable the Reset on submit property of the Form widget and use the **Reset** button on the form to reset value.
+4. To validate data before inserting, Scroll to the **Validation** section in the property pane of the Form widget. Enter the validation criteria, such as **Required**, **Max Characters**, **Regex**, etc. The submit button remains disabled until all widgets meet the defined validation criteria. For more information, see [Validation](/reference/widgets/input#regex-string).
+5. Add a Button widget to the page and set it's onClick event to open the modal using the following code:
+   ```jsx
+   showModal("insertDetails")
+   ```
+
+## Update form fields dynamically
+
+To update fields dynamically, follow these steps:
+Set the `onTextChange`, `onSelect`, or other event properties of your widgets to set up the properties of other form fields as needed.
+For example to set the `offerCode` based on the selection of `location` for a new offer use the following code:
+
+```jsx
+{{ offerCode.setText(location.selectedOptionValue + code) }}
+```
+
+For more information, see [Dynamic data mapping](/reference/widgets/list#dynamic-data-mapping).

--- a/website/docs/build-apps/how-to-guides/insert-data.md
+++ b/website/docs/build-apps/how-to-guides/insert-data.md
@@ -17,7 +17,7 @@ To insert data in a new page, follow these steps:
    ```jsx
    {{ offerCode.setText(location.selectedOptionValue + code) }}
    ```
-   For more information, see [Dynamic data mapping](/reference/widgets/list#dynamic-data-mapping).
+   For more information, see [Bind Data to Wdigets](/core-concepts/building-ui/dynamic-ui).
 
 4. To validate data before inserting, scroll to the **Validation** section in the property pane of the Form widget. Enter the validation criteria, such as **Required**, **Max Characters**, **Regex**, etc. The submit button remains disabled until all widgets meet the defined validation criteria. For more information, see [Validation](/reference/widgets/input#regex-string).
 5. Select the **Submit** button on the Form, and add an **Action** to the **onClick** property. Select **Execute a query**, and then select your insert query.

--- a/website/docs/build-apps/how-to-guides/submit-form-data.md
+++ b/website/docs/build-apps/how-to-guides/submit-form-data.md
@@ -1,7 +1,7 @@
 ---
 description: This page shows you how to display a master-detail form and update table data using a JSON form and Form widget.
 ---
-# Update Form data in Modal
+# Update data
 
 This page shows how to update table data using the Form and Modal widgets.
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -331,8 +331,6 @@ const sidebars = {
           link: { type: 'doc', id: 'build-apps/how-to-guides/README' },
           items: [
             'core-concepts/building-ui/dynamic-ui/README',
-            'build-apps/how-to-guides/insert-data',
-            'build-apps/how-to-guides/submit-form-data',
             {
               type: 'category',
               label: 'Display and Lookup Table Data',
@@ -345,6 +343,8 @@ const sidebars = {
                 'build-apps/how-to-guides/search-and-filter-table-data'
               ],
             },
+            'build-apps/how-to-guides/insert-data',
+            'build-apps/how-to-guides/submit-form-data',
             'reference/widgets/table/inline-editing',
             'build-apps/how-to-guides/refresh-table-data',
             'build-apps/how-to-guides/Upload-CSV-Data-to-Table',

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -347,6 +347,7 @@ const sidebars = {
             'build-apps/how-to-guides/refresh-table-data',
             'build-apps/how-to-guides/Upload-CSV-Data-to-Table',
             'build-apps/how-to-guides/submit-form-data',
+            'build-apps/how-to-guides/insert-data',
             'build-apps/how-to-guides/Setup-Server-side-Pagination-on-List',
             'build-apps/how-to-guides/Create-Nested-Lists',
             'build-apps/how-to-guides/Create-Custom-Widgets-Using-Iframe',

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -331,6 +331,8 @@ const sidebars = {
           link: { type: 'doc', id: 'build-apps/how-to-guides/README' },
           items: [
             'core-concepts/building-ui/dynamic-ui/README',
+            'build-apps/how-to-guides/insert-data',
+            'build-apps/how-to-guides/submit-form-data',
             {
               type: 'category',
               label: 'Display and Lookup Table Data',
@@ -346,8 +348,6 @@ const sidebars = {
             'reference/widgets/table/inline-editing',
             'build-apps/how-to-guides/refresh-table-data',
             'build-apps/how-to-guides/Upload-CSV-Data-to-Table',
-            'build-apps/how-to-guides/submit-form-data',
-            'build-apps/how-to-guides/insert-data',
             'build-apps/how-to-guides/Setup-Server-side-Pagination-on-List',
             'build-apps/how-to-guides/Create-Nested-Lists',
             'build-apps/how-to-guides/Create-Custom-Widgets-Using-Iframe',


### PR DESCRIPTION
closes #1901 
## Checklist
I have:
- [ ] run the content through Grammarly
- [ ] linked to sample apps when relevant
- [ ] added the meta description for each page in the PR
- [ ] minimized the callouts and added only when necessary
- [ ] added the `queryString` parameter to the Tabs (if used)
- [ ] masked PII in images. For example, login credentials, account details, and more
- [ ] added images only when necessary
- [ ] deleted the images that are no longer used for the updated pages in the PR
- [ ] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [ ] used the `<figure/>` tag instead of a markdown representation for images
- [ ] added the `<figcaption/>` tag to add a caption to the image
- [ ] added the `alt` attribute in the `<img/>` tag
- [ ] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [ ] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.