### PR TITLE
fix: Additional user attributes

### DIFF
--- a/website/docs/reference/appsmith-framework/context-object.md
+++ b/website/docs/reference/appsmith-framework/context-object.md
@@ -153,17 +153,56 @@ This object contains the data of the currently authenticated user.
 
 ```javascript
 {
-  email: string
-  username: string
-  name: string
-  isEnabled: boolean
-  accountNonExpired: boolean
-  accountNonLocked: boolean
-  credentialsNonExpired: boolean
-  isAnonymous: boolean
+  "email": string,
+  "username": string,
+  "name": string,
+  "useCase": string,
+  "enableTelemetry": boolean,
+  "roles": object,
+  "groups": object,
+  "accountNonExpired": boolean,
+  "accountNonLocked": boolean,
+  "credentialsNonExpired": boolean,
+  "emptyInstance": boolean,
+  "isAnonymous": boolean,
+  "isEnabled": boolean,
+  "isSuperUser": boolean,
+  "isConfigurable": boolean,
+  "adminSettingsVisible": boolean,
+  "isIntercomConsentGiven": boolean
 }
 ```
-<!-- vale off -->
+
+#### email `string`
+The `email` property of user contains the email address of the user.
+To access the email, use the following code:
+```jsx
+{{appsmith.user.email}}
+```
+
+#### username `string`
+The `username` attribute represents the unique username associated with the user's account.
+To access the username, use the following code:
+```jsx
+{{appsmith.user.username}}
+```
+
+#### name `string`
+The `name` attribute holds the full name of the user. To access the username, use the following code:
+```jsx
+{{appsmith.user.name}}
+```
+
+#### useCase `string`
+This attribute describes the use case that the user has specified, giving insight into what they intend to achieve with Appsmith. To access the username, use the following code:
+```jsx
+{{appsmith.user.useCase}}
+```
+#### enableTelemetry `boolean`
+This boolean flag indicates if the user has consented to send telemetry data to Appsmith. Telemetry data typically includes usage statistics and error reports that help improve the platform. To access the username, use the following code:
+```jsx
+{{appsmith.user.enableTelemetry}}
+```
 
 <div className="tag-wrapper">
 
@@ -262,6 +301,57 @@ In the above example, the visibility of the button is determined by a group. Onl
 
 </dd>
 
+#### accountNonExpired `boolean`
+This attribute indicates whether the user's account is still active and has not expired. An expired account may be reactivated or may need subscription renewal. To access the username, use the following code:
+```jsx
+{{appsmith.user.accountNonExpired}}
+``` 
+
+#### accountNonLocked `boolean`
+The accountNonLocked attribute signifies whether the user's account is locked or unlocked. A locked account cannot be accessed until an administrator unlocks it. To access the username, use the following code:
+```jsx
+{{appsmith.user.accountNonLocked}}
+``` 
+#### credentialsNonExpired `boolean`
+This boolean attribute states if the user's credentials (such as their password) are still valid or if they need to be updated. Expired credentials typically require the user to reset their password. To access the username, use the following code:
+```jsx
+{{appsmith.user.credentialsNonExpired}}
+``` 
+#### emptyInstance `boolean`
+The emptyInstance attribute indicates whether this user object is an empty instance, lacking in actual data. This might occur when no user is logged in or in case of a system-level operation. To access the username, use the following code:
+```jsx
+{{appsmith.user.emptyInstance}}
+``` 
+#### isAnonymous `boolean`
+The isAnonymous attribute reflects whether the current user is anonymous (not logged in) or identified (logged in). This can affect the presentation and permissions of the user interface. To access the username, use the following code:
+```jsx
+{{appsmith.user.isAnonymous}}
+``` 
+#### isEnabled `boolean`
+This attribute indicates if the user's account is currently enabled. An enabled account can log in and interact with Appsmith applications, while disabled ones cannot. To access the username, use the following code:
+```jsx
+{{appsmith.user.isEnabled}}
+``` 
+#### isSuperUser `boolean`
+The isSuperUser flag shows whether the user has superuser status. Superusers typically have elevated privileges and access to all parts of the Appsmith application. To access the username, use the following code:
+```jsx
+{{appsmith.user.isSuperUser}}
+```
+#### isConfigurable `boolean`
+This attribute denotes whether the user has the ability to configure or alter settings within the Appsmith platform. To access the username, use the following code:
+```jsx
+{{appsmith.user.isConfigurable}}
+```
+#### adminSettingsVisible `boolean`
+The adminSettingsVisible attribute states if the user is able to see and possibly modify the admin settings area. To access the username, use the following code:
+```jsx
+{{appsmith.user.adminSettingsVisible}}
+```
+#### isIntercomConsentGiven `boolean`
+This boolean indicates whether the user has given consent to use Intercom, a messaging tool that might be used in Appsmith for support and communication purposes. To access the username, use the following code:
+```jsx
+{{appsmith.user.isIntercomConsentGiven}}
+```
 #### idToken `object`
 
 <dd>


### PR DESCRIPTION
closes #1460 
## Checklist
I have:
- [ ] run the content through Grammarly
- [ ] linked to sample apps when relevant
- [ ] added the meta description for each page in the PR
- [ ] minimized the callouts and added only when necessary
- [ ] added the `queryString` parameter to the Tabs (if used)
- [ ] masked PII in images. For example, login credentials, account details, and more
- [ ] added images only when necessary
- [ ] deleted the images that are no longer used for the updated pages in the PR
- [ ] followed the image file naming convention while renaming or adding new images. (Use lowercase letters, dashes between words, and be as descriptive as possible)
- [ ] used the `<figure/>` tag instead of a markdown representation for images
- [ ] added the `<figcaption/>` tag to add a caption to the image
- [ ] added the `alt` attribute in the `<img/>` tag
- [ ] verified and updated the cross-references or created redirect rules for the changed or removed content 
- [ ] reviewed and applied the style changes for UI formatting. For example, Bold the UI elements(Buttons on screen) used in the doc.