### PR TITLE
fix: Browse and Display Documents

### DIFF
--- a/website/docs/build-apps/how-to-guides/browse-and-display-documents.md
+++ b/website/docs/build-apps/how-to-guides/browse-and-display-documents.md
@@ -1,0 +1,64 @@
+# Browse and Display Documents
+
+This guide shows how to organize and display documents using the Tabs widget.
+
+
+<figure>
+  <img src="/img/display-doc.gif" style= {{width:"700px", height:"auto"}} alt="Browse and Display Documents"/>
+  <figcaption align = "center"><i>Browse and Display Documents</i></figcaption>
+</figure>
+
+1. Connect the Table widget to a query containing document-related columns, either in base64 or URL format.
+
+2. Drop a Tabs widget to organize and browse multiple documents.
+
+3. For each Tab, add an appropriate widget based on the document type present in the respective column:
+
+<dd>
+
+- For images (PNG, JPG, SVG), use the Image widget.
+- For document files such as PDF, TXT, PPTX, and others, use the Document Viewer widget.
+
+
+</dd>
+
+4. To display the document, connect the selected row of the Table widget to the Image or Document Viewer widget, like:
+
+<dd>
+
+```js
+{{Docs_Table.selectedRow.doc_type_passport}}
+```
+
+If you don't know the file type of that column, you can create a JS function to change visibility of widgets dynamically:
+
+```js
+export default {
+  myFun1() {
+    const imageUrl = Table1.selectedRow.doc_type_passport;
+
+    if (imageUrl.includes('.png') || imageUrl.includes('.jpg')) {
+      
+      Image1.setVisibility(true);
+      DocumentViewer1.setVisibility(false);
+      Image1.setImage(Table1.selectedRow.doc_type_passport);
+    } else {
+
+      Image1.setVisibility(false);
+      DocumentViewer1.setVisibility(true);
+      DocumentViewer1.setURL(Table1.selectedRow.doc_type_passport);
+    }
+  }
+};
+// If the image is in base64 format, you can handle it by checking if the imageUrl starts with the prefix `data:image/`.
+```
+
+The above function displays an Image or a Document Viewer based on the file type of a selected row, showing the Image if it's a PNG or JPG file, and displaying the Document Viewer otherwise. Set the **onRowselected** event to execute the provided function.
+
+
+</dd>
+
+5. Configure the **Zoom level** property to allow users to zoom into the document, and **Enable download** to allow users to download that document.
+
+
+

--- a/website/docs/build-apps/how-to-guides/browse-and-display-documents.md
+++ b/website/docs/build-apps/how-to-guides/browse-and-display-documents.md
@@ -30,30 +30,19 @@ This guide shows how to organize and display documents using the Tabs widget.
 {{Docs_Table.selectedRow.doc_type_passport}}
 ```
 
-If you don't know the file type of that column, you can create a JS function to change visibility of widgets dynamically:
+If you don't know the file type of that column, you can create a JS function to change the visibility of widgets dynamically. Enable JS and following code in **Visible** property:
 
 ```js
-export default {
-  myFun1() {
-    const imageUrl = Table1.selectedRow.doc_type_passport;
+//For Image 
+{{Docs_Table.selectedRow.doc_type_passport.includes(".jpg") || false}}
 
-    if (imageUrl.includes('.png') || imageUrl.includes('.jpg')) {
-      
-      Image1.setVisibility(true);
-      DocumentViewer1.setVisibility(false);
-      Image1.setImage(Table1.selectedRow.doc_type_passport);
-    } else {
+//For Document Viewer
+{{Docs_Table.selectedRow.doc_type_passport.includes(".pdf") || false}}
 
-      Image1.setVisibility(false);
-      DocumentViewer1.setVisibility(true);
-      DocumentViewer1.setURL(Table1.selectedRow.doc_type_passport);
-    }
-  }
-};
 // If the image is in base64 format, you can handle it by checking if the imageUrl starts with the prefix `data:image/`.
 ```
 
-The above function displays an Image or a Document Viewer based on the file type of a selected row, showing the Image if it's a PNG or JPG file, and displaying the Document Viewer otherwise. Set the **onRowselected** event to execute the provided function.
+The above code displays an Image or a Document Viewer based on the file type of a selected row, showing the Image if it's a JPG file, and displaying the Document Viewer otherwise. 
 
 
 </dd>

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -332,6 +332,7 @@ const sidebars = {
                 'build-apps/how-to-guides/create-drill-down-view',
                 'build-apps/how-to-guides/Server-side-pagination-in-table',
                 'build-apps/how-to-guides/Setup-Server-side-Pagination-on-List',
+                `build-apps/how-to-guides/browse-and-display-documents`,
                 'build-apps/how-to-guides/display-map-markers',
                 `build-apps/how-to-guides/display-select-options-dynamically`
               ],


### PR DESCRIPTION
## Checklist
I have:
- [ ] run the content through Grammarly
- [ ] linked to sample apps when relevant
- [ ] added the meta description for each page in the PR
- [ ] minimized the callouts and added only when necessary
- [ ] added the `queryString` parameter to the Tabs (if used)
- [ ] masked PII in images. For example, login credentials, account details, and more
- [ ] added images only when necessary
- [ ] deleted the images that are no longer used for the updated pages in the PR
- [ ] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [ ] used the `<figure/>` tag instead of a markdown representation for images
- [ ] added the `<figcaption/>` tag to add a caption to the image
- [ ] added the `alt` attribute in the `<img/>` tag
- [ ] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [ ] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.