### PR TITLE
fix: default file size

### DIFF
--- a/website/docs/getting-started/setup/environment-variables.md
+++ b/website/docs/getting-started/setup/environment-variables.md
@@ -405,7 +405,7 @@ Replace `<YOUR_GOOGLE_MAPS_API_KEY>` with a valid API key obtained from the [Goo
 
 ### File size limit
 
-The default file size limit in Appsmith is 150 MB. This limit is customizable based on your requirements for larger file uploads in self-hosted instances.
+The default file size limit in Appsmith is 200 MB. This limit is customizable based on your requirements for larger file uploads in self-hosted instances.
 
 ##### `APPSMITH_CODEC_SIZE`
 <dd>

--- a/website/docs/getting-started/setup/instance-configuration/file-size-limit.md
+++ b/website/docs/getting-started/setup/instance-configuration/file-size-limit.md
@@ -1,6 +1,6 @@
 # Upload File Size Limit
 
-In self-hosted Appsmith instances, the default file size limit is 150 MB. You can adjust the limit to support larger files. This page explains how to update the file size limit and configure reverse proxies or load balancers, if used, to ensure the new limits are applied.
+In self-hosted Appsmith instances, the default file size limit is 200 MB. You can adjust the limit to support larger files. This page explains how to update the file size limit and configure reverse proxies or load balancers, if used, to ensure the new limits are applied.
 
 ## Change file size limit
 

--- a/website/docs/help-and-support/troubleshooting-guide/action-errors/README.md
+++ b/website/docs/help-and-support/troubleshooting-guide/action-errors/README.md
@@ -50,7 +50,7 @@ messageContent="Payload too large. File size cannot exceed 100MB."></Message>
 
 #### Cause
 
-Appsmith imposes a default file size limit of 150 MB. This is a configurable limit if you're using a self-hosted Appsmith instance. The reason you may get this error is due to a file size limit set at 100 MB on your self-hosted instance.
+Appsmith imposes a default file size limit of 200 MB. This is a configurable limit if you're using a self-hosted Appsmith instance. The reason you may get this error is due to a file size limit set at 100 MB on your self-hosted instance.
 
 #### Solution
 


### PR DESCRIPTION
## Description 

Provide a concise summary of the changes made in this pull request
- Default file size limit was increased to 200 MB. GH issue for reference https://github.com/appsmithorg/appsmith/issues/14248

## Pull request type

Check the appropriate box:

- [ ] Review Fixes
- [ ] Documentation Overhaul
- [ ] Feature/Story
    - Link one or more Engineering Tickets
        * 
- [ ] A-Force
- [x] Error in documentation
- [ ] Maintenance

## Documentation tickets

 Link to one or more documentation tickets:
 - 

## Checklist

From the below options, select the ones that are applicable:

- [ ] Checked for Grammarly suggestions.
- [ ] Adhered to the writing checklist.
- [ ] Adhered to the media checklist.
- [ ] Verified and updated cross-references or added redirect rules.
- [ ] Tested the redirect rules on deploy preview.
- [ ] Validated the modifications made to the content on the deploy preview.
- [ ] Validated the CSS modifications on different screen sizes.
