### PR TITLE
fix: remove outdated video from Pass Runtime Parameters to Queries

### DIFF
--- a/website/docs/connect-data/how-to-guides/how-to-pass-params-to-an-api.mdx
+++ b/website/docs/connect-data/how-to-guides/how-to-pass-params-to-an-api.mdx
@@ -10,16 +10,9 @@ import CodeBlock from "@theme/CodeBlock";
 
 In Appsmith, you have the ability to pass static [parameters to queries](connect-data/concepts/dynamic-queries) using mustache bindings `{{}}`. But if you need to execute a query multiple times with dynamic parameters, such as iterating through an array of ids and running a query to delete each record, then you will need to pass them in the `run()` function of the query.
 
-<VideoEmbed
-  host="youtube"
-  videoId="znaaDiQbAS8"
-  title="How to pass parameters to an API call"
-  caption="How to pass parameters to an API call"
-/>
-
 ## Using the `run()` Function with Parameters
 
-To pass different parameters every time a query is executed, you can leverage the `run()` function's `params` argument. Within the query, you can access the passed parameters by using the Mustache notation `{{this.params.key}}`.
+To pass different parameters every time a query is executed, you can leverage the [run()](/reference/appsmith-framework/query-object#queryrun) function's `params` argument. Within the query, you can access the passed parameters by using the Mustache notation `{{this.params.key}}`.
 
 ## Example Scenario: Bulk User Deletion
 


### PR DESCRIPTION
## Checklist
I have:
- [ ] run the content through Grammarly
- [ ] linked to sample apps when relevant
- [ ] added the meta description for each page in the PR
- [ ] minimized the callouts and added only when necessary
- [ ] added the `queryString` parameter to the Tabs (if used)
- [ ] masked PII in images. For example, login credentials, account details, and more
- [ ] added images only when necessary
- [ ] deleted the images that are no longer used for the updated pages in the PR
- [ ] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [ ] used the `<figure/>` tag instead of a markdown representation for images
- [ ] added the `<figcaption/>` tag to add a caption to the image
- [ ] added the `alt` attribute in the `<img/>` tag
- [ ] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [ ] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.