### PR TITLE
fix: Geolocation references

### DIFF
--- a/website/docs/reference/appsmith-framework/widget-actions/README.md
+++ b/website/docs/reference/appsmith-framework/widget-actions/README.md
@@ -24,4 +24,7 @@ Browse this section to learn about the different actions you can trigger on Apps
 * [postWindowMessage()](reference/appsmith-framework/widget-actions/post-message)
 * [windowMessageListener()](/reference/appsmith-framework/widget-actions/window-message-listener)
 * [unlistenWindowMessage()](/reference/appsmith-framework/widget-actions/unlisten-window-message)
+* [getGeolocation()](/reference/appsmith-framework/widget-actions/get-geolocation)
+* [watchGeolocation()](/reference/appsmith-framework/widget-actions/watch-geolocation)
+* [stopWatchGeolocation()](/reference/appsmith-framework/widget-actions/stop-watching-geolocation)
             

--- a/website/docs/reference/appsmith-framework/widget-actions/get-geolocation.md
+++ b/website/docs/reference/appsmith-framework/widget-actions/get-geolocation.md
@@ -1,0 +1,42 @@
+---
+description: >-
+  getCurrentPosition() reference
+toc_max_heading_level: 2
+---
+
+# getCurrentPosition()
+
+`getCurrentPosition()` gets the current position of a device.
+
+
+
+## Signature
+
+```javascript
+geolocation.getCurrentPosition(success, error, options);
+```
+
+### Parameters
+
+#### success
+
+A callback function that takes a GeolocationPosition object as its sole input parameter.
+
+#### error
+
+An optional callback function that takes a GeolocationPositionError object as its sole input parameter.
+
+#### options
+An optional object including the following parameters:
+- maximumAge: A positive long value indicating the maximum age in milliseconds of a possible cached position that is acceptable to return. 
+- timeout: A positive long value representing the maximum length of time (in milliseconds) the device is allowed to take in order to return a position. 
+- enableHighAccuracy: A boolean value that indicates the application would like to receive the best possible results.
+
+### Example
+```jsx
+navigator.geolocation.getCurrentPosition(success, error, options);
+```
+
+## See also
+* [watchGeolocation()](/reference/appsmith-framework/widget-actions/watch-geolocation)
+* [stopWatchGeolocation()](/reference/appsmith-framework/widget-actions/stop-watching-geolocation)

--- a/website/docs/reference/appsmith-framework/widget-actions/stop-watching-geolocation.md
+++ b/website/docs/reference/appsmith-framework/widget-actions/stop-watching-geolocation.md
@@ -1,0 +1,31 @@
+---
+description: >-
+  clearWatchGeolocation() reference
+toc_max_heading_level: 2
+---
+
+# clearWatchGeolocation()
+
+`clearWatchGeolocation()` unregister location/error monitoring handlers previously installed using Geolocation.watchPosition().
+
+
+## Signature
+
+```javascript
+clearWatch(id)
+```
+
+### Parameters
+
+#### id
+
+The ID number returned by the Geolocation.watchPosition() method when installing the handler you wish to remove.
+
+### Example
+```jsx
+navigator.geolocation.clearWatch(id)
+```
+
+## See also
+* [getGeolocation()](/reference/appsmith-framework/widget-actions/get-geolocation)
+* [watchGeolocation()](/reference/appsmith-framework/widget-actions/watch-geolocation)

--- a/website/docs/reference/appsmith-framework/widget-actions/watch-geolocation.md
+++ b/website/docs/reference/appsmith-framework/widget-actions/watch-geolocation.md
@@ -1,0 +1,38 @@
+---
+description: >-
+  watchGeolocation() reference
+toc_max_heading_level: 2
+---
+
+# watchGeolocation()
+
+`watchGeolocation()` registers a handler function that will be called automatically each time the position of the device changes. You can also, optionally, specify an error handling callback function.
+
+
+## Signature
+
+```javascript
+geolocation.getCurrentPosition(success, error, options);
+```
+
+### Parameters
+
+#### success
+
+A callback function that takes a GeolocationPosition object as its sole input parameter.
+
+#### error
+
+An optional callback function that takes a GeolocationPositionError object as an input parameter.
+
+#### options
+An optional object that provides configuration options for the location watch. 
+
+### Example
+```jsx
+navigator.geolocation.watchPosition(success, error, options)
+```
+
+## See also
+* [getGeolocation()](/reference/appsmith-framework/widget-actions/get-geolocation)
+* [stopWatchGeolocation()](/reference/appsmith-framework/widget-actions/stop-watching-geolocation)

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -555,7 +555,10 @@ const sidebars = {
               'reference/appsmith-framework/widget-actions/set-timeout',
               'reference/appsmith-framework/widget-actions/post-message',
               'reference/appsmith-framework/widget-actions/window-message-listener',
-              'reference/appsmith-framework/widget-actions/unlisten-window-message'
+              'reference/appsmith-framework/widget-actions/unlisten-window-message',
+              'reference/appsmith-framework/widget-actions/get-geolocation',
+              'reference/appsmith-framework/widget-actions/watch-geolocation',
+              'reference/appsmith-framework/widget-actions/stop-watching-geolocation'
 
             ]
           },


### PR DESCRIPTION
closes #781 
## Checklist
I have:
- [ ] run the content through Grammarly
- [ ] linked to sample apps when relevant
- [ ] added the meta description for each page in the PR
- [ ] minimized the callouts and added only when necessary
- [ ] added the `queryString` parameter to the Tabs (if used)
- [ ] masked PII in images. For example, login credentials, account details, and more
- [ ] added images only when necessary
- [ ] deleted the images that are no longer used for the updated pages in the PR
- [ ] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [ ] used the `<figure/>` tag instead of a markdown representation for images
- [ ] added the `<figcaption/>` tag to add a caption to the image
- [ ] added the `alt` attribute in the `<img/>` tag
- [ ] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [ ] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.