### PR TITLE
feat: add docs for migrating from statefulset to deployment

### DIFF
--- a/website/docs/getting-started/setup/installation-guides/kubernetes/README.mdx
+++ b/website/docs/getting-started/setup/installation-guides/kubernetes/README.mdx
@@ -91,7 +91,7 @@ Follow these steps to install Appsmith:
 10. Once you've created an account, you can either start with the free plan or activate your instance with a license key. If you want to generate a license key, sign up on [customer.appsmith.com](https://customer.appsmith.com) to create one, and then proceed to activate your instance using the newly generated license key.
 
 
-For high availability and scalability configuration, see the [Configure High Availability and Scalability](/getting-started/setup/installation-guides/kubernetes/configure-high-availability) guide. To expose Appsmith installation on the internet, see the [Expose K8s to Internet](/getting-started/setup/installation-guides/kubernetes/publish-appsmith-online) guide.
+For high availability and scalability configuration, see the [Configure High Availability and Scalability](/getting-started/setup/installation-guides/kubernetes/configure-high-availability) guide. If you are migrating an existing single-pod installation to HA, see [Migrate Helm deployment from non-HA to HA](/getting-started/setup/installation-guides/kubernetes/migrate-non-ha-to-ha-helm). To expose Appsmith installation on the internet, see the [Expose K8s to Internet](/getting-started/setup/installation-guides/kubernetes/publish-appsmith-online) guide.
 
 ## Install Appsmith Community
 

