### PR TITLE
docs: Add APPSMITH_BASE_URL environment variable documentation

### DIFF
--- a/website/docs/getting-started/setup/environment-variables.md
+++ b/website/docs/getting-started/setup/environment-variables.md
@@ -127,6 +127,44 @@ With Appsmith, you can manage user access and authentication methods in your ins
 Set to `true` to turn off the default username and password login. Useful for administrators who want to enforce Single Sign-On (SSO) or limit authentication methods for added security and control.
 </dd>
 
+### Security
+
+Configure security settings to protect your Appsmith instance against account takeover attacks and ensure secure authentication flows.
+
+##### `APPSMITH_BASE_URL`
+
+<dd>
+
+Specifies the base URL of your Appsmith instance. When configured, this variable enables Origin header validation for password reset and email verification requests, preventing account takeover attacks.
+
+When `APPSMITH_BASE_URL` is set, the system validates that the `Origin` header in password reset and email verification requests matches the configured base URL. Requests with mismatched origins are rejected, preventing attackers from:
+
+- Using arbitrary Origin headers to redirect reset links to malicious domains
+- Exploiting the password reset flow to send tokens to attacker-controlled endpoints
+- Performing account takeover attacks through email verification redirects
+
+**Configuration:**
+
+You can configure this variable either:
+
+- **Via Admin Settings UI**: Navigate to **Settings → Configuration → Appsmith Base URL**
+- **Via environment variable**: Set the `APPSMITH_BASE_URL` environment variable in your configuration file
+
+**Example:**
+
+```yaml
+APPSMITH_BASE_URL=https://appsmith.yourdomain.com
+```
+
+**Backward compatibility:**
+
+If `APPSMITH_BASE_URL` is not set, the system maintains backward compatibility by skipping validation, ensuring existing deployments continue to function without changes. However, it is strongly recommended to set this variable to enable protection against account takeover attempts.
+
+**Recommendation:**
+
+We strongly recommend setting `APPSMITH_BASE_URL` in your environment configuration to enable this protection. This ensures that sensitive authentication flows are restricted to your trusted domain, significantly reducing the attack surface for account takeover attempts.
+
+</dd>
 
 ### Email server
 


### PR DESCRIPTION
## Description 
- Add new Security section to environment-variables.md
- Document APPSMITH_BASE_URL for Origin header validation
- Explain protection against account takeover attacks
- Include configuration options (Admin Settings UI and env var)
- Add backward compatibility notes and recommendations

This addresses the account takeover vulnerability by documenting the Origin header validation feature for password reset and email verification requests.


Related PRs:
https://github.com/appsmithorg/appsmith-ee/pull/8448
https://github.com/appsmithorg/appsmith/pull/41426

## Pull request type

Check the appropriate box:

- [ ] Review Fixes
- [ ] Documentation Overhaul
- [ ] Feature/Story
    - Link one or more Engineering Tickets
        * 
- [ ] A-Force
- [ ] Error in documentation
- [ ] Maintenance

## Documentation tickets

 Link to one or more documentation tickets:
 - 

## Checklist

From the below options, select the ones that are applicable:

- [ ] Checked for Grammarly suggestions.
- [ ] Adhered to the writing checklist.
- [ ] Adhered to the media checklist.
- [ ] Verified and updated cross-references or added redirect rules.
- [ ] Tested the redirect rules on deploy preview.
- [ ] Validated the modifications made to the content on the deploy preview.
- [ ] Validated the CSS modifications on different screen sizes.
