### PR TITLE
fix: Add video tutorials for AMI and Entra ID

### DIFF
--- a/website/docs/getting-started/setup/installation-guides/aws-ami.md
+++ b/website/docs/getting-started/setup/installation-guides/aws-ami.md
@@ -5,7 +5,7 @@ sidebar_position: 4
 
 # AWS AMI
 
-This page provides steps to install Appsmith using an Amazon Machine Image (AMI).
+This page provides steps to install Appsmith using an Amazon Machine Image (AMI). You may also follow the video tutorial on how to install Appsmith using an <a href="https://www.youtube.com/watch?v=nnyikBImju8" target="_blank" rel="noopener noreferrer" className="external-link">Amazon Machine Image (AMI)</a>. 
 
 ## Prerequisites
 

--- a/website/docs/getting-started/setup/instance-configuration/authentication/security-assertion-markup-language-saml/entra-id.mdx
+++ b/website/docs/getting-started/setup/instance-configuration/authentication/security-assertion-markup-language-saml/entra-id.mdx
@@ -22,7 +22,7 @@ tags={[
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-To configure Appsmith to use [Microsoft Entra ID (Azure AD)](https://www.microsoft.com/en-in/security/business/identity-access/microsoft-entra-id) as a SAML provider, follow the steps below:
+This page shows how to configure [Microsoft Entra ID (Azure AD)](https://www.microsoft.com/en-in/security/business/identity-access/microsoft-entra-id) as a SAML provider on your Appsmith instance. You may also follow the video tutorial on how to configure SAML Single Sign-on with <a href="https://www.youtube.com/watch?v=_IUPUbu9tgI" target="_blank" rel="noopener noreferrer" className="external-link">Azure Entra ID</a>.
 
 ## Prerequisites
 

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -750,3 +750,18 @@ h4+.tags {
 .permissions-table td {
   text-align: left;
 }
+
+.external-link::after {
+  content: " ↗";
+  font-size: 0.85em;
+  color: inherit;
+}
+
+.external-link {
+  color: #0366d6;
+  text-decoration: none;
+}
+
+.external-link:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Description 

Provide a concise summary of the changes made in this pull request
- Updated docs to add video tutorial links 
         - SAML SSO for Azure Entra 
         - Install Appsmith using an Amazon AMI
- Added a CSS to show that the links are external.

## Pull request type

Check the appropriate box:

- [ ] Review Fixes
- [ ] Documentation Overhaul
- [x] Feature/Story
    - Link one or more Engineering Tickets
        - #2473
        - #2474 
- [ ] A-Force
- [ ] Error in documentation
- [ ] Maintenance

## Documentation tickets

 Link to one or more documentation tickets:
 - 

## Checklist

From the below options, select the ones that are applicable:

- [ ] Checked for Grammarly suggestions.
- [ ] Adhered to the writing checklist.
- [ ] Adhered to the media checklist.
- [ ] Verified and updated cross-references or added redirect rules.
- [ ] Tested the redirect rules on deploy preview.
- [ ] Validated the modifications made to the content on the deploy preview.
- [ ] Validated the CSS modifications on different screen sizes.
