### PR TITLE
chore: Remove version in docker-compose.yml

### DIFF
--- a/website/docs/getting-started/setup/installation-guides/docker/README.mdx
+++ b/website/docs/getting-started/setup/installation-guides/docker/README.mdx
@@ -29,7 +29,6 @@ Follow these steps to install Appsmith:
 2. Create a `docker-compose.yml` file with:
 
    ```yaml
-   version: "3"
    services:
       appsmith:
         image: index.docker.io/appsmith/appsmith-ee


### PR DESCRIPTION
## Description 

This top-level field has been obsoleted.

Ref: <https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-obsolete>.

[Slack thread](https://theappsmith.slack.com/archives/C02MUD8DNUR/p1715156294594419).

## Pull request type

Check the appropriate box:

- [ ] Review Fixes
- [ ] Documentation Overhaul
- [ ] Feature/Story
    - Link one or more Engineering Tickets
        * 
- [ ] A-Force
- [ ] Error in documentation
- [ ] Maintenance

## Documentation tickets

 Link to one or more documentation tickets:
 - 

## Checklist

From the below options, select the ones that are applicable:

- [ ] Checked for Grammarly suggestions.
- [ ] Adhered to the writing checklist.
- [ ] Adhered to the media checklist.
- [ ] Verified and updated cross-references or added redirect rules.
- [ ] Tested the redirect rules on deploy preview.
- [ ] Validated the modifications made to the content on the deploy preview.
- [ ] Validated the CSS modifications on different screen sizes.
