### PR TITLE
fix(docs): clarify security report rewards policy

### DIFF
--- a/website/docs/getting-started/faq.md
+++ b/website/docs/getting-started/faq.md
@@ -17,7 +17,7 @@ Appsmith is open source, which means developers can easily adopt, extend and use
 
 Appsmith applications are secure by default. See [Security](/product/security) for more information. For Appsmith cloud users, data is stored and processed on servers in the US. If you want to have complete control over how your data is stored and transmitted, or need to ensure HIPAA compliance, you can [self-host Appsmith](/getting-started/setup) to ensure none of your data leaves your VPC.
 
-We appreciate any information that can help improve the security of our systems and protect users' data. We do reward security researchers who report serious and previously undiscovered issues. If you believe you have discovered a security vulnerability, please email our security team at [security@appsmith.com](mailto:security@appsmith.com) with a description of the issue and any relevant details. After reviewing the report, appropriate action is taken to address the issue.
+We appreciate any information that can help improve the security of our systems and protect users' data. If you believe you have discovered a security vulnerability, please email our security team at [security@appsmith.com](mailto:security@appsmith.com) with a description of the issue and any relevant details. After reviewing the report, appropriate action is taken to address the issue. Please note that Appsmith does not typically offer monetary rewards for security reports.
 
 ## Does Appsmith support multi-user editing?
 

--- a/website/docs/product/security.md
+++ b/website/docs/product/security.md
@@ -82,5 +82,5 @@ This method allows for a good balance between security, and convenience. Having 
 These security implementations demonstrate Appsmith's commitment to maintaining a secure environment for developers and users alike. By following the guidelines provided, you can contribute to creating secure applications on the Appsmith platform.
 
 :::info
-Appsmith maintains an open communication channel with security researchers to report security vulnerabilities responsibly. If you notice a security vulnerability, please email `security@appsmith.com`.
+Appsmith maintains an open communication channel with security researchers to report security vulnerabilities responsibly. If you notice a security vulnerability, please email `security@appsmith.com`. Please note that Appsmith does not typically offer monetary rewards for security reports.
 :::


### PR DESCRIPTION
## Summary
- Removes the misleading statement *"We do reward security researchers who report serious and previously undiscovered issues"* from the FAQ page
- Adds a clear note in both the **FAQ** (`getting-started/faq.md`) and the **Security** page (`product/security.md`) that Appsmith does not typically offer monetary rewards for security reports
- Aligns documentation with actual company policy

## Context
- **Linear:** [APP-14890](https://linear.app/appsmith/issue/APP-14890/revise-documentation-to-clarify-security-report-rewards-policy)
- The previous FAQ wording was creating confusion for external security reporters who expected monetary compensation

## Files Changed
| File | Change |
|------|--------|
| `website/docs/getting-started/faq.md` | Removed reward claim, added clarification |
| `website/docs/product/security.md` | Added clarification to the security researcher info block |

## Test plan
- [ ] Verify the FAQ page renders correctly at `/getting-started/faq`
- [ ] Verify the Security page renders correctly at `/product/security`
- [ ] Confirm no other docs reference security rewards/bounty (verified via GitHub code search — none found)


Made with [Cursor](https://cursor.com)