### PR TITLE
fix: Configure HTTP/HTTPs Proxy

### DIFF
--- a/website/docs/getting-started/setup/instance-configuration/http-proxy.md
+++ b/website/docs/getting-started/setup/instance-configuration/http-proxy.md
@@ -4,31 +4,84 @@ description: This page provides steps to configure HTTP/HTTPS proxy on your self
 
 # Configure HTTP/HTTPS Proxy
 
-Appsmith offers support for running behind a forward proxy, which is beneficial when deploying Appsmith on a server behind a corporate firewall, and allows internet access through a proxy server. This page provides instructions for configuring HTTP/HTTPS proxy server on your self-hosted Appsmith instance.
+When Appsmith runs behind a corporate firewall or a Virtual Private Network (VPN), it may require proxy settings to access the internet and communicate with [cs.appsmith.com](http://cs.appsmith.com). This page shows how to set up HTTP/HTTPS proxy on your self-hosted Appsmith instance so that you can access Appsmith using a proxy.
 
 ## Prerequisites
 
-- A self-hosted Appsmith instance. See the [installation guides](/getting-started/setup/installation-guides) to set up your Appsmith instance.
+- Self-hosted Appsmith instance. If not installed yet, see the [installation guides](/getting-started/setup/installation-guides) for installing Appsmith.
 
-## Add Proxy details to the configuration file
+## Verify connectivity
 
-Follow these steps to configure HTTP/HTTPS proxy for your self-hosted instance:
+Before you begin proxy configuration, verify if your Appsmith instance can connect to [cs.appsmith.com](http://cs.appsmith.com/) for internal communication. 
 
-1. Go to your Appsmith instance configuration file, such as the `docker.env` file for Docker or the `values.yaml` file for Kubernetes.
+1. Connect to the `appsmith` container as root:
+
+    ```bash
+    docker exec -it -u root appsmith bash
+    ```
+
+2. Test connection with:
+
+    ```bash
+    curl -i -v cs.appsmith.com
+    ```
+
+    The command shows output as below:
+
+    ```bash
+    * Trying <IP_Address>...
+    * TCP_NODELAY set
+    ```
+    If you see below connection errors after the above output, it shows that a connection is not established and a proxy set up may be required.
+
+    - `connect to <IP address> port 80 failed: Connection timed out`
+    - `curl: (7) Failed to connect to <IP address> port 80: Network unreachable`
+
+## Set up proxy
+
+Follow below steps to configure proxy by setting environment variables:
+
+1. Open the Appsmith installation configuration file:
+    - Docker: `docker.env`
+    - Kubernetes: `values.yaml`
+
 2. Use any one of the below pair of environment variables to set proxy:
+    - `HTTP_PROXY` and `HTTPS_PROXY` (uppercase)
+    - `http_proxy` and `https_proxy` (lowercase)
 
- a. `HTTP_PROXY` and/or `HTTPS_PROXY` 
+    For example, set up proxy using uppercase environment variables:
 
- b. `http_proxy` and/or `https_proxy`
+    ```bash
+    HTTP_PROXY=http://1.2.3.4:8080
+    HTTPS_PROXY=http://1.2.3.4:8080
+    ```
 
-For example, add the chosen environment variables as shown below:
- ```bash
- HTTP_PROXY=http://1.2.3.4:8080
- HTTPS_PROXY=http://1.2.3.4:8080
- ```
-3. Save the changes and restart the Appsmith instance.
-4. When using an HTTPS proxy, you may want to add a trusted custom Certificate Authority (CA) to Appsmith. See [Custom Root CA Certificate](/getting-started/setup/instance-configuration/custom-domain/custom-ca-root-certificate) to set up a certificate authority.
+3. Save the file and restart Appsmith instance.
+
+4. Confirm proxy configuration with:
+
+    ```bash
+    curl -i -v cs.appsmith.com
+    ```
+
+    The command shows below output when connection is successfully established:
+
+    ```bash
+    Trying <IP_ADDRESS>:8080...
+    * TCP_NODELAY set
+    * Connected to proxy (<IP_ADDRESS>) port 8080 (#0)
+    ```
+
+5. When using an HTTPS proxy, you may want to add a trusted custom Certificate Authority to Appsmith. For more information, see [Custom Root CA Certificate](/getting-started/setup/instance-configuration/custom-domain/custom-ca-root-certificate) guide.
 
 ## Troubleshooting
 
-If you face issues, contact the support team using the chat widget at the bottom right of this page.
+You may face some common issues while configuring the proxy. Troubleshoot by:
+
+- Verifying the proxy address and port.
+- Confirming that you've set up correct environment variables.
+- Reviewing the network or firewall settings.
+
+If you continue to face issues, contact the support team using the chat widget at the bottom right of this page.
+
+


### PR DESCRIPTION
## Description 

Provide a concise summary of the changes made in this pull request
Updated doc - [Configure HTTP/HTTPS proxy](https://appsmith-docs-git-fix-setup-proxy-for-appsmith-get-appsmith.vercel.app/getting-started/setup/instance-configuration/http-proxy)
- Added a Verify Connectivity section to verify if proxy configuration is required
- Rewrote the instructions, and updated section headings for clarity
- Rewrote the troubleshooting guide section

## Pull request type

Check the appropriate box:

- [ ] Review Fixes
- [ ] Documentation Overhaul
- [ ] Feature/Story
    - Link one or more Engineering Tickets
        * 
- [ ] A-Force
- [ ] Error in documentation
- [x] Maintenance

## Documentation tickets

 Link to one or more documentation tickets:
 - #2206

## Checklist

From the below options, select the ones that are applicable:

- [x] Checked for Grammarly suggestions.
- [x] Adhered to the writing checklist.
- [ ] Adhered to the media checklist.
- [ ] Verified and updated cross-references or added redirect rules.
- [ ] Tested the redirect rules on deploy preview.
- [ ] Validated the modifications made to the content on the deploy preview.
- [ ] Validated the CSS modifications on different screen sizes.
