### PR TITLE
fix: add post installation configurations for installation guides

### DIFF
--- a/website/docs/getting-started/setup/installation-guides/aws-ami.md
+++ b/website/docs/getting-started/setup/installation-guides/aws-ami.md
@@ -101,7 +101,7 @@ Once you have completed the installation process, consider performing the tasks 
     </div>
     <hr/>
     <div className="containerDescription">
-      Configure SSO to allow users to sign in using your identity provider. Appsmith supports various SSO providers, including Google and GitHub, using protocols like SAML and OpenID. <a href="/getting-started/setup/instance-configuration/authentication">Learn more about configuring SSO</a>
+      Configure SSO to allow users to sign in using your identity provider. <a href="/getting-started/setup/instance-configuration/authentication">Learn more about configuring SSO</a>
     </div>
     
   </div>
@@ -114,7 +114,7 @@ Once you have completed the installation process, consider performing the tasks 
     </div>
     <hr/>
     <div className="containerDescription">
-      Set up an email service to enable Appsmith to send notifications and alerts. You can configure providers like AWS SES, Gmail, or others. <a href="/getting-started/setup/instance-configuration/email">Learn more about configuring email services</a>
+      Set up an email service to enable Appsmith to send notifications and alerts. <a href="/getting-started/setup/instance-configuration/email">Learn more about configuring email services</a>
     </div>
     
   </div>
@@ -129,9 +129,7 @@ Once you have completed the installation process, consider performing the tasks 
     </div>
     <hr/>
     <div className="containerDescription">
-      Set up a custom domain for your Appsmith instance and secure it with SSL. A default SSL certificate from Let's Encrypt is provided. If you use a custom SSL certificate, you will need to <a href="/getting-started/setup/instance-configuration/custom-domain/custom-ca-root-certificate">
-        <strong>install custom CA root certificates</strong>
-      </a> to ensure proper security and integration. <a href="/getting-started/setup/instance-configuration/custom-domain">Learn more about setting up custom domains and SSL</a>
+      Set up a custom domain for your Appsmith instance and secure it with SSL <a href="/getting-started/setup/instance-configuration/custom-domain">Learn more about setting up custom domains and SSL</a>
     </div>
     
   </div>

