### PR TITLE
fix: Bind Data to Widgets typo

### DIFF
--- a/website/docs/build-apps/how-to-guides/README.md
+++ b/website/docs/build-apps/how-to-guides/README.md
@@ -6,7 +6,7 @@
 <div class="containerGridSampleApp">
 <div class="containerColumnSampleApp columnGrid column-one">
         <div class="containerCol">
-            <a href="/core-concepts/building-ui/dynamic-ui"><strong>Trigger UI Workflow</strong></a>
+            <a href="/core-concepts/building-ui/dynamic-ui"><strong>Bind Data to Widgets</strong></a>
         </div> <hr/>
         <div class="containerDescription">This page shows how you can dynamically update widget properties using queries, JavaScript functions, and setter methods.</div>
         <div class="containerTutorialLink"></div>


### PR DESCRIPTION
## Checklist
I have:
- [ ] run the content through Grammarly
- [ ] linked to sample apps when relevant
- [ ] added the meta description for each page in the PR
- [ ] minimized the callouts and added only when necessary
- [ ] added the `queryString` parameter to the Tabs (if used)
- [ ] masked PII in images. For example, login credentials, account details, and more
- [ ] added images only when necessary
- [ ] deleted the images that are no longer used for the updated pages in the PR
- [ ] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [ ] used the `<figure/>` tag instead of a markdown representation for images
- [ ] added the `<figcaption/>` tag to add a caption to the image
- [ ] added the `alt` attribute in the `<img/>` tag
- [ ] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [ ] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.