### PR TITLE
fix: unbreak link

### DIFF
--- a/website/docs/connect-data/how-to-guides/how-to-pass-params-to-an-api.mdx
+++ b/website/docs/connect-data/how-to-guides/how-to-pass-params-to-an-api.mdx
@@ -8,7 +8,7 @@ import CodeBlock from "@theme/CodeBlock";
 
 # Pass Runtime Parameters to Queries
 
-In Appsmith, you have the ability to pass static [parameters to queries](connect-data/concepts/dynamic-queries) using mustache bindings `{{}}`. But if you need to execute a query multiple times with dynamic parameters, such as iterating through an array of ids and running a query to delete each record, then you will need to pass them in the `run()` function of the query.
+In Appsmith, you have the ability to pass static [parameters to queries](/connect-data/concepts/dynamic-queries) using mustache bindings `{{}}`. But if you need to execute a query multiple times with dynamic parameters, such as iterating through an array of ids and running a query to delete each record, then you will need to pass them in the `run()` function of the query.
 
 ## Using the `run()` Function with Parameters
 


### PR DESCRIPTION
Linking from the docs root (`/<path>`), as seems to be the convention.