### PR TITLE
fix: Updates to create a new guide for the AWS EKS Kubernetes Cluster

### DIFF
--- a/.github/styles/config/vocabularies/technical/accept.txt
+++ b/.github/styles/config/vocabularies/technical/accept.txt
@@ -79,3 +79,4 @@ UserAgent
 k8s
 K8s
 Kubernetes
+CLI

--- a/website/docs/getting-started/setup/installation-guides/kubernetes/README.mdx
+++ b/website/docs/getting-started/setup/installation-guides/kubernetes/README.mdx
@@ -29,71 +29,11 @@ This page provides steps to install Appsmith on a Kubernetes cluster using the [
    - [MacOS using Homebrew](https://kubernetes.io/docs/tasks/tools/install-kubectl-macos/#install-with-homebrew-on-macos)
    - [Linux using native package management](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management)
    - [Windows using Chocolatey, Scoop, or winget](https://kubernetes.io/docs/tasks/tools/install-kubectl-windows/#install-nonstandard-package-tools).
+3. Set up a Kubernetes cluster and persistent volume on your preferred platform for hosting the Kubernetes cluster. If you are hosting the Kubernetes cluster on AWS-EKS, see [Set up Kubernetes cluster on AWS-EKS](/getting-started/setup/installation-guides/kubernetes/setup-kubernetes-cluster-aws-eks)
 
-## Set up Kubernetes cluster
-
-Installing Appsmith via Kubernetes requires a persistent volume. In this section, you will create a KubeConfig and define a storage class that automatically generates a persistent volume during installation. If you're using a different cloud provider, ensure that your Kubernetes cluster can access a persistent volume for Appsmith to function properly. Follow these steps using a terminal to set up the cluster on AWS EKS:
-
-:::info
-You are free to choose your preferred platform for hosting the Kubernetes cluster. Ensure you have configured Kubeconfig, created a default storage class, and verified that the cluster can access a persistent volume before proceeding with the Appsmith installation. If you encounter any issues, contact the support team using the chat widget at the bottom right of this page.
+:::caution
+A persistent volume configuration is required on the Kubernetes cluster before proceeding with the Appsmith installation.
 :::
-
-1. Verify if you have access to AWS CLI with:
-
-  ```bash
-    aws sts get-caller-identity
-  ```
-
-  The above command provides information related to your account and ARN, indicating that you can connect and access your Amazon account using a terminal.
-
-2. Create KubeConfig with:
-
-  ```bash
-  aws eks update-kubeconfig --region ap-south-1 --name CLUSTER_NAME  --profile <PROFILE_NAME>
-  ```
-
-  In the above command, add the profile name that has access to the EKS cluster to the `--profile` parameter.
-
-3. Test your Kubernetes configuration with:
-
-  ```bash
-  kubectl cluster-info
-  ```
-  
-  The above command provides a summary of the current cluster configuration, including the Kubernetes master and other cluster information.
-
-4. Define a storage class.
-
-  * For Kubernetes version earlier than `1.23`, define the storage class with:
-
-    ```bash
-    kubectl apply -f - <<EOF
-      apiVersion: storage.k8s.io/v1
-      kind: StorageClass
-      apiVersion: storage.k8s.io/v1
-      metadata:
-        name: gp2
-      provisioner: kubernetes.io/aws-ebs
-      EOF
-    ```
-  * For Kubernetes version `1.23` and later, define the storage class with:
-    1. Create an IAM role by following the Amazon official documentation for [Creating the Amazon EBS CSI driver IAM role](https://docs.aws.amazon.com/eks/latest/userguide/csi-iam-role.html).
-    2. Add the Amazon Elastic Block Store (Amazon EBS) Container Storage Interface (CSI) driver chart repository with:
-      ```bash
-      helm repo add aws-ebs-csi-driver https://kubernetes-sigs.github.io/aws-ebs-csi-driver
-      ```
-    3. Update the Amazon EBS CSI driver repository with:
-      ```bash
-      helm repo update
-      ```
-    4. Install Amazon EBS CSI driver with:
-      ```bash
-      helm upgrade --install aws-ebs-csi-driver --namespace kube-system aws-ebs-csi-driver aws-ebs-csi-driver
-      ```
-    5. Verify the Amazon EBS CSI driver installation with:
-      ```
-      kubectl get pods -n kube-system -l app.kubernetes.io/name=aws-ebs-csi-driver
-      ```
 
 ## Install Appsmith
 

--- a/website/docs/getting-started/setup/installation-guides/kubernetes/setup-kubernetes-cluster-aws-eks.md
+++ b/website/docs/getting-started/setup/installation-guides/kubernetes/setup-kubernetes-cluster-aws-eks.md
@@ -1,0 +1,87 @@
+---
+description: Deploy Appsmith on a Kubernetes cluster
+toc_max_heading_level: 2
+---
+
+# Set up Kubernetes Cluster on AWS-EKS
+
+This page provides steps to set up a Kubernetes Cluster with the persistent volume on AWS-EKS.
+
+## Prerequisites
+
+Ensure you have access to the AWS Command Line Interface (CLI). Use the following command to verify whether you can access information related to your account and ARN. This verification confirms that you can connect to and access your Amazon account using the CLI.
+
+  ```bash
+    aws sts get-caller-identity
+  ```
+
+## Create and configure cluster
+
+Follow these steps to create a `KubeConfig` and define a storage class that automatically generates a persistent volume during [installation of Appsmith](/getting-started/setup/installation-guides/kubernetes).
+
+1. Create KubeConfig with:
+
+    ```bash
+    aws eks update-kubeconfig --region ap-south-1 --name CLUSTER_NAME  --profile <PROFILE_NAME>
+    ```
+
+    In the above command, add the profile name that has access to the AWS-EKS cluster to the `--profile` parameter.
+
+2. Test your Kubernetes configuration with:
+
+    ```bash
+    kubectl cluster-info
+    ```
+
+    The above command provides a summary of the current cluster configuration, including the Kubernetes master and other cluster information.
+
+3. Define a storage class:
+
+   * If your Kubernetes version is prior to `1.23`, execute the following command:
+
+        ```bash
+        kubectl apply -f - <<EOF
+        apiVersion: storage.k8s.io/v1
+        kind: StorageClass
+        metadata:
+        name: gp2
+        provisioner: kubernetes.io/aws-ebs
+        EOF
+        ```
+
+    * If your Kubernetes version is `1.23` or later, follow these steps:
+
+        1. Create an IAM role by following the official Amazon documentation on [Creating the Amazon EBS CSI driver IAM role](https://docs.aws.amazon.com/eks/latest/userguide/csi-iam-role.html).
+
+        2. Add the Amazon Elastic Block Store (Amazon EBS) Container Storage Interface (CSI) driver chart repository:
+
+            ```bash
+            helm repo add aws-ebs-csi-driver https://kubernetes-sigs.github.io/aws-ebs-csi-driver
+            ```
+
+        3. Update the Amazon EBS CSI driver repository:
+
+            ```bash
+            helm repo update
+            ```
+
+        4. Install the Amazon EBS CSI driver:
+
+            ```bash
+            helm upgrade --install aws-ebs-csi-driver --namespace kube-system aws-ebs-csi-driver aws-ebs-csi-driver
+            ```
+
+        5. Verify the installation of the Amazon EBS CSI driver:
+
+            ```bash
+            kubectl get pods -n kube-system -l app.kubernetes.io/name=aws-ebs-csi-driver
+            ```
+
+## Next steps
+
+* [Install Appsmith on Kubernetes Cluster](/getting-started/setup/installation-guides/kubernetes)
+
+## Troubleshooting
+
+If you are facing issues during deployment, refer to the guide on [troubleshooting deployment errors](/help-and-support/troubleshooting-guide/deployment-errors). If you continue to face issues, contact the support team using the chat widget at the bottom right of this page.
+

--- a/website/docs/getting-started/setup/installation-guides/kubernetes/setup-kubernetes-cluster-aws-eks.md
+++ b/website/docs/getting-started/setup/installation-guides/kubernetes/setup-kubernetes-cluster-aws-eks.md
@@ -83,5 +83,5 @@ Follow these steps to create a `KubeConfig` and define a storage class that auto
 
 ## Troubleshooting
 
-If you are facing issues during deployment, refer to the guide on [troubleshooting deployment errors](/help-and-support/troubleshooting-guide/deployment-errors). If you continue to face issues, contact the support team using the chat widget at the bottom right of this page.
+If you are facing issues contact the support team using the chat widget at the bottom right of this page.
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -51,6 +51,7 @@ const sidebars = {
                     id: 'getting-started/setup/installation-guides/kubernetes/README',
                   },
                   items: [
+                    'getting-started/setup/installation-guides/kubernetes/setup-kubernetes-cluster-aws-eks',
                     'getting-started/setup/installation-guides/kubernetes/configure-high-availability',
                     'getting-started/setup/installation-guides/kubernetes/publish-appsmith-online',
                     'getting-started/setup/installation-guides/kubernetes/migrate-to-be-chart',
@@ -641,7 +642,7 @@ const sidebars = {
           collapsed: true,
           label: 'How-to Guides',
           items: [
-            'packages/how-to-guides/use-query-inside-js-module',          ],
+            'packages/how-to-guides/use-query-inside-js-module',],
         },
         {
           type: 'category',


### PR DESCRIPTION
## Description 

Provide a concise summary of the changes made in this pull request.

- A separate guide for setting up a Kubernetes cluster on AWS-EKS
- Updates to the installation guide to remove the setup instructions above and create relevant cross-references

## Type of PR

Check the appropriate box:

- [ ] Review Fixes
- [ ] Documentation Overhaul
- [ ] Feature/Story
    - Link one or more Engineering Tickets
        * 
- [x] A-Force
- [ ] Error in documentation

## Documentation tickets
 Link to one or more documentation tickets:
 - 

## Checklist
Choose only the ones that are applicable.

- [x] Checked for Grammarly suggestions.
- [x] Adhered to the writing checklist.
- [ ] Adhered to the media checklist.
- [ ] Verified and updated cross-references or added redirect rules.
- [ ] Tested the redirect rules on deploy preview.
- [ ] Validated the modifications made to the content on the deploy preview.
- [ ] Validated the CSS modifications on different screen sizes.