--- a/website/docs/getting-started/setup/installation-guides/aws-ami.md
+++ b/website/docs/getting-started/setup/installation-guides/aws-ami.md
@@ -88,6 +88,68 @@ The application password is **only** available in system logs for the initial 24
 
 To install the open source edition of Appsmith (Appsmith Community), choose the [Appsmith Community Edition](https://aws.amazon.com/marketplace/pp/prodview-mclslaty46ah4) in step 7 of the [Install Appsmith](#install-appsmith) section on this page.
 
+
+## Post-installation configuration
+
+Once you have completed the installation process, consider performing the tasks below to configure and manage your Appsmith instance, enhancing its security and performance, specifically if it's intended for production use.
+<div className="containerGridSampleApp">
+  <div className="containerColumnSampleApp columnGrid column-one">
+    <div className="containerCol">
+      <a href="/getting-started/setup/instance-configuration/authentication">
+        <strong>Configure Single Sign-on (SSO)</strong>
+      </a>
+    </div>
+    <hr/>
+    <div className="containerDescription">
+      Configure SSO to allow users to sign in using your identity provider. Appsmith supports various SSO providers, including Google and GitHub, using protocols like SAML and OpenID. <a href="/getting-started/setup/instance-configuration/authentication">Learn more about configuring SSO</a>
+    </div>
+    
+  </div>
+
+  <div className="containerColumnSampleApp columnGrid column-two">
+    <div className="containerCol">
+      <a href="/getting-started/setup/instance-configuration/email">
+        <strong>Configure Email Service</strong>
+      </a>
+    </div>
+    <hr/>
+    <div className="containerDescription">
+      Set up an email service to enable Appsmith to send notifications and alerts. You can configure providers like AWS SES, Gmail, or others. <a href="/getting-started/setup/instance-configuration/email">Learn more about configuring email services</a>
+    </div>
+    
+  </div>
+</div>
+
+<div className="containerGridSampleApp">
+  <div className="containerColumnSampleApp columnGrid column-one">
+    <div className="containerCol">
+      <a href="/getting-started/setup/instance-configuration/custom-domain">
+        <strong>Set Up Custom Domain and SSL</strong>
+      </a>
+    </div>
+    <hr/>
+    <div className="containerDescription">
+      Set up a custom domain for your Appsmith instance and secure it with SSL. A default SSL certificate from Let's Encrypt is provided. If you use a custom SSL certificate, you will need to <a href="/getting-started/setup/instance-configuration/custom-domain/custom-ca-root-certificate">
+        <strong>install custom CA root certificates</strong>
+      </a> to ensure proper security and integration. <a href="/getting-started/setup/instance-configuration/custom-domain">Learn more about setting up custom domains and SSL</a>
+    </div>
+    
+  </div>
+
+  <div className="containerColumnSampleApp columnGrid column-two">
+    <div className="containerCol">
+      <a href="/getting-started/setup/instance-configuration/update-appsmith">
+        <strong>Update Appsmith</strong>
+      </a>
+    </div>
+    <hr/>
+    <div className="containerDescription">
+      Update Appsmith to the latest version on your self-hosted Appsmith instance to benefit from the latest features and improvements.  <a href="/getting-started/setup/instance-configuration/update-appsmith">Learn more about updating Appsmith</a>
+    </div>
+   
+  </div>
+</div>
+
 ## Troubleshooting
 
 If you are facing issues during deployment, please refer to the guide on [troubleshooting deployment errors](/help-and-support/troubleshooting-guide/deployment-errors).

--- a/website/docs/getting-started/setup/installation-guides/aws-ami.md
+++ b/website/docs/getting-started/setup/installation-guides/aws-ami.md
@@ -135,16 +135,16 @@ Once you have completed the installation process, consider performing the tasks 
   </div>
 
   <div className="containerColumnSampleApp columnGrid column-two">
-    <div className="containerCol">
-      <a href="/getting-started/setup/instance-management/update-appsmith">
-        <strong>Update Appsmith</strong>
+     <div className="containerCol">
+      <a href="/getting-started/setup/instance-management/appsmithctl">
+        <strong>Backup and Restore</strong>
       </a>
     </div>
     <hr/>
     <div className="containerDescription">
-      Update Appsmith to the latest version on your self-hosted Appsmith instance to benefit from the latest features and improvements.  <a href="/getting-started/setup/instance-management/update-appsmith">Learn more about updating Appsmith</a>
+      Ensure the safety of your Appsmith instance data by regularly backing up and restoring it when needed. 
+      <a href="/getting-started/setup/instance-management/appsmithctl">Learn more about Backup and Restore</a>
     </div>
-   
   </div>
 </div>
 

--- a/website/docs/getting-started/setup/installation-guides/aws-ami.md
+++ b/website/docs/getting-started/setup/installation-guides/aws-ami.md
@@ -138,13 +138,13 @@ Once you have completed the installation process, consider performing the tasks 
 
   <div className="containerColumnSampleApp columnGrid column-two">
     <div className="containerCol">
-      <a href="/getting-started/setup/instance-configuration/update-appsmith">
+      <a href="/getting-started/setup/instance-management/update-appsmith">
         <strong>Update Appsmith</strong>
       </a>
     </div>
     <hr/>
     <div className="containerDescription">
-      Update Appsmith to the latest version on your self-hosted Appsmith instance to benefit from the latest features and improvements.  <a href="/getting-started/setup/instance-configuration/update-appsmith">Learn more about updating Appsmith</a>
+      Update Appsmith to the latest version on your self-hosted Appsmith instance to benefit from the latest features and improvements.  <a href="/getting-started/setup/instance-management/update-appsmith">Learn more about updating Appsmith</a>
     </div>
    
   </div>

--- a/website/docs/getting-started/setup/installation-guides/aws-ecs-on-fargate.md
+++ b/website/docs/getting-started/setup/installation-guides/aws-ecs-on-fargate.md
@@ -239,6 +239,67 @@ Follow these steps to create and run an ECS service:
 
 To install the Appsmith open source edition (Appsmith Community), replace `appsmith-ee` with `appsmith-ce` in step 4 of the [Create task and container definitions](#create-task-and-container-definitions) section on this page.
 
+## Post-installation configuration
+
+Once you have completed the installation process, consider performing the tasks below to configure and manage your Appsmith instance, enhancing its security and performance, specifically if it's intended for production use.
+
+<div className="containerGridSampleApp">
+  <div className="containerColumnSampleApp columnGrid column-one">
+    <div className="containerCol">
+      <a href="/getting-started/setup/installation-guides/aws-ecs/set-up-high-availability">
+        <strong>Set Up High Availability (HA)</strong>
+      </a>
+    </div>
+    <hr/>
+    <div className="containerDescription">
+      Configure high availability for your Appsmith deployment on AWS ECS on Fargate. This setup ensures that your applications are resilient and can handle increased load effectively. <a href="/getting-started/setup/installation-guides/aws-ecs/set-up-high-availability">Learn more about setting up high availability</a>
+    </div>
+  </div>
+
+  <div className="containerColumnSampleApp columnGrid column-two">
+    <div className="containerCol">
+      <a href="/getting-started/setup/instance-configuration/authentication">
+        <strong>Configure Single Sign-on (SSO)</strong>
+      </a>
+    </div>
+    <hr/>
+    <div className="containerDescription">
+      Configure SSO to allow users to sign in using your identity provider. Appsmith supports various SSO providers, including Google and GitHub, using protocols like SAML and OpenID.
+      <a href="/getting-started/setup/instance-configuration/authentication">Learn more about configuring SSO</a>
+    </div>
+  </div>
+</div>
+
+<div className="containerGridSampleApp">
+  <div className="containerColumnSampleApp columnGrid column-one">
+    <div className="containerCol">
+      <a href="/getting-started/setup/instance-configuration/email">
+        <strong>Configure Email Service</strong>
+      </a>
+    </div>
+    <hr/>
+    <div className="containerDescription">
+      Set up an email service to enable Appsmith to send notifications and alerts. You can configure providers like AWS SES, Gmail, or others.
+      <a href="/getting-started/setup/instance-configuration/email">Learn more about configuring email services</a>
+    </div>
+  </div>
+
+  <div className="containerColumnSampleApp columnGrid column-two">
+    <div className="containerCol">
+      <a href="/getting-started/setup/instance-configuration/custom-domain">
+        <strong>Set Up Custom Domain and SSL</strong>
+      </a>
+    </div>
+    <hr/>
+    <div className="containerDescription">
+      Set up a custom domain for your Appsmith instance and secure it with SSL. A default SSL certificate from Let's Encrypt is provided. If you use a custom SSL certificate, you will need to <a href="/getting-started/setup/instance-configuration/custom-domain/custom-ca-root-certificate">
+        <strong>install custom CA root certificates</strong>
+      </a> to ensure proper security and integration.
+      <a href="/getting-started/setup/instance-configuration/custom-domain">Learn more about setting up custom domains and SSL</a>
+    </div>
+  </div>
+</div>
+
 ## Troubleshooting
 
 If you are facing issues during deployment, please refer to the guide on [troubleshooting deployment errors](/help-and-support/troubleshooting-guide/deployment-errors).

--- a/website/docs/getting-started/setup/installation-guides/aws-ecs-on-fargate.md
+++ b/website/docs/getting-started/setup/installation-guides/aws-ecs-on-fargate.md
@@ -252,7 +252,7 @@ Once you have completed the installation process, consider performing the tasks 
     </div>
     <hr/>
     <div className="containerDescription">
-      Configure high availability for your Appsmith deployment on AWS ECS on Fargate. This setup ensures that your applications are resilient and can handle increased load effectively. <a href="/getting-started/setup/installation-guides/aws-ecs/set-up-high-availability">Learn more about setting up high availability</a>
+      Configure high availability for your Appsmith deployment on AWS Fargate to handle increased load. <a href="/getting-started/setup/installation-guides/aws-ecs/set-up-high-availability">Learn more about setting up high availability</a>
     </div>
   </div>
 
@@ -264,7 +264,7 @@ Once you have completed the installation process, consider performing the tasks 
     </div>
     <hr/>
     <div className="containerDescription">
-      Configure SSO to allow users to sign in using your identity provider. Appsmith supports various SSO providers, including Google and GitHub, using protocols like SAML and OpenID.
+      Configure SSO to allow users to sign in using your identity provider.
       <a href="/getting-started/setup/instance-configuration/authentication">Learn more about configuring SSO</a>
     </div>
   </div>
@@ -279,7 +279,7 @@ Once you have completed the installation process, consider performing the tasks 
     </div>
     <hr/>
     <div className="containerDescription">
-      Set up an email service to enable Appsmith to send notifications and alerts. You can configure providers like AWS SES, Gmail, or others.
+      Set up an email service to enable Appsmith to send notifications and alerts.
       <a href="/getting-started/setup/instance-configuration/email">Learn more about configuring email services</a>
     </div>
   </div>
@@ -292,9 +292,7 @@ Once you have completed the installation process, consider performing the tasks 
     </div>
     <hr/>
     <div className="containerDescription">
-      Set up a custom domain for your Appsmith instance and secure it with SSL. A default SSL certificate from Let's Encrypt is provided. If you use a custom SSL certificate, you will need to <a href="/getting-started/setup/instance-configuration/custom-domain/custom-ca-root-certificate">
-        install custom CA root certificates
-      </a> to ensure proper security and integration.
+      Set up a custom domain for your Appsmith instance and secure it with SSL. 
       <a href="/getting-started/setup/instance-configuration/custom-domain">Learn more about setting up custom domains and SSL</a>
     </div>
   </div>

--- a/website/docs/getting-started/setup/installation-guides/aws-ecs-on-fargate.md
+++ b/website/docs/getting-started/setup/installation-guides/aws-ecs-on-fargate.md
@@ -293,7 +293,7 @@ Once you have completed the installation process, consider performing the tasks 
     <hr/>
     <div className="containerDescription">
       Set up a custom domain for your Appsmith instance and secure it with SSL. A default SSL certificate from Let's Encrypt is provided. If you use a custom SSL certificate, you will need to <a href="/getting-started/setup/instance-configuration/custom-domain/custom-ca-root-certificate">
-        <strong>install custom CA root certificates</strong>
+        install custom CA root certificates
       </a> to ensure proper security and integration.
       <a href="/getting-started/setup/instance-configuration/custom-domain">Learn more about setting up custom domains and SSL</a>
     </div>

--- a/website/docs/getting-started/setup/installation-guides/aws-ecs/aws-ecs-on-ec2.md
+++ b/website/docs/getting-started/setup/installation-guides/aws-ecs/aws-ecs-on-ec2.md
@@ -166,7 +166,7 @@ Once you have completed the installation process, consider performing the tasks 
     <hr/>
     <div className="containerDescription">
       Set up a custom domain for your Appsmith instance and secure it with SSL. A default SSL certificate from Let's Encrypt is provided. If you use a custom SSL certificate, you will need to <a href="/getting-started/setup/instance-configuration/custom-domain/custom-ca-root-certificate">
-        <strong>install custom CA root certificates</strong>
+        install custom CA root certificates
       </a> to ensure proper security and integration. <a href="/getting-started/setup/instance-configuration/custom-domain">Learn more about setting up custom domains and SSL</a>
     </div>
     
@@ -174,15 +174,15 @@ Once you have completed the installation process, consider performing the tasks 
 
   <div className="containerColumnSampleApp columnGrid column-two">
     <div className="containerCol">
-      <a href="/getting-started/setup/instance-configuration/update-appsmith">
+      <a href="/getting-started/setup/instance-management/update-appsmith">
         <strong>Update Appsmith</strong>
       </a>
     </div>
     <hr/>
     <div className="containerDescription">
-      Update Appsmith to the latest version on your self-hosted Appsmith instance to benefit from the latest features and improvements.  <a href="/getting-started/setup/instance-configuration/update-appsmith">Learn more about updating Appsmith</a>
+      Update Appsmith to the latest version on your self-hosted Appsmith instance to benefit from the latest features and improvements. <a href="/getting-started/setup/instance-management/update-appsmith">Learn more about updating Appsmith</a>
     </div>
-   
+
   </div>
 </div>
 

--- a/website/docs/getting-started/setup/installation-guides/aws-ecs/aws-ecs-on-ec2.md
+++ b/website/docs/getting-started/setup/installation-guides/aws-ecs/aws-ecs-on-ec2.md
@@ -171,16 +171,16 @@ Once you have completed the installation process, consider performing the tasks 
   </div>
 
   <div className="containerColumnSampleApp columnGrid column-two">
-    <div className="containerCol">
-      <a href="/getting-started/setup/instance-management/update-appsmith">
-        <strong>Update Appsmith</strong>
+     <div className="containerCol">
+      <a href="/getting-started/setup/instance-management/appsmithctl">
+        <strong>Backup and Restore</strong>
       </a>
     </div>
     <hr/>
     <div className="containerDescription">
-      Update Appsmith to the latest version on your self-hosted Appsmith instance to benefit from the latest features and improvements. <a href="/getting-started/setup/instance-management/update-appsmith">Learn more about updating Appsmith</a>
+      Ensure the safety of your Appsmith instance data by regularly backing up and restoring it when needed. 
+      <a href="/getting-started/setup/instance-management/appsmithctl">Learn more about Backup and Restore</a>
     </div>
-
   </div>
 </div>
 

--- a/website/docs/getting-started/setup/installation-guides/aws-ecs/aws-ecs-on-ec2.md
+++ b/website/docs/getting-started/setup/installation-guides/aws-ecs/aws-ecs-on-ec2.md
@@ -124,6 +124,68 @@ To deploy Appsmith on the Amazon ECS cluster that has a single node, you need to
 
 For the Appsmith open source edition (Appsmith Community), substitute `appsmith/appsmith-ee` with `appsmith/appsmith-ce` in the container definition for **Container-1** in the [Create task and container definition](#create-task-and-container-definition) section on this page.
 
+
+## Post-installation configuration
+
+Once you have completed the installation process, consider performing the tasks below to configure and manage your Appsmith instance, enhancing its security and performance, specifically if it's intended for production use.
+<div className="containerGridSampleApp">
+  <div className="containerColumnSampleApp columnGrid column-one">
+    <div className="containerCol">
+      <a href="/getting-started/setup/instance-configuration/authentication">
+        <strong>Configure Single Sign-on (SSO)</strong>
+      </a>
+    </div>
+    <hr/>
+    <div className="containerDescription">
+      Configure SSO to allow users to sign in using your identity provider. Appsmith supports various SSO providers, including Google and GitHub, using protocols like SAML and OpenID. <a href="/getting-started/setup/instance-configuration/authentication">Learn more about configuring SSO</a>
+    </div>
+    
+  </div>
+
+  <div className="containerColumnSampleApp columnGrid column-two">
+    <div className="containerCol">
+      <a href="/getting-started/setup/instance-configuration/email">
+        <strong>Configure Email Service</strong>
+      </a>
+    </div>
+    <hr/>
+    <div className="containerDescription">
+      Set up an email service to enable Appsmith to send notifications and alerts. You can configure providers like AWS SES, Gmail, or others. <a href="/getting-started/setup/instance-configuration/email">Learn more about configuring email services</a>
+    </div>
+    
+  </div>
+</div>
+
+<div className="containerGridSampleApp">
+  <div className="containerColumnSampleApp columnGrid column-one">
+    <div className="containerCol">
+      <a href="/getting-started/setup/instance-configuration/custom-domain">
+        <strong>Set Up Custom Domain and SSL</strong>
+      </a>
+    </div>
+    <hr/>
+    <div className="containerDescription">
+      Set up a custom domain for your Appsmith instance and secure it with SSL. A default SSL certificate from Let's Encrypt is provided. If you use a custom SSL certificate, you will need to <a href="/getting-started/setup/instance-configuration/custom-domain/custom-ca-root-certificate">
+        <strong>install custom CA root certificates</strong>
+      </a> to ensure proper security and integration. <a href="/getting-started/setup/instance-configuration/custom-domain">Learn more about setting up custom domains and SSL</a>
+    </div>
+    
+  </div>
+
+  <div className="containerColumnSampleApp columnGrid column-two">
+    <div className="containerCol">
+      <a href="/getting-started/setup/instance-configuration/update-appsmith">
+        <strong>Update Appsmith</strong>
+      </a>
+    </div>
+    <hr/>
+    <div className="containerDescription">
+      Update Appsmith to the latest version on your self-hosted Appsmith instance to benefit from the latest features and improvements.  <a href="/getting-started/setup/instance-configuration/update-appsmith">Learn more about updating Appsmith</a>
+    </div>
+   
+  </div>
+</div>
+
 ## Troubleshooting
 
 If you are facing issues during deployment, refer to the guide on [troubleshooting deployment errors](/help-and-support/troubleshooting-guide/deployment-errors). If you continue to face issues, reach out to the support team via the chat widget on this page.

--- a/website/docs/getting-started/setup/installation-guides/aws-ecs/aws-ecs-on-ec2.md
+++ b/website/docs/getting-started/setup/installation-guides/aws-ecs/aws-ecs-on-ec2.md
@@ -137,7 +137,7 @@ Once you have completed the installation process, consider performing the tasks 
     </div>
     <hr/>
     <div className="containerDescription">
-      Configure SSO to allow users to sign in using your identity provider. Appsmith supports various SSO providers, including Google and GitHub, using protocols like SAML and OpenID. <a href="/getting-started/setup/instance-configuration/authentication">Learn more about configuring SSO</a>
+      Configure SSO to allow users to sign in using your identity provider. <a href="/getting-started/setup/instance-configuration/authentication">Learn more about configuring SSO</a>
     </div>
     
   </div>
@@ -150,7 +150,7 @@ Once you have completed the installation process, consider performing the tasks 
     </div>
     <hr/>
     <div className="containerDescription">
-      Set up an email service to enable Appsmith to send notifications and alerts. You can configure providers like AWS SES, Gmail, or others. <a href="/getting-started/setup/instance-configuration/email">Learn more about configuring email services</a>
+      Set up an email service to enable Appsmith to send notifications and alerts. <a href="/getting-started/setup/instance-configuration/email">Learn more about configuring email services</a>
     </div>
     
   </div>
@@ -165,9 +165,7 @@ Once you have completed the installation process, consider performing the tasks 
     </div>
     <hr/>
     <div className="containerDescription">
-      Set up a custom domain for your Appsmith instance and secure it with SSL. A default SSL certificate from Let's Encrypt is provided. If you use a custom SSL certificate, you will need to <a href="/getting-started/setup/instance-configuration/custom-domain/custom-ca-root-certificate">
-        install custom CA root certificates
-      </a> to ensure proper security and integration. <a href="/getting-started/setup/instance-configuration/custom-domain">Learn more about setting up custom domains and SSL</a>
+      Set up a custom domain for your Appsmith instance and secure it with SSL.  <a href="/getting-started/setup/instance-configuration/custom-domain">Learn more about setting up custom domains and SSL</a>
     </div>
     
   </div>

--- a/website/docs/getting-started/setup/installation-guides/azure-aci.md
+++ b/website/docs/getting-started/setup/installation-guides/azure-aci.md
@@ -134,16 +134,16 @@ Once you have completed the installation process, consider performing the tasks 
   </div>
 
   <div className="containerColumnSampleApp columnGrid column-two">
-    <div className="containerCol">
-      <a href="/getting-started/setup/instance-management/update-appsmith">
-        <strong>Update Appsmith</strong>
+     <div className="containerCol">
+      <a href="/getting-started/setup/instance-management/appsmithctl">
+        <strong>Backup and Restore</strong>
       </a>
     </div>
     <hr/>
     <div className="containerDescription">
-      Update Appsmith to the latest version on your self-hosted Appsmith instance to benefit from the latest features and improvements.  <a href="/getting-started/setup/instance-management/update-appsmith">Learn more about updating Appsmith</a>
+      Ensure the safety of your Appsmith instance data by regularly backing up and restoring it when needed. 
+      <a href="/getting-started/setup/instance-management/appsmithctl">Learn more about Backup and Restore</a>
     </div>
-   
   </div>
 </div>
 

--- a/website/docs/getting-started/setup/installation-guides/azure-aci.md
+++ b/website/docs/getting-started/setup/installation-guides/azure-aci.md
@@ -129,7 +129,7 @@ Once you have completed the installation process, consider performing the tasks 
     <hr/>
     <div className="containerDescription">
       Set up a custom domain for your Appsmith instance and secure it with SSL. A default SSL certificate from Let's Encrypt is provided. If you use a custom SSL certificate, you will need to <a href="/getting-started/setup/instance-configuration/custom-domain/custom-ca-root-certificate">
-        <strong>install custom CA root certificates</strong>
+        install custom CA root certificates
       </a> to ensure proper security and integration. <a href="/getting-started/setup/instance-configuration/custom-domain">Learn more about setting up custom domains and SSL</a>
     </div>
     
@@ -137,13 +137,13 @@ Once you have completed the installation process, consider performing the tasks 
 
   <div className="containerColumnSampleApp columnGrid column-two">
     <div className="containerCol">
-      <a href="/getting-started/setup/instance-configuration/update-appsmith">
+      <a href="/getting-started/setup/instance-management/update-appsmith">
         <strong>Update Appsmith</strong>
       </a>
     </div>
     <hr/>
     <div className="containerDescription">
-      Update Appsmith to the latest version on your self-hosted Appsmith instance to benefit from the latest features and improvements.  <a href="/getting-started/setup/instance-configuration/update-appsmith">Learn more about updating Appsmith</a>
+      Update Appsmith to the latest version on your self-hosted Appsmith instance to benefit from the latest features and improvements.  <a href="/getting-started/setup/instance-management/update-appsmith">Learn more about updating Appsmith</a>
     </div>
    
   </div>

--- a/website/docs/getting-started/setup/installation-guides/azure-aci.md
+++ b/website/docs/getting-started/setup/installation-guides/azure-aci.md
@@ -87,6 +87,68 @@ az storage share create --name $fileShareName --account-name $storageAccountName
 
 To install the Appsmith open source edition (Appsmith Community), replace `appsmith-ee` with `appsmith-ce` while creating an Azure container instance file on this page.
 
+
+## Post-installation configuration
+
+Once you have completed the installation process, consider performing the tasks below to configure and manage your Appsmith instance, enhancing its security and performance, specifically if it's intended for production use.
+<div className="containerGridSampleApp">
+  <div className="containerColumnSampleApp columnGrid column-one">
+    <div className="containerCol">
+      <a href="/getting-started/setup/instance-configuration/authentication">
+        <strong>Configure Single Sign-on (SSO)</strong>
+      </a>
+    </div>
+    <hr/>
+    <div className="containerDescription">
+      Configure SSO to allow users to sign in using your identity provider. Appsmith supports various SSO providers, including Google and GitHub, using protocols like SAML and OpenID. <a href="/getting-started/setup/instance-configuration/authentication">Learn more about configuring SSO</a>
+    </div>
+    
+  </div>
+
+  <div className="containerColumnSampleApp columnGrid column-two">
+    <div className="containerCol">
+      <a href="/getting-started/setup/instance-configuration/email">
+        <strong>Configure Email Service</strong>
+      </a>
+    </div>
+    <hr/>
+    <div className="containerDescription">
+      Set up an email service to enable Appsmith to send notifications and alerts. You can configure providers like AWS SES, Gmail, or others. <a href="/getting-started/setup/instance-configuration/email">Learn more about configuring email services</a>
+    </div>
+    
+  </div>
+</div>
+
+<div className="containerGridSampleApp">
+  <div className="containerColumnSampleApp columnGrid column-one">
+    <div className="containerCol">
+      <a href="/getting-started/setup/instance-configuration/custom-domain">
+        <strong>Set Up Custom Domain and SSL</strong>
+      </a>
+    </div>
+    <hr/>
+    <div className="containerDescription">
+      Set up a custom domain for your Appsmith instance and secure it with SSL. A default SSL certificate from Let's Encrypt is provided. If you use a custom SSL certificate, you will need to <a href="/getting-started/setup/instance-configuration/custom-domain/custom-ca-root-certificate">
+        <strong>install custom CA root certificates</strong>
+      </a> to ensure proper security and integration. <a href="/getting-started/setup/instance-configuration/custom-domain">Learn more about setting up custom domains and SSL</a>
+    </div>
+    
+  </div>
+
+  <div className="containerColumnSampleApp columnGrid column-two">
+    <div className="containerCol">
+      <a href="/getting-started/setup/instance-configuration/update-appsmith">
+        <strong>Update Appsmith</strong>
+      </a>
+    </div>
+    <hr/>
+    <div className="containerDescription">
+      Update Appsmith to the latest version on your self-hosted Appsmith instance to benefit from the latest features and improvements.  <a href="/getting-started/setup/instance-configuration/update-appsmith">Learn more about updating Appsmith</a>
+    </div>
+   
+  </div>
+</div>
+
 ## Troubleshooting
 
 If you are facing issues during deployment, please refer to the guide on [troubleshooting deployment errors](/help-and-support/troubleshooting-guide/deployment-errors).

--- a/website/docs/getting-started/setup/installation-guides/azure-aci.md
+++ b/website/docs/getting-started/setup/installation-guides/azure-aci.md
@@ -100,7 +100,7 @@ Once you have completed the installation process, consider performing the tasks 
     </div>
     <hr/>
     <div className="containerDescription">
-      Configure SSO to allow users to sign in using your identity provider. Appsmith supports various SSO providers, including Google and GitHub, using protocols like SAML and OpenID. <a href="/getting-started/setup/instance-configuration/authentication">Learn more about configuring SSO</a>
+      Configure SSO to allow users to sign in using your identity provider. <a href="/getting-started/setup/instance-configuration/authentication">Learn more about configuring SSO</a>
     </div>
     
   </div>
@@ -113,7 +113,7 @@ Once you have completed the installation process, consider performing the tasks 
     </div>
     <hr/>
     <div className="containerDescription">
-      Set up an email service to enable Appsmith to send notifications and alerts. You can configure providers like AWS SES, Gmail, or others. <a href="/getting-started/setup/instance-configuration/email">Learn more about configuring email services</a>
+      Set up an email service to enable Appsmith to send notifications and alerts. <a href="/getting-started/setup/instance-configuration/email">Learn more about configuring email services</a>
     </div>
     
   </div>
@@ -128,9 +128,7 @@ Once you have completed the installation process, consider performing the tasks 
     </div>
     <hr/>
     <div className="containerDescription">
-      Set up a custom domain for your Appsmith instance and secure it with SSL. A default SSL certificate from Let's Encrypt is provided. If you use a custom SSL certificate, you will need to <a href="/getting-started/setup/instance-configuration/custom-domain/custom-ca-root-certificate">
-        install custom CA root certificates
-      </a> to ensure proper security and integration. <a href="/getting-started/setup/instance-configuration/custom-domain">Learn more about setting up custom domains and SSL</a>
+      Set up a custom domain for your Appsmith instance and secure it with SSL.  <a href="/getting-started/setup/instance-configuration/custom-domain">Learn more about setting up custom domains and SSL</a>
     </div>
     
   </div>

--- a/website/docs/getting-started/setup/installation-guides/digitalocean.md
+++ b/website/docs/getting-started/setup/installation-guides/digitalocean.md
@@ -60,6 +60,68 @@ cd /root/appsmith && docker-compose pull && docker-compose rm -fsv appsmith && d
 
 If you have updated your Appsmith instance and face any issues. You can roll back the changes and [restore the Appsmith instance](/getting-started/setup/instance-management/appsmithctl#restore-instance) from a backup archive.
 
+
+## Post-installation configuration
+
+Once you have completed the installation process, consider performing the tasks below to configure and manage your Appsmith instance, enhancing its security and performance, specifically if it's intended for production use.
+<div className="containerGridSampleApp">
+  <div className="containerColumnSampleApp columnGrid column-one">
+    <div className="containerCol">
+      <a href="/getting-started/setup/instance-configuration/authentication">
+        <strong>Configure Single Sign-on (SSO)</strong>
+      </a>
+    </div>
+    <hr/>
+    <div className="containerDescription">
+      Configure SSO to allow users to sign in using your identity provider. Appsmith supports various SSO providers, including Google and GitHub, using protocols like SAML and OpenID. <a href="/getting-started/setup/instance-configuration/authentication">Learn more about configuring SSO</a>
+    </div>
+    
+  </div>
+
+  <div className="containerColumnSampleApp columnGrid column-two">
+    <div className="containerCol">
+      <a href="/getting-started/setup/instance-configuration/email">
+        <strong>Configure Email Service</strong>
+      </a>
+    </div>
+    <hr/>
+    <div className="containerDescription">
+      Set up an email service to enable Appsmith to send notifications and alerts. You can configure providers like AWS SES, Gmail, or others. <a href="/getting-started/setup/instance-configuration/email">Learn more about configuring email services</a>
+    </div>
+    
+  </div>
+</div>
+
+<div className="containerGridSampleApp">
+  <div className="containerColumnSampleApp columnGrid column-one">
+    <div className="containerCol">
+      <a href="/getting-started/setup/instance-configuration/custom-domain">
+        <strong>Set Up Custom Domain and SSL</strong>
+      </a>
+    </div>
+    <hr/>
+    <div className="containerDescription">
+      Set up a custom domain for your Appsmith instance and secure it with SSL. A default SSL certificate from Let's Encrypt is provided. If you use a custom SSL certificate, you will need to <a href="/getting-started/setup/instance-configuration/custom-domain/custom-ca-root-certificate">
+        <strong>install custom CA root certificates</strong>
+      </a> to ensure proper security and integration. <a href="/getting-started/setup/instance-configuration/custom-domain">Learn more about setting up custom domains and SSL</a>
+    </div>
+    
+  </div>
+
+  <div className="containerColumnSampleApp columnGrid column-two">
+    <div className="containerCol">
+      <a href="/getting-started/setup/instance-configuration/update-appsmith">
+        <strong>Update Appsmith</strong>
+      </a>
+    </div>
+    <hr/>
+    <div className="containerDescription">
+      Update Appsmith to the latest version on your self-hosted Appsmith instance to benefit from the latest features and improvements.  <a href="/getting-started/setup/instance-configuration/update-appsmith">Learn more about updating Appsmith</a>
+    </div>
+   
+  </div>
+</div>
+
 ## Troubleshooting
 
 If you are facing issues during deployment, please refer to the guide on [troubleshooting deployment errors](/help-and-support/troubleshooting-guide/deployment-errors).

--- a/website/docs/getting-started/setup/installation-guides/digitalocean.md
+++ b/website/docs/getting-started/setup/installation-guides/digitalocean.md
@@ -107,16 +107,16 @@ Once you have completed the installation process, consider performing the tasks 
   </div>
 
   <div className="containerColumnSampleApp columnGrid column-two">
-    <div className="containerCol">
-      <a href="/getting-started/setup/instance-management/update-appsmith">
-        <strong>Update Appsmith</strong>
+     <div className="containerCol">
+      <a href="/getting-started/setup/instance-management/appsmithctl">
+        <strong>Backup and Restore</strong>
       </a>
     </div>
     <hr/>
     <div className="containerDescription">
-      Update Appsmith to the latest version on your self-hosted Appsmith instance to benefit from the latest features and improvements.  <a href="/getting-started/setup/instance-management/update-appsmith">Learn more about updating Appsmith</a>
+      Ensure the safety of your Appsmith instance data by regularly backing up and restoring it when needed. 
+      <a href="/getting-started/setup/instance-management/appsmithctl">Learn more about Backup and Restore</a>
     </div>
-   
   </div>
 </div>
 

--- a/website/docs/getting-started/setup/installation-guides/digitalocean.md
+++ b/website/docs/getting-started/setup/installation-guides/digitalocean.md
@@ -73,7 +73,7 @@ Once you have completed the installation process, consider performing the tasks 
     </div>
     <hr/>
     <div className="containerDescription">
-      Configure SSO to allow users to sign in using your identity provider. Appsmith supports various SSO providers, including Google and GitHub, using protocols like SAML and OpenID. <a href="/getting-started/setup/instance-configuration/authentication">Learn more about configuring SSO</a>
+      Configure SSO to allow users to sign in using your identity provider. <a href="/getting-started/setup/instance-configuration/authentication">Learn more about configuring SSO</a>
     </div>
     
   </div>
@@ -86,7 +86,7 @@ Once you have completed the installation process, consider performing the tasks 
     </div>
     <hr/>
     <div className="containerDescription">
-      Set up an email service to enable Appsmith to send notifications and alerts. You can configure providers like AWS SES, Gmail, or others. <a href="/getting-started/setup/instance-configuration/email">Learn more about configuring email services</a>
+      Set up an email service to enable Appsmith to send notifications and alerts. <a href="/getting-started/setup/instance-configuration/email">Learn more about configuring email services</a>
     </div>
     
   </div>
@@ -101,9 +101,7 @@ Once you have completed the installation process, consider performing the tasks 
     </div>
     <hr/>
     <div className="containerDescription">
-      Set up a custom domain for your Appsmith instance and secure it with SSL. A default SSL certificate from Let's Encrypt is provided. If you use a custom SSL certificate, you will need to <a href="/getting-started/setup/instance-configuration/custom-domain/custom-ca-root-certificate">
-        install custom CA root certificates
-      </a> to ensure proper security and integration. <a href="/getting-started/setup/instance-configuration/custom-domain">Learn more about setting up custom domains and SSL</a>
+      Set up a custom domain for your Appsmith instance and secure it with SSL.  <a href="/getting-started/setup/instance-configuration/custom-domain">Learn more about setting up custom domains and SSL</a>
     </div>
     
   </div>

--- a/website/docs/getting-started/setup/installation-guides/digitalocean.md
+++ b/website/docs/getting-started/setup/installation-guides/digitalocean.md
@@ -102,7 +102,7 @@ Once you have completed the installation process, consider performing the tasks 
     <hr/>
     <div className="containerDescription">
       Set up a custom domain for your Appsmith instance and secure it with SSL. A default SSL certificate from Let's Encrypt is provided. If you use a custom SSL certificate, you will need to <a href="/getting-started/setup/instance-configuration/custom-domain/custom-ca-root-certificate">
-        <strong>install custom CA root certificates</strong>
+        install custom CA root certificates
       </a> to ensure proper security and integration. <a href="/getting-started/setup/instance-configuration/custom-domain">Learn more about setting up custom domains and SSL</a>
     </div>
     
@@ -110,13 +110,13 @@ Once you have completed the installation process, consider performing the tasks 
 
   <div className="containerColumnSampleApp columnGrid column-two">
     <div className="containerCol">
-      <a href="/getting-started/setup/instance-configuration/update-appsmith">
+      <a href="/getting-started/setup/instance-management/update-appsmith">
         <strong>Update Appsmith</strong>
       </a>
     </div>
     <hr/>
     <div className="containerDescription">
-      Update Appsmith to the latest version on your self-hosted Appsmith instance to benefit from the latest features and improvements.  <a href="/getting-started/setup/instance-configuration/update-appsmith">Learn more about updating Appsmith</a>
+      Update Appsmith to the latest version on your self-hosted Appsmith instance to benefit from the latest features and improvements.  <a href="/getting-started/setup/instance-management/update-appsmith">Learn more about updating Appsmith</a>
     </div>
    
   </div>

--- a/website/docs/getting-started/setup/installation-guides/docker/README.mdx
+++ b/website/docs/getting-started/setup/installation-guides/docker/README.mdx
@@ -57,11 +57,71 @@ Follow these steps to install Appsmith:
 
 6. Once you've created an account, you can either start with the free plan or activate your instance with a license key. If you want to generate a license key, sign up on [customer.appsmith.com](https://customer.appsmith.com) to create one, and then proceed to activate your instance using the newly generated license key.
 
+## Post-installation configuration
+
+Once you have completed the installation process, consider performing the tasks below to configure and manage your Appsmith instance, enhancing its security and performance, specifically if it's intended for production use.
+<div className="containerGridSampleApp">
+  <div className="containerColumnSampleApp columnGrid column-one">
+    <div className="containerCol">
+      <a href="/getting-started/setup/instance-configuration/authentication">
+        <strong>Configure Single Sign-on (SSO)</strong>
+      </a>
+    </div>
+    <hr/>
+    <div className="containerDescription">
+      Configure SSO to allow users to sign in using your identity provider. Appsmith supports various SSO providers, including Google and GitHub, using protocols like SAML and OpenID. <a href="/getting-started/setup/instance-configuration/authentication">Learn more about configuring SSO</a>
+    </div>
+    
+  </div>
+
+  <div className="containerColumnSampleApp columnGrid column-two">
+    <div className="containerCol">
+      <a href="/getting-started/setup/instance-configuration/email">
+        <strong>Configure Email Service</strong>
+      </a>
+    </div>
+    <hr/>
+    <div className="containerDescription">
+      Set up an email service to enable Appsmith to send notifications and alerts. You can configure providers like AWS SES, Gmail, or others. <a href="/getting-started/setup/instance-configuration/email">Learn more about configuring email services</a>
+    </div>
+    
+  </div>
+</div>
+
+<div className="containerGridSampleApp">
+  <div className="containerColumnSampleApp columnGrid column-one">
+    <div className="containerCol">
+      <a href="/getting-started/setup/instance-configuration/custom-domain">
+        <strong>Set Up Custom Domain and SSL</strong>
+      </a>
+    </div>
+    <hr/>
+    <div className="containerDescription">
+      Set up a custom domain for your Appsmith instance and secure it with SSL. A default SSL certificate from Let's Encrypt is provided. If you use a custom SSL certificate, you will need to <a href="/getting-started/setup/instance-configuration/custom-domain/custom-ca-root-certificate">
+        <strong>install custom CA root certificates</strong>
+      </a> to ensure proper security and integration. <a href="/getting-started/setup/instance-configuration/custom-domain">Learn more about setting up custom domains and SSL</a>
+    </div>
+    
+  </div>
+
+  <div className="containerColumnSampleApp columnGrid column-two">
+    <div className="containerCol">
+      <a href="/getting-started/setup/instance-configuration/update-appsmith">
+        <strong>Update Appsmith</strong>
+      </a>
+    </div>
+    <hr/>
+    <div className="containerDescription">
+      Update Appsmith to the latest version on your self-hosted Appsmith instance to benefit from the latest features and improvements.  <a href="/getting-started/setup/instance-configuration/update-appsmith">Learn more about updating Appsmith</a>
+    </div>
+   
+  </div>
+</div>
+
+
 ## Troubleshooting
 
-If you are facing issues during deployment, please refer to the guide on [troubleshooting deployment errors](/help-and-support/troubleshooting-guide/deployment-errors).
-
-If you continue to face issues, contact the support team using the chat widget at the bottom right of this page.
+If you are facing issues during deployment, please refer to the guide on [troubleshooting deployment errors](/help-and-support/troubleshooting-guide/deployment-errors). If you continue to face issues, contact the support team using the chat widget at the bottom right of this page.
 
 ## Further reading
 

--- a/website/docs/getting-started/setup/installation-guides/docker/README.mdx
+++ b/website/docs/getting-started/setup/installation-guides/docker/README.mdx
@@ -69,7 +69,7 @@ Once you have completed the installation process, consider performing the tasks 
     </div>
     <hr/>
     <div className="containerDescription">
-      Configure SSO to allow users to sign in using your identity provider. Appsmith supports various SSO providers, including Google and GitHub, using protocols like SAML and OpenID. <a href="/getting-started/setup/instance-configuration/authentication">Learn more about configuring SSO</a>
+      Configure SSO to allow users to sign in using your identity provider. <a href="/getting-started/setup/instance-configuration/authentication">Learn more about configuring SSO</a>
     </div>
     
   </div>
@@ -82,7 +82,7 @@ Once you have completed the installation process, consider performing the tasks 
     </div>
     <hr/>
     <div className="containerDescription">
-      Set up an email service to enable Appsmith to send notifications and alerts. You can configure providers like AWS SES, Gmail, or others. <a href="/getting-started/setup/instance-configuration/email">Learn more about configuring email services</a>
+      Set up an email service to enable Appsmith to send notifications and alerts. <a href="/getting-started/setup/instance-configuration/email">Learn more about configuring email services</a>
     </div>
     
   </div>
@@ -97,9 +97,7 @@ Once you have completed the installation process, consider performing the tasks 
     </div>
     <hr/>
     <div className="containerDescription">
-      Set up a custom domain for your Appsmith instance and secure it with SSL. A default SSL certificate from Let's Encrypt is provided. If you use a custom SSL certificate, you will need to <a href="/getting-started/setup/instance-configuration/custom-domain/custom-ca-root-certificate">
-        install custom CA root certificates
-      </a> to ensure proper security and integration. <a href="/getting-started/setup/instance-configuration/custom-domain">Learn more about setting up custom domains and SSL</a>
+      Set up a custom domain for your Appsmith instance and secure it with SSL.  <a href="/getting-started/setup/instance-configuration/custom-domain">Learn more about setting up custom domains and SSL</a>
     </div>
     
   </div>

--- a/website/docs/getting-started/setup/installation-guides/docker/README.mdx
+++ b/website/docs/getting-started/setup/installation-guides/docker/README.mdx
@@ -104,15 +104,15 @@ Once you have completed the installation process, consider performing the tasks 
 
   <div className="containerColumnSampleApp columnGrid column-two">
     <div className="containerCol">
-      <a href="/getting-started/setup/instance-management/update-appsmith">
-        <strong>Update Appsmith</strong>
+      <a href="/getting-started/setup/instance-management/appsmithctl">
+        <strong>Backup and Restore</strong>
       </a>
     </div>
     <hr/>
     <div className="containerDescription">
-      Update Appsmith to the latest version on your self-hosted Appsmith instance to benefit from the latest features and improvements.  <a href="/getting-started/setup/instance-management/update-appsmith">Learn more about updating Appsmith</a>
+      Ensure the safety of your Appsmith instance data by regularly backing up and restoring it when needed. 
+      <a href="/getting-started/setup/instance-management/appsmithctl">Learn more about Backup and Restore</a>
     </div>
-   
   </div>
 </div>
 

--- a/website/docs/getting-started/setup/installation-guides/docker/README.mdx
+++ b/website/docs/getting-started/setup/installation-guides/docker/README.mdx
@@ -98,7 +98,7 @@ Once you have completed the installation process, consider performing the tasks 
     <hr/>
     <div className="containerDescription">
       Set up a custom domain for your Appsmith instance and secure it with SSL. A default SSL certificate from Let's Encrypt is provided. If you use a custom SSL certificate, you will need to <a href="/getting-started/setup/instance-configuration/custom-domain/custom-ca-root-certificate">
-        <strong>install custom CA root certificates</strong>
+        install custom CA root certificates
       </a> to ensure proper security and integration. <a href="/getting-started/setup/instance-configuration/custom-domain">Learn more about setting up custom domains and SSL</a>
     </div>
     
@@ -106,13 +106,13 @@ Once you have completed the installation process, consider performing the tasks 
 
   <div className="containerColumnSampleApp columnGrid column-two">
     <div className="containerCol">
-      <a href="/getting-started/setup/instance-configuration/update-appsmith">
+      <a href="/getting-started/setup/instance-management/update-appsmith">
         <strong>Update Appsmith</strong>
       </a>
     </div>
     <hr/>
     <div className="containerDescription">
-      Update Appsmith to the latest version on your self-hosted Appsmith instance to benefit from the latest features and improvements.  <a href="/getting-started/setup/instance-configuration/update-appsmith">Learn more about updating Appsmith</a>
+      Update Appsmith to the latest version on your self-hosted Appsmith instance to benefit from the latest features and improvements.  <a href="/getting-started/setup/instance-management/update-appsmith">Learn more about updating Appsmith</a>
     </div>
    
   </div>

--- a/website/docs/getting-started/setup/installation-guides/google-cloud-run.mdx
+++ b/website/docs/getting-started/setup/installation-guides/google-cloud-run.mdx
@@ -178,7 +178,7 @@ Once you have completed the installation process, consider performing the tasks 
     <hr/>
     <div className="containerDescription">
       Set up a custom domain for your Appsmith instance and secure it with SSL. A default SSL certificate from Let's Encrypt is provided. If you use a custom SSL certificate, you will need to <a href="/getting-started/setup/instance-configuration/custom-domain/custom-ca-root-certificate">
-        <strong>install custom CA root certificates</strong>
+        install custom CA root certificates
       </a> to ensure proper security and integration.
       <a href="/getting-started/setup/instance-configuration/custom-domain">Learn more about setting up custom domains and SSL</a>
     </div>

--- a/website/docs/getting-started/setup/installation-guides/google-cloud-run.mdx
+++ b/website/docs/getting-started/setup/installation-guides/google-cloud-run.mdx
@@ -124,6 +124,68 @@ Follow these steps to install Appsmith on Google Cloud Run:
 
 To install the Appsmith open source edition (Appsmith Community), replace `appsmith-ee` with `appsmith-ce` while creating a service in step 3 of the [Install Appsmith](#install-appsmith) section on this page.
 
+## Post-installation configuration
+
+Once you have completed the installation process, consider performing the tasks below to configure and manage your Appsmith instance, enhancing its security and performance, specifically if it's intended for production use.
+
+<div className="containerGridSampleApp">
+  <div className="containerColumnSampleApp columnGrid column-one">
+    <div className="containerCol">
+      <a href="/getting-started/setup/installation-guides/aws-ecs/set-up-high-availability">
+        <strong>Set Up High Availability (HA)</strong>
+      </a>
+    </div>
+    <hr/>
+    <div className="containerDescription">
+      Configure high availability for your Appsmith deployment on Google Cloud Run. This setup ensures that your applications are resilient and can handle increased load effectively. <a href="/getting-started/setup/installation-guides/google-cloud-run/manage-traffic">Learn more about setting up high availability</a>
+    </div>
+  </div>
+
+  <div className="containerColumnSampleApp columnGrid column-two">
+    <div className="containerCol">
+      <a href="/getting-started/setup/instance-configuration/authentication">
+        <strong>Configure Single Sign-on (SSO)</strong>
+      </a>
+    </div>
+    <hr/>
+    <div className="containerDescription">
+      Configure SSO to allow users to sign in using your identity provider. Appsmith supports various SSO providers, including Google and GitHub, using protocols like SAML and OpenID.
+      <a href="/getting-started/setup/instance-configuration/authentication">Learn more about configuring SSO</a>
+    </div>
+  </div>
+</div>
+
+<div className="containerGridSampleApp">
+  <div className="containerColumnSampleApp columnGrid column-one">
+    <div className="containerCol">
+      <a href="/getting-started/setup/instance-configuration/email">
+        <strong>Configure Email Service</strong>
+      </a>
+    </div>
+    <hr/>
+    <div className="containerDescription">
+      Set up an email service to enable Appsmith to send notifications and alerts. You can configure providers like AWS SES, Gmail, or others.
+      <a href="/getting-started/setup/instance-configuration/email">Learn more about configuring email services</a>
+    </div>
+  </div>
+
+  <div className="containerColumnSampleApp columnGrid column-two">
+    <div className="containerCol">
+      <a href="/getting-started/setup/instance-configuration/custom-domain">
+        <strong>Set Up Custom Domain and SSL</strong>
+      </a>
+    </div>
+    <hr/>
+    <div className="containerDescription">
+      Set up a custom domain for your Appsmith instance and secure it with SSL. A default SSL certificate from Let's Encrypt is provided. If you use a custom SSL certificate, you will need to <a href="/getting-started/setup/instance-configuration/custom-domain/custom-ca-root-certificate">
+        <strong>install custom CA root certificates</strong>
+      </a> to ensure proper security and integration.
+      <a href="/getting-started/setup/instance-configuration/custom-domain">Learn more about setting up custom domains and SSL</a>
+    </div>
+  </div>
+</div>
+
+
 ## Troubleshooting
 
 If you are facing issues during deployment, please refer to the guide on [troubleshooting deployment errors](/help-and-support/troubleshooting-guide/deployment-errors).

--- a/website/docs/getting-started/setup/installation-guides/google-cloud-run.mdx
+++ b/website/docs/getting-started/setup/installation-guides/google-cloud-run.mdx
@@ -137,7 +137,7 @@ Once you have completed the installation process, consider performing the tasks 
     </div>
     <hr/>
     <div className="containerDescription">
-      Configure high availability for your Appsmith deployment on Google Cloud Run. This setup ensures that your applications are resilient and can handle increased load effectively. <a href="/getting-started/setup/installation-guides/google-cloud-run/manage-traffic">Learn more about setting up high availability</a>
+      Configure high availability for your Appsmith deployment on Google Cloud Run to handle increased load. <a href="/getting-started/setup/installation-guides/google-cloud-run/manage-traffic">Learn more about setting up high availability</a>
     </div>
   </div>
 
@@ -149,7 +149,7 @@ Once you have completed the installation process, consider performing the tasks 
     </div>
     <hr/>
     <div className="containerDescription">
-      Configure SSO to allow users to sign in using your identity provider. Appsmith supports various SSO providers, including Google and GitHub, using protocols like SAML and OpenID.
+      Configure SSO to allow users to sign in using your identity provider.
       <a href="/getting-started/setup/instance-configuration/authentication">Learn more about configuring SSO</a>
     </div>
   </div>
@@ -164,7 +164,7 @@ Once you have completed the installation process, consider performing the tasks 
     </div>
     <hr/>
     <div className="containerDescription">
-      Set up an email service to enable Appsmith to send notifications and alerts. You can configure providers like AWS SES, Gmail, or others.
+      Set up an email service to enable Appsmith to send notifications and alerts.
       <a href="/getting-started/setup/instance-configuration/email">Learn more about configuring email services</a>
     </div>
   </div>
@@ -177,9 +177,7 @@ Once you have completed the installation process, consider performing the tasks 
     </div>
     <hr/>
     <div className="containerDescription">
-      Set up a custom domain for your Appsmith instance and secure it with SSL. A default SSL certificate from Let's Encrypt is provided. If you use a custom SSL certificate, you will need to <a href="/getting-started/setup/instance-configuration/custom-domain/custom-ca-root-certificate">
-        install custom CA root certificates
-      </a> to ensure proper security and integration.
+      Set up a custom domain for your Appsmith instance and secure it with SSL. 
       <a href="/getting-started/setup/instance-configuration/custom-domain">Learn more about setting up custom domains and SSL</a>
     </div>
   </div>

--- a/website/docs/getting-started/setup/installation-guides/kubernetes/README.mdx
+++ b/website/docs/getting-started/setup/installation-guides/kubernetes/README.mdx
@@ -103,6 +103,65 @@ helm repo add appsmith https://helm.appsmith.com
 
 2. Replace `appsmith-ee` with `appsmith` in the commands on this page.
 
+## Post-installation configuration
+
+Once you have completed the installation process, consider performing the tasks below to configure and manage your Appsmith instance, enhancing its security and performance, specifically if it's intended for production use.
+
+<div className="containerGridSampleApp">
+  <div className="containerColumnSampleApp columnGrid column-one">
+    <div className="containerCol">
+      <a href="/getting-started/setup/installation-guides/kubernetes/configure-high-availability">
+        <strong>Set Up High Availability (HA)</strong>
+      </a>
+    </div>
+    <hr/>
+    <div className="containerDescription">
+      Configure high availability and scalability for your Appsmith deployment on Kubernetes to ensure uninterrupted access to your applications. <a href="/getting-started/setup/installation-guides/kubernetes/configure-high-availability">Learn more about setting up high availability</a>
+    </div>
+   
+  </div>
+
+  <div className="containerColumnSampleApp columnGrid column-two">
+    <div className="containerCol">
+      <a href="/getting-started/setup/installation-guides/kubernetes/publish-appsmith-online">
+        <strong>Expose K8s to Internet</strong>
+      </a>
+    </div>
+    <hr/>
+    <div className="containerDescription">
+      Configure your Appsmith Kubernetes installation to be accessible from the internet, enabling remote access and usage. <a href="/getting-started/setup/installation-guides/kubernetes/publish-appsmith-online">Learn more about exposing Appsmith online</a>
+    </div>
+    
+  </div>
+</div>
+
+<div className="containerGridSampleApp">
+  <div className="containerColumnSampleApp columnGrid column-one">
+    <div className="containerCol">
+      <a href="/getting-started/setup/instance-configuration/authentication">
+        <strong>Configure Single Sign-on (SSO)</strong>
+      </a>
+    </div>
+    <hr/>
+    <div className="containerDescription">
+      Enable SSO to allow users to log in using your identity provider. Appsmith supports multiple SSO providers through SAML and OpenID protocols. <a href="/getting-started/setup/instance-configuration/authentication">Learn more about configuring SSO</a>
+    </div>
+   
+  </div>
+
+  <div className="containerColumnSampleApp columnGrid column-two">
+    <div className="containerCol">
+      <a href="/getting-started/setup/instance-configuration/email">
+        <strong>Configure Email Service</strong>
+      </a>
+    </div>
+    <hr/>
+    <div className="containerDescription">
+      Set up an email service to enable Appsmith to send notifications and alerts. You can use providers such as AWS SES, Gmail, or others. <a href="/getting-started/setup/instance-configuration/email">Learn more about configuring email services</a>
+    </div>
+      </div>
+</div>
+
 ## Troubleshooting
 
 If you are facing issues during deployment, refer to the guide on [troubleshooting deployment errors](/help-and-support/troubleshooting-guide/deployment-errors). If you continue to face issues, contact the support team using the chat widget at the bottom right of this page.


### PR DESCRIPTION
## Description 

Provide a concise summary of the changes made in this pull request
- Added post-installation configurations for installation guides except Ansible.

## Pull request type

Check the appropriate box:

- [ ] Review Fixes
- [ ] Documentation Overhaul
- [x] Feature/Story
    - Link one or more Engineering Tickets
        * 
- [ ] A-Force
- [ ] Error in documentation
- [ ] Maintenance

## Documentation tickets

 Link to one or more documentation tickets:
 - 

## Checklist

From the below options, select the ones that are applicable:

- [x] Checked for Grammarly suggestions.
- [x] Adhered to the writing checklist.
- [ ] Adhered to the media checklist.
- [ ] Verified and updated cross-references or added redirect rules.
- [ ] Tested the redirect rules on deploy preview.
- [ ] Validated the modifications made to the content on the deploy preview.
- [ ] Validated the CSS modifications on different screen sizes.
