### PR TITLE
chore: removed fast xml parser from built-in libraries section

### DIFF
--- a/website/docs/write-code/reference/Built-in-JS-Libraries.md
+++ b/website/docs/write-code/reference/Built-in-JS-Libraries.md
@@ -28,17 +28,6 @@ Simplifies working with dates and times in JavaScript by providing functions for
 For more information, see [Moment](https://momentjs.com/docs/)
 </dd>
 
-#### Fast XML Parser
-
-<dd>
-Fast XML Parser can be used to work with cryptographic algorithms and protocols in JavaScript.
-
-```
-{{ xmlParser.parse(xmlAPI.data) }}
-```
-For more information, see [Fast XML Parser](https://github.com/NaturalIntelligence/fast-xml-parser#readme)
-</dd>
-
 #### Forge
 <dd>
 Forge can be used to work with cryptographic algorithms and protocols in JavaScript.


### PR DESCRIPTION
## Description 

Provide a concise summary of the changes made in this pull request
-  Removed the Fast XML Parser from built-in libraries as this is no longer supported

## Pull request type

Check the appropriate box:

- [ ] Review Fixes
- [ ] Documentation Overhaul
- [ ] Feature/Story
    - Link one or more Engineering Tickets
        * 
- [ ] A-Force
- [ ] Error in documentation
- [x] Maintenance

## Documentation tickets

 Link to one or more documentation tickets:
 - NA

## Checklist

From the below options, select the ones that are applicable:

- [ ] Checked for Grammarly suggestions.
- [ ] Adhered to the writing checklist.
- [ ] Adhered to the media checklist.
- [ ] Verified and updated cross-references or added redirect rules.
- [ ] Tested the redirect rules on deploy preview.
- [ ] Validated the modifications made to the content on the deploy preview.
- [ ] Validated the CSS modifications on different screen sizes.
