### PR TITLE
fix: wrong helm instructions to get current values from install

### DIFF
--- a/website/docs/getting-started/setup/instance-configuration/configure-using-environment-variables.mdx
+++ b/website/docs/getting-started/setup/instance-configuration/configure-using-environment-variables.mdx
@@ -42,7 +42,7 @@ For Kubernetes installations using Helm, modify the `values.yaml` file and updat
     ```bash
     helm get values appsmith -n appsmith -o yaml > values.yaml
     ```
-3. Update parameters under the `applicationConfig` section. For instance:
+3. Modify parameters under the `applicationConfig` section in the `values.yaml` file. For example, to set the sender email address:
     ```yaml
     applicationConfig:
       #highlight-next-line
@@ -60,7 +60,7 @@ For Kubernetes installations using Helm, modify the `values.yaml` file and updat
     ```bash
     helm get values appsmith -n appsmith -o yaml > values.yaml
     ```
-3. Modify parameters under the `applicationConfig` section. For example, to set the sender email address:
+3. Modify parameters under the `applicationConfig` section in the `values.yaml` file. For example, to set the sender email address:
     ```yaml
     applicationConfig:
       #highlight-next-line

--- a/website/docs/getting-started/setup/instance-configuration/configure-using-environment-variables.mdx
+++ b/website/docs/getting-started/setup/instance-configuration/configure-using-environment-variables.mdx
@@ -33,14 +33,14 @@ Follow these steps to configure Appsmith using environment variables for Docker-
 
 <TabItem label="Helm" value="helm">
 
-For Kubernetes installations using Helm, modify the `values.yaml` file to configure environment variables.
+For Kubernetes installations using Helm, modify the `values.yaml` file and update with Helm to configure environment variables.
 
 **Steps for Commercial Edition:**
 
-1. Navigate to your installation's root directory.
-2. Generate a `values.yaml` file:
+1. Open a shell on your Kubernetes client.
+2. Retrieve the current values from your installation and store them in a file:
     ```bash
-    helm show values appsmith-ee/appsmith > values.yaml
+    helm get values appsmith -n appsmith -o yaml > values.yaml
     ```
 3. Update parameters under the `applicationConfig` section. For instance:
     ```yaml
@@ -55,10 +55,10 @@ For Kubernetes installations using Helm, modify the `values.yaml` file to config
 ---
 **Steps for Community Edition:**
 
-1. Navigate to your installation's root directory.
-2. Generate a `values.yaml` file:
+1. Open a shell on your Kubernetes client.
+2. Retrieve the current values from your installation and store them in a file:
     ```bash
-    helm show values appsmith/appsmith > values.yaml
+    helm get values appsmith -n appsmith -o yaml > values.yaml
     ```
 3. Modify parameters under the `applicationConfig` section. For example, to set the sender email address:
     ```yaml


### PR DESCRIPTION
This page was showing `helm show values` which shows the _default_ values for a chart, not the currently supplied values. `helm get values` is the correct command for this operation.

## Description 

Provide a concise summary of the changes made in this pull request
- 

## Pull request type

Check the appropriate box:

- [ ] Review Fixes
- [ ] Documentation Overhaul
- [ ] Feature/Story
    - Link one or more Engineering Tickets
        * 
- [ ] A-Force
- [x] Error in documentation
- [ ] Maintenance

## Documentation tickets

 Link to one or more documentation tickets:
 - 

## Checklist

From the below options, select the ones that are applicable:

- [ ] Checked for Grammarly suggestions.
- [ ] Adhered to the writing checklist.
- [ ] Adhered to the media checklist.
- [ ] Verified and updated cross-references or added redirect rules.
- [ ] Tested the redirect rules on deploy preview.
- [ ] Validated the modifications made to the content on the deploy preview.
- [ ] Validated the CSS modifications on different screen sizes.
