### PR TITLE
fix: button color property description

### DIFF
--- a/website/docs/reference/widgets/button/README.md
+++ b/website/docs/reference/widgets/button/README.md
@@ -180,7 +180,7 @@ This property can be dynamically set using JavaScript by providing a string valu
 
 <dd>
 
-Represents the color of the button, specified as a [CSS color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color). Additionally, the font color can be programmatically modified using JavaScript functions.
+Represents the color of the button, specified as a [CSS color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color). The background color can also be modified programmatically using JavaScript functions.
 
 </dd>
 

--- a/website/docs/reference/widgets/category-slider.md
+++ b/website/docs/reference/widgets/category-slider.md
@@ -240,7 +240,7 @@ Enables you to select a font style for the widget, such as bold or italic. Addit
 
 <dd>
 
-Represents the color of the slider, specified as a [CSS color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color). Additionally, the font color can be programmatically modified using JavaScript functions.
+Represents the color of the slider, specified as a [CSS color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color). The slider color can also be modified programmatically using JavaScript functions.
 
 </dd>
 

--- a/website/docs/reference/widgets/code-scanner.md
+++ b/website/docs/reference/widgets/code-scanner.md
@@ -153,7 +153,7 @@ This property can be dynamically set using JavaScript by providing a string valu
 
 <dd>
 
-Represents the color of the button, specified as a [CSS color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color). Additionally, the font color can be programmatically modified using JavaScript functions.
+Represents the color of the button, specified as a [CSS color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color). The background color can also be modified programmatically using JavaScript functions.
 
 </dd>
 

--- a/website/docs/reference/widgets/filepicker.md
+++ b/website/docs/reference/widgets/filepicker.md
@@ -163,7 +163,7 @@ Allows you to configure one or multiple actions (Framework functions, queries, o
 
 <dd>
 
-Represents the color of the button, specified as a [CSS color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color). When JS is enabled, the font color can be programmatically modified using JavaScript functions.
+Represents the color of the button, specified as a [CSS color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color). When JS is enabled, the background color can be programmatically modified using JavaScript functions.
 
 </dd>
 

--- a/website/docs/reference/widgets/icon-button.md
+++ b/website/docs/reference/widgets/icon-button.md
@@ -99,7 +99,7 @@ This property can be dynamically set using JavaScript by providing a string valu
 
 <dd>
 
-Represents the color of the button, specified as a [CSS color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color). Additionally, the font color can be programmatically modified using JavaScript functions.
+Represents the color of the button, specified as a [CSS color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color). The background color can also be modified programmatically using JavaScript functions.
 
 </dd>
 

--- a/website/docs/reference/widgets/json-form.md
+++ b/website/docs/reference/widgets/json-form.md
@@ -267,7 +267,7 @@ This property adds a drop shadow effect to the frame of the widget. If JavaScrip
 
 <dd>
 
-Represents the color of the button, specified as a [CSS color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color). Additionally, the font color can be programmatically modified using JavaScript functions.
+Represents the color of the button, specified as a [CSS color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color). The background color can also be modified programmatically using JavaScript functions.
 
 </dd>
 

--- a/website/docs/reference/widgets/menu/README.md
+++ b/website/docs/reference/widgets/menu/README.md
@@ -180,7 +180,7 @@ Determines the spacing between the **Icon** and the **Label**.
 
 <dd>
 
-Represents the color of the button, specified as a [CSS color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color). Additionally, the font color can be programmatically modified using JavaScript functions.
+Represents the color of the button, specified as a [CSS color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color). The background color can also be modified programmatically using JavaScript functions.
 
 </dd>
 

--- a/website/docs/reference/widgets/number-slider.md
+++ b/website/docs/reference/widgets/number-slider.md
@@ -270,7 +270,7 @@ Enables you to select a font style for the widget, such as bold or italic. Addit
 
 <dd>
 
-Represents the color of the slider, specified as a [CSS color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color). Additionally, the font color can be programmatically modified using JavaScript functions.
+Represents the color of the slider, specified as a [CSS color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color). The slider color can also be modified programmatically using JavaScript functions.
 
 </dd>
 

--- a/website/docs/reference/widgets/range-slider.md
+++ b/website/docs/reference/widgets/range-slider.md
@@ -295,7 +295,7 @@ Enables you to select a font style for the widget, such as bold or italic. Addit
 
 <dd>
 
-Represents the color of the slider, specified as a [CSS color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color). Additionally, the font color can be programmatically modified using JavaScript functions.
+Represents the color of the slider, specified as a [CSS color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color). The slider color can also be modified programmatically using JavaScript functions.
 
 </dd>
 


### PR DESCRIPTION
## Description 

Provide a concise summary of the changes made in this pull request
- The current references to the button color property in the docs suggest that users can change the font color of a button, which is not currently supported. However, there's an active [feature request](https://github.com/appsmithorg/appsmith/issues/15065) for this styling capability.

## Pull request type

Check the appropriate box:

- [ ] Review Fixes
- [ ] Documentation Overhaul
- [ ] Feature/Story
    - Link one or more Engineering Tickets
        * 
- [ ] A-Force
- [x] Error in documentation
- [ ] Maintenance

## Documentation tickets

 Link to one or more documentation tickets:
 - 

## Checklist

From the below options, select the ones that are applicable:

- [ ] Checked for Grammarly suggestions.
- [ ] Adhered to the writing checklist.
- [ ] Adhered to the media checklist.
- [ ] Verified and updated cross-references or added redirect rules.
- [ ] Tested the redirect rules on deploy preview.
- [ ] Validated the modifications made to the content on the deploy preview.
- [ ] Validated the CSS modifications on different screen sizes.
