### PR TITLE
chore: reverted changes to use markdown instead of html tag for Session Timeout to ensure anchor tag works.

### DIFF
--- a/website/docs/getting-started/setup/instance-configuration/user-management.md
+++ b/website/docs/getting-started/setup/instance-configuration/user-management.md
@@ -40,14 +40,17 @@ For more details, see [Restrict Query Access](/advanced-concepts/granular-access
 <!-- vale off -->
 
 <div className="tag-wrapper">
-<h4>Session Timeout</h4>
 
+#### Session Timeout
 <Tags
-tags={[
-{ name: "Enterprise", link: "https://www.appsmith.com/pricing", additionalClass: "enterprise" }
-]}
+  tags={[
+    {
+      name: "Enterprise",
+      link: "https://www.appsmith.com/pricing",
+      additionalClass: "enterprise",
+    }
+  ]}
 />
-
 </div>
 
 <!-- vale on -->


### PR DESCRIPTION
## Description 
In earlier PR, had added Enterprise Badge for Session Timeout. But with that, lost anchor tag to session-timeout.
Reverted changes to use markdown instead of html tag, so that anchor tag is available for session timeout.

## Pull request type

Check the appropriate box:

- [ ] Review Fixes
- [ ] Documentation Overhaul
- [ ] Feature/Story
    - Link one or more Engineering Tickets
        * 
- [ ] A-Force
- [ ] Error in documentation
- [ ] Maintenance

## Documentation tickets

 Link to one or more documentation tickets:
 - 

## Checklist

From the below options, select the ones that are applicable:

- [ ] Checked for Grammarly suggestions.
- [ ] Adhered to the writing checklist.
- [ ] Adhered to the media checklist.
- [ ] Verified and updated cross-references or added redirect rules.
- [ ] Tested the redirect rules on deploy preview.
- [ ] Validated the modifications made to the content on the deploy preview.
- [ ] Validated the CSS modifications on different screen sizes.
