### PR TITLE
feat: added modal name property references, showModal & closeModal usage

### DIFF
--- a/website/docs/reference/appsmith-framework/widget-actions/close-modal.md
+++ b/website/docs/reference/appsmith-framework/widget-actions/close-modal.md
@@ -26,4 +26,4 @@ A string which is the name of the modal widget to close.
 _Example:_
 
 ```javascript
-{{ closeModal("Modal1") }}
+{{ closeModal(Modal1.name) }}

--- a/website/docs/reference/appsmith-framework/widget-actions/show-modal.md
+++ b/website/docs/reference/appsmith-framework/widget-actions/show-modal.md
@@ -48,7 +48,7 @@ If you want to use JavaScript instead of the action selector, you can enable *JS
 
 
 ```javascript
-{{ showModal("ProductDetailsModal") }}
+{{ showModal(ProductDetailsModal.name) }}
 ```
 </dd>
 
@@ -64,7 +64,7 @@ If you want to show a Modal on page load, you can achieve this by using a JSObje
 export default {
     // Function to show Modal
     showMyModal() {
-        showModal('UserDetailsModal'); 
+        showModal(UserDetailsModal.name); 
     }
 }
 // Enable "Run on Page Load" from JSObject settings
@@ -84,7 +84,7 @@ If you need to display Modals conditionally, based on user roles or status, you 
 
 ```js
 // Enable JS next to the event and add the code
-{{currentRow.role === 'admin' ? showModal('adminModal') : showModal('userModal')}}
+{{currentRow.role === 'admin' ? showModal(adminModal.name) : showModal(userModal.name)}}
 ```
 
 This code shows either the `adminModal` or `userModal` based on the role of the selected row in the `userTable`.

--- a/website/docs/reference/widgets/modal.md
+++ b/website/docs/reference/widgets/modal.md
@@ -100,6 +100,19 @@ Reflects whether the widget is visible or not.
 
 </dd>
 
+#### name `string`
+
+<dd>
+
+Reflects the widget name of the modal.
+
+*Example:*
+```js
+{{Modal1.name}}
+```
+
+</dd>
+
 
 ## Update data with Modal
 


### PR DESCRIPTION
## Description 

Provide a concise summary of the changes made in this pull request
- Adds a references property for the Modal widget
- Describes how to use the above property in `showModal` & `closeModal` functions

## Pull request type

Check the appropriate box:

- [ ] Review Fixes
- [ ] Documentation Overhaul
- [x] Feature/Story
    - Link one or more Engineering Tickets
        * 
- [ ] A-Force
- [ ] Error in documentation
- [ ] Maintenance

## Documentation tickets

 Link to one or more documentation tickets:
 - 

## Checklist

From the below options, select the ones that are applicable:

- [x] Checked for Grammarly suggestions.
- [ ] Adhered to the writing checklist.
- [ ] Adhered to the media checklist.
- [ ] Verified and updated cross-references or added redirect rules.
- [ ] Tested the redirect rules on deploy preview.
- [ ] Validated the modifications made to the content on the deploy preview.
- [ ] Validated the CSS modifications on different screen sizes.