--- a/website/docs/getting-started/setup/installation-guides/kubernetes/configure-high-availability.mdx
+++ b/website/docs/getting-started/setup/installation-guides/kubernetes/configure-high-availability.mdx
@@ -131,6 +131,7 @@ If you encounter errors, roll back to a previous version. See the [Restore insta
 
 ## See also
 
+- [Migrate Helm deployment from non-HA to HA](/getting-started/setup/installation-guides/kubernetes/migrate-non-ha-to-ha-helm): Follow this guide to migrate an existing single-pod Appsmith Helm deployment to shared RWX storage before enabling multiple replicas.
 - [Expose K8s to the Internet](/getting-started/setup/installation-guides/kubernetes/publish-appsmith-online): Follow this guide to expose your Kubernetes-hosted Appsmith instance to the internet, enabling external access.
 - [Restore Appsmith instance](/getting-started/setup/instance-management/backup-and-restore/restore-instance): Follow this guide to restore your Appsmith instance from a backup, ensuring minimal downtime and data loss.
 - [SAML Single Sign-On](/getting-started/setup/instance-configuration/authentication/security-assertion-markup-language-saml): Learn how to configure SAML-based Single Sign-On (SSO) for secure authentication in your Appsmith instance.

--- a/website/docs/getting-started/setup/installation-guides/kubernetes/migrate-non-ha-to-ha-helm.mdx
+++ b/website/docs/getting-started/setup/installation-guides/kubernetes/migrate-non-ha-to-ha-helm.mdx
@@ -1,0 +1,159 @@
+---
+description: Migrate an existing Appsmith Helm deployment on Kubernetes from non-HA storage to HA storage with minimal data loss.
+title: Migrate K8s Helm Deployment to HA
+hide_title: true
+---
+
+<!-- vale off -->
+
+<div className="tag-wrapper">
+ <h1>Migrate Appsmith Helm Deployment from Non-HA to HA (Kubernetes)</h1>
+
+<Tags
+tags={[
+{ name: "Business", link: "https://www.appsmith.com/pricing", additionalClass: "business" }
+]}
+/>
+
+</div>
+
+<!-- vale on -->
+
+This guide explains how to migrate an existing Appsmith Helm deployment from single-pod storage (typically `ReadWriteOnce`) to shared storage (`ReadWriteMany`) so you can run Appsmith in high availability mode with multiple pods.
+
+The default Helm configuration sets `autoscaling.enabled: false`, which deploys Appsmith as a StatefulSet and creates a pod volume mounted at `/appsmith-stacks`. In most clusters, this uses the default StorageClass and is not shareable across multiple pods.
+
+To enable HA safely, migrate data to a new `ReadWriteMany` (RWX) volume first, then cut Appsmith over to that claim.
+
+For all available chart parameters, see Helm [values.yaml](https://github.com/appsmithorg/appsmith/blob/release/deploy/helm/values.yaml).
+
+## System requirements
+
+- At least 2 GB of free storage space for backup and migration tasks.
+
+## Prerequisites
+
+Before you begin, ensure:
+
+1. You already have Appsmith installed on Kubernetes using Helm.
+2. You can run `kubectl` and `helm` commands against your cluster.
+3. You have a maintenance window for final cutover.
+4. You have a backup of the instance. See [Backup instance](/getting-started/setup/instance-management/backup-and-restore/backup-instance?current-command-type=kubernetes-commands).
+
+## Step 1: Provision RWX storage outside the Helm chart
+
+Create a new PersistentVolume (PV) and PersistentVolumeClaim (PVC) backed by a RWX-capable storage class using your cloud/on-prem CSI driver.
+
+Use provider guides as needed:
+
+- AWS EKS + EFS CSI driver: [Install the Amazon EFS CSI driver](https://docs.aws.amazon.com/eks/latest/userguide/efs-csi.html)
+- Google Kubernetes Engine + Filestore CSI driver: [Use Filestore with GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/filestore-csi-driver)
+- Generic Kubernetes storage: [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
+
+For this migration scenario, it is cleaner to create and manage the PV/PVC outside the Appsmith Helm chart and then reference the PVC from `values.yaml`.
+
+In the examples below, the target PVC name is `appsmith-data-ha`.
+
+## Step 2: Mount the new PVC as a temporary secondary path
+
+Follow the below steps to mount the new claim as a temporary secondary path:
+
+1. Update `values.yaml` to add the new claim as an extra volume and mount point:
+
+   ```yaml
+   extraVolumes:
+     - name: appsmith-data-ha-volume
+       persistentVolumeClaim:
+         claimName: appsmith-data-ha
+   extraVolumeMounts:
+     - name: appsmith-data-ha-volume
+       mountPath: /appsmith-stacks-ha
+   ```
+
+2. Apply the change:
+
+   ```bash
+   helm upgrade -i <release_name> appsmith-ee/appsmith -n <namespace> -f values.yaml
+   ```
+
+3. Wait until Appsmith is healthy:
+
+   ```bash
+   kubectl get pods -n <namespace>
+   ```
+
+## Step 3: Copy data from current volume to RWX volume
+
+Follow the below steps to copy data from the existing volume to the new RWX volume:
+
+1. Open a shell in the running Appsmith pod:
+
+   ```bash
+   kubectl exec -it pod/<appsmith_pod_name> -n <namespace> -- bash
+   ```
+
+2. Copy all data from the original path to the temporary RWX path:
+
+   ```bash
+   cp -a /appsmith-stacks/* /appsmith-stacks-ha/
+   ```
+
+## Step 4: Cut over Appsmith to the new existing claim
+
+Follow the below steps to cut over Appsmith to the new claim:
+
+1. Remove the temporary `extraVolumes` and `extraVolumeMounts` entries.
+2. Set Appsmith persistence to use the new claim directly:
+
+   ```yaml
+   persistence:
+     existingClaim:
+       enabled: true
+       name: appsmith-data-ha
+       claimName: appsmith-data-ha
+   ```
+
+3. Apply the final cutover:
+
+   ```bash
+   helm upgrade -i <release_name> appsmith-ee/appsmith -n <namespace> -f values.yaml
+   ```
+
+## Step 5: Enable HA replicas
+
+If not already enabled, follow the below steps to set autoscaling:
+
+1. Update `values.yaml`:
+
+   ```yaml
+   autoscaling:
+     enabled: true
+     minReplicas: 2
+     maxReplicas: 2
+   ```
+
+2. Apply the update and verify multiple healthy pods:
+
+   ```bash
+   kubectl get pods -n <namespace>
+   ```
+
+## Data consistency note
+
+:::caution
+Data written between the copy step and final cutover can be missed.
+:::
+
+To minimize risk:
+
+- Keep the copy-to-cutover window as short as possible.
+- Consider temporarily blocking user traffic (for example, disable ingress) during final cutover.
+- If needed, run an additional sync pass (for example, with `rsync`) just before cutover.
+
+In most cases, the highest-risk loss is recent filesystem writes such as logs, but configuration artifacts can also be affected if the window is large.
+
+## See also
+
+- [Configure High Availability on AWS EKS (K8s)](/getting-started/setup/installation-guides/kubernetes/configure-high-availability)
+- [Kubernetes installation guide](/getting-started/setup/installation-guides/kubernetes)
+- [Restore instance](/getting-started/setup/instance-management/backup-and-restore/restore-instance)

--- a/website/docs/getting-started/setup/installation-guides/kubernetes/migrate-non-ha-to-ha-helm.mdx
+++ b/website/docs/getting-started/setup/installation-guides/kubernetes/migrate-non-ha-to-ha-helm.mdx
@@ -27,18 +27,15 @@ To enable HA safely, migrate data to a new `ReadWriteMany` (RWX) volume first, t
 
 For all available chart parameters, see Helm [values.yaml](https://github.com/appsmithorg/appsmith/blob/release/deploy/helm/values.yaml).
 
-## System requirements
-
-- At least 2 GB of free storage space for backup and migration tasks.
-
 ## Prerequisites
 
 Before you begin, ensure:
 
-1. You already have Appsmith installed on Kubernetes using Helm.
-2. You can run `kubectl` and `helm` commands against your cluster.
-3. You have a maintenance window for final cutover.
-4. You have a backup of the instance. See [Backup instance](/getting-started/setup/instance-management/backup-and-restore/backup-instance?current-command-type=kubernetes-commands).
+1. You already have an Appsmith instance installed on Kubernetes using Helm using a StatefulSet. If this is not your current situation, start your [Kubernetes deployment with HA enabled](/getting-started/setup/installation-guides/kubernetes/configure-high-availability).
+2. You have `kubectl` and `helm` access to the target Kubernetes cluster.
+3. You have access to create the required storage resources in your cloud provider and/or Kubernetes cluster.
+4. It is recommended to download the latest backup of your Appsmith instance from the cluster before you start migration. See [Backup instance](/getting-started/setup/instance-management/backup-and-restore/backup-instance?current-command-type=kubernetes-commands).
+5. You have a maintenance window for final cutover.
 
 ## Step 1: Provision RWX storage outside the Helm chart
 

--- a/website/docs/getting-started/setup/installation-guides/kubernetes/migrate-non-ha-to-ha-helm.mdx
+++ b/website/docs/getting-started/setup/installation-guides/kubernetes/migrate-non-ha-to-ha-helm.mdx
@@ -48,11 +48,29 @@ Use provider guides as needed:
 
 - AWS EKS + EFS CSI driver: [Install the Amazon EFS CSI driver](https://docs.aws.amazon.com/eks/latest/userguide/efs-csi.html)
 - Google Kubernetes Engine + Filestore CSI driver: [Use Filestore with GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/filestore-csi-driver)
-- Generic Kubernetes storage: [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
+- For on-prem deployments: [NFS CSI Driver](https://github.com/kubernetes-csi/csi-driver-nfs)
 
 For this migration scenario, it is cleaner to create and manage the PV/PVC outside the Appsmith Helm chart and then reference the PVC from `values.yaml`.
 
 In the examples below, the target PVC name is `appsmith-data-ha`.
+
+An example PVC you can use might look like this:
+
+```
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: appsmith-data-ha
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: nfs-csi
+  resources:
+    requests:
+      storage: 5Gi
+```
+
+But adapt it for your provider and/or situation.
 
 ## Step 2: Mount the new PVC as a temporary secondary path
 
@@ -73,7 +91,7 @@ Follow the below steps to mount the new claim as a temporary secondary path:
 2. Apply the change:
 
    ```bash
-   helm upgrade -i <release_name> appsmith-ee/appsmith -n <namespace> -f values.yaml
+   helm upgrade <release_name> appsmith-ee/appsmith -n <namespace> -f values.yaml
    ```
 
 3. Wait until Appsmith is healthy:
@@ -111,37 +129,32 @@ Follow the below steps to cut over Appsmith to the new claim:
        enabled: true
        name: appsmith-data-ha
        claimName: appsmith-data-ha
+   autoscaling:
+     enabled: true
    ```
 
-3. Apply the final cutover:
+3. Apply the final cutover and verify:
 
    ```bash
    helm upgrade -i <release_name> appsmith-ee/appsmith -n <namespace> -f values.yaml
    ```
 
-## Step 5: Enable HA replicas
-
-If not already enabled, follow the below steps to set autoscaling:
-
-1. Update `values.yaml`:
-
-   ```yaml
-   autoscaling:
-     enabled: true
-     minReplicas: 2
-     maxReplicas: 2
-   ```
-
-2. Apply the update and verify multiple healthy pods:
+Watch for pods to become healthy:
 
    ```bash
    kubectl get pods -n <namespace>
    ```
 
+Verify the pods are mounting your new volume by desribing the deployment and checking the volumes section:
+
+   ```bash
+   kubectl describe deployment/<release_name> -n <namespace>
+   ```
+
 ## Data consistency note
 
 :::caution
-Data written between the copy step and final cutover can be missed.
+Data written between the copy step and final cutover will be left behind on the old volume.
 :::
 
 To minimize risk:

--- a/website/docs/getting-started/setup/instance-configuration/README.mdx
+++ b/website/docs/getting-started/setup/instance-configuration/README.mdx
@@ -51,6 +51,18 @@ This page provides detailed resources to assist you in configuring and managing 
            <div className="containerDescription">This guide walks you through the steps to set up high availability for an Appsmith instance on  Google Cloud Run, ensuring scalability and fault tolerance.</div>
        </div>
    </a>
+
+   <a className="containerAnchor" href="/getting-started/setup/installation-guides/kubernetes/migrate-non-ha-to-ha-helm">
+       <div className="containerColumnSampleApp columnGrid column-two">
+           <div className="containerHead">
+               <div className="containerHeading">
+                   <strong>Migrate Kubernetes Single-Pod to HA</strong>
+               </div>
+           </div>
+           <hr className="gradient-hr" />
+           <div className="containerDescription">This guide walks you through the steps to migrate an existing single-pod Appsmith Kubernetes Helm deployment to high availability using shared RWX storage and multiple replicas.</div>
+       </div>
+   </a>
 </div>
 
 ---

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -61,8 +61,16 @@ const sidebars = {
               type: 'category',
               label: 'High Availability Guides',
               items: [
-                'getting-started/setup/installation-guides/kubernetes/configure-high-availability',
-                'getting-started/setup/installation-guides/kubernetes/migrate-non-ha-to-ha-helm',
+                {
+                  type: 'doc',
+                  id: 'getting-started/setup/installation-guides/kubernetes/configure-high-availability',
+                  label: 'Kubernetes: AWS EKS with HA',
+                },
+                {
+                  type: 'doc',
+                  id: 'getting-started/setup/installation-guides/kubernetes/migrate-non-ha-to-ha-helm',
+                  label: 'Kubernetes: Migrate Single-Pod to HA',
+                },
                 {
                   type: 'category',
                   label: 'AWS ECS on Fargate',

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -62,6 +62,7 @@ const sidebars = {
               label: 'High Availability Guides',
               items: [
                 'getting-started/setup/installation-guides/kubernetes/configure-high-availability',
+                'getting-started/setup/installation-guides/kubernetes/migrate-non-ha-to-ha-helm',
                 {
                   type: 'category',
                   label: 'AWS ECS on Fargate',


### PR DESCRIPTION
## Description 

Provide a concise summary of the changes made in this pull request
- Creates a guide for migrating from a single pod StatefulSet deployment to an autoscaled deployment.

## Pull request type

Check the appropriate box:

- [ ] Review Fixes
- [ ] Documentation Overhaul
- [x] Feature/Story
    - Link one or more Engineering Tickets
        * 
- [ ] A-Force
- [ ] Error in documentation
- [ ] Maintenance

## Documentation tickets

 Link to one or more documentation tickets:
 - https://linear.app/appsmith/issue/APP-14977/guide-to-migrate-into-ha-setup-on-appsmith

## Checklist

From the below options, select the ones that are applicable:

- [ ] Checked for Grammarly suggestions.
- [ ] Adhered to the writing checklist.
- [ ] Adhered to the media checklist.
- [ ] Verified and updated cross-references or added redirect rules.
- [ ] Tested the redirect rules on deploy preview.
- [ ] Validated the modifications made to the content on the deploy preview.
- [ ] Validated the CSS modifications on different screen sizes.
