### PR TITLE
update codec variable to remove mb

### DIFF
--- a/website/docs/getting-started/setup/instance-configuration/file-size-limit.md
+++ b/website/docs/getting-started/setup/instance-configuration/file-size-limit.md
@@ -12,7 +12,7 @@ To accommodate large files, update the Appsmith instance configuration by settin
 For example, to increase the file size limit to 500 MB, use the following configuration:
 
 ```bash
-APPSMITH_CODEC_SIZE=500MB
+APPSMITH_CODEC_SIZE=500
 ```
 
 ## Change reverse proxy or load balancer limit


### PR DESCRIPTION
It seems that the application is already appending `mb` to the numerical value specified in the `APPSMITH_CODEC_SIZE` variable so setting the value to the existing `500MB` results in startup errors.

## Description 

Provide a concise summary of the changes made in this pull request
- 

## Pull request type

Check the appropriate box:

- [ ] Review Fixes
- [ ] Documentation Overhaul
- [ ] Feature/Story
    - Link one or more Engineering Tickets
        * 
- [ ] A-Force
- [x] Error in documentation
- [ ] Maintenance

## Documentation tickets

 Link to one or more documentation tickets:
 - 

## Checklist

From the below options, select the ones that are applicable:

- [ ] Checked for Grammarly suggestions.
- [ ] Adhered to the writing checklist.
- [ ] Adhered to the media checklist.
- [ ] Verified and updated cross-references or added redirect rules.
- [ ] Tested the redirect rules on deploy preview.
- [x] Validated the modifications made to the content on the deploy preview.
- [ ] Validated the CSS modifications on different screen sizes.
