### PR TITLE
fix: broken/outdated links

### DIFF
--- a/website/docs/getting-started/setup/instance-configuration/external-redis.mdx
+++ b/website/docs/getting-started/setup/instance-configuration/external-redis.mdx
@@ -19,7 +19,7 @@ Before configuring an external Redis instance for your Appsmith instance, ensure
 Follow these steps to set up an external Redis instance for Appsmith. If you already have a Redis instance, skip this step and move to [Connect Appsmith to external Redis](#connect-appsmith-to-external-redis) section.
 
 1. Create a Redis instance:
-      - **Self-hosted Redis**: Install and configure Redis on your server using the [Redis installation guide](https://redis.io/docs/getting-started/installation/).  
+      - **Self-hosted Redis**: Install and configure Redis on your server using the [Redis installation guide](https://redis.io/docs/latest/get-started/).  
 
       - **Cloud-hosted Redis**: Set up a managed Redis instance using a cloud provider such as AWS ElastiCache, Redis Cloud, or Azure Cache for Redis.  
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -101,7 +101,7 @@ const config = {
             position: 'right',
           },
           {
-            href: 'https://app.appsmith.com',
+            href: 'https://login.appsmith.com',
             label: 'Try Appsmith',
             position: 'right'
           },


### PR DESCRIPTION
## Description 

Provide a concise summary of the changes made in this pull request
- Fixed Try Appsmith button to point to `login.appsmith.com` instead of `app.appsmith.com` and fixed broken link to Redis installation guide.

## Pull request type

Check the appropriate box:

- [ ] Review Fixes
- [ ] Documentation Overhaul
- [ ] Feature/Story
    - Link one or more Engineering Tickets
        * 
- [ ] A-Force
- [ ] Error in documentation
- [x] Maintenance

## Documentation tickets

 Link to one or more documentation tickets:
 - 

## Checklist

From the below options, select the ones that are applicable:

- [ ] Checked for Grammarly suggestions.
- [ ] Adhered to the writing checklist.
- [ ] Adhered to the media checklist.
- [ ] Verified and updated cross-references or added redirect rules.
- [ ] Tested the redirect rules on deploy preview.
- [ ] Validated the modifications made to the content on the deploy preview.
- [ ] Validated the CSS modifications on different screen sizes.
