### PR TITLE
fix: typos in tutorial

### DIFF
--- a/website/docs/getting-started/tutorials/the-basics/connect-query-display-data.md
+++ b/website/docs/getting-started/tutorials/the-basics/connect-query-display-data.md
@@ -45,7 +45,7 @@ This tutorial takes you through the process of connecting a datasource and query
 
 2. Rename the query from **Query1** to `getUsers`. You may have to click the pencil icon if it is not already selected.
 
-3. For this tutorial, modify the query as shown below to fetch the records in the ascdending order of the `id` field.
+3. For this tutorial, modify the query as shown below to fetch the records in the ascending order of the `id` field.
 
   ```sql
   SELECT * FROM public."users" ORDER BY id LIMIT 10;

--- a/website/docs/getting-started/tutorials/the-basics/write-js-code.md
+++ b/website/docs/getting-started/tutorials/the-basics/write-js-code.md
@@ -6,7 +6,7 @@ description:  Now Code It
 
 # Lesson 3 - Now Code It
 
-This tutorial take you through the process of writing JavaScript code in Appsmith. In the earlier lessons, you have written JS code inside the mustache syntax `{{}}` which is great for single line coding. If you want to write more complex code, you have to use JS Objects.
+This tutorial takes you through the process of writing JavaScript code in Appsmith. In the earlier lessons, you have written JS code inside the mustache syntax `{{}}` which is great for single-line coding. If you want to write more complex code, you have to use JS Objects.
 
 ## Write JS functions
 
@@ -70,12 +70,12 @@ Appsmith provides global objects and functions within its framework to help buil
 2. Create a new blank page by clicking on the **+** next to **Pages** on the Entity Explorer to the left of the screen. Rename the page to `Account Details`.  
 
 
-3. Let's display the name of the currently logged in user. Drop a Text widget at the top of this page. You will see your name or email id by default. Take a look at the **Text** property on the right. It contains the following code snippet.
+3. Let's display the name of the currently logged-in user. Drop a Text widget at the top of this page. You will see your name or email id by default. Take a look at the **Text** property on the right. It contains the following code snippet.
 
   ```javascript
   Hello {{appsmith.user.name || appsmith.user.email}}
   ```
-  Here you are using the `appsmith` global object to extract information about the currently logged in user and append it to the text `Hello`. For more information, refer to [appsmith](/reference/appsmith-framework/context-object) global object.
+  Here you are using the `appsmith` global object to extract information about the currently logged-in user and append it to the text `Hello`. For more information, refer to [appsmith](/reference/appsmith-framework/context-object) global object.
 
 ### Navigate to another page  
 


### PR DESCRIPTION
Fixed some typos in the tutorial

## Checklist
I have:
- [ ] run the content through Grammarly
- [ ] linked to sample apps when relevant
- [ ] added the meta description for each page in the PR
- [ ] minimized the callouts and added only when necessary
- [ ] added the `queryString` parameter to the Tabs (if used)
- [ ] masked PII in images. For example, login credentials, account details, and more
- [ ] added images only when necessary
- [ ] deleted the images that are no longer used for the updated pages in the PR
- [ ] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [ ] used the `<figure/>` tag instead of a markdown representation for images
- [ ] added the `<figcaption/>` tag to add a caption to the image
- [ ] added the `alt` attribute in the `<img/>` tag
- [ ] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [ ] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.