### PR TITLE
fix: breadcrumb cut off by removing negative margin

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -612,11 +612,6 @@ ul.circle>li:before {
   }
 }
 
-
-body {
-  margin-top: -30px !important;
-}
-
 .tag-wrapper {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Description 

Fixes the breadcrumbs on the webpage being cut off by the banner due to a negative margin being set on the body.

### Before

| Desktop | Mobile |
|--------|--------|
| <img width="1725" alt="before-desktop" src="https://github.com/appsmithorg/appsmith-docs/assets/37105197/b8d841b8-fdca-4509-b7fb-060d9ac96982"> | <img width="425" alt="before-mobile" src="https://github.com/appsmithorg/appsmith-docs/assets/37105197/90dc4e73-61c3-4d47-a9a3-6b65ee12b6bc"> |


### After

| Desktop | Mobile |
|--------|--------|
| <img width="1727" alt="after-desktop" src="https://github.com/appsmithorg/appsmith-docs/assets/37105197/c99f4692-2df4-4a71-9e8c-50855b826317"> | <img width="424" alt="after-mobile" src="https://github.com/appsmithorg/appsmith-docs/assets/37105197/0cea2d27-df37-4c34-bd26-98b35393e36e"> |

## Type of PR

Check the appropriate box:

- [ ] Review Fixes
- [ ] Documentation Overhaul
- [ ] Feature/Story
    - Link one or more Engineering Tickets

        * 

- [ ] A-Force
- [ ] Error in documentation

## Documentation tickets
 Link to one or more documentation tickets:
 
 - 

## Checklist
Choose only the ones that are applicable.

- [ ] Checked for Grammarly suggestions.
- [ ] Adhered to the writing checklist.
- [ ] Adhered the media checklist.
- [ ] Verified and updated cross-references or added redirect rules.
- [ ] Tested the redirect rules on deploy preview.
- [ ] Validated the modifications made to the content on deploy preview.
- [ ] Validated the CSS modifications on different screen sizes.
