### PR TITLE
docs: update installation guides to require pinned Appsmith image tags

### DIFF
--- a/website/docs/connect-data/how-to-guides/how-to-work-with-local-apis-on-appsmith.mdx
+++ b/website/docs/connect-data/how-to-guides/how-to-work-with-local-apis-on-appsmith.mdx
@@ -122,14 +122,14 @@ In this guide, you'll use networked Docker containers to spin up a Postgres inst
 
 1. Create two folders, `Appsmith` and `Datasource`.
 
-1. Within the `Appsmith` folder, create a `docker-compose.yml` file for Appsmith. Assign it to the network from the first step, such as in the bottom of this example file:
+1. Within the `Appsmith` folder, create a `docker-compose.yml` file for Appsmith. Assign it to the network from the first step, such as in the bottom of this example file. Replace `<version>` with a release tag from [Appsmith on GitHub](https://github.com/appsmithorg/appsmith/releases). For the Commercial edition image, use `appsmith-ee` instead of `appsmith-ce`.
 
     ```yaml
     version: "3"
     services:
         appsmith:
             # appsmith-ce for community edition, appsmith-ee for business.
-            image: index.docker.io/appsmith/appsmith-ce
+            image: index.docker.io/appsmith/appsmith-ce:<version>
             container_name: appsmith
             ports:
                 - "80:80"

--- a/website/docs/getting-started/setup/best-practices.md
+++ b/website/docs/getting-started/setup/best-practices.md
@@ -74,6 +74,7 @@ Regular backups and recovery plans are critical to prevent data loss and ensure 
 
 Having a proper upgrade strategy ensures that your environment remains up-to-date with the latest features and security patches.
 
+- Pin the Appsmith `image` to a specific release tag from [Appsmith on GitHub](https://github.com/appsmithorg/appsmith/releases) instead of relying on the implicit `latest` reference, so upgrades are deliberate and rollbacks are predictable. For the full workflow, see [Upgrade Appsmith Versions](/getting-started/setup/instance-management/update-appsmith).
 - Backup your environment and configuration files before upgrading. For more information, see the [Backup and recovery management(#backup-and-recovery-management) section.
 - Verify whether you need to **Upgrade to Checkpoint Version (v1.9.2)** before proceeding.
 - To stay up-to-date, enable **auto-updates**. For more information, see the [Schedule Automatic Updates](/getting-started/setup/instance-management/maintenance-window) guide.

--- a/website/docs/getting-started/setup/installation-guides/aws-ecs-on-fargate.md
+++ b/website/docs/getting-started/setup/installation-guides/aws-ecs-on-fargate.md
@@ -103,7 +103,7 @@ Follow these steps to create task and container definitions for your cluster:
    
 4. In the **Container-1** section:
     * **Name** - Give a meaningful and unique name. For example, `appsmith`.
-    * **Image/URI** - `appsmith/appsmith-ee`
+    * **Image/URI** - `appsmith/appsmith-ee:<version>`, replacing `<version>` with a release tag from [Appsmith on GitHub](https://github.com/appsmithorg/appsmith/releases). Use a pinned tag so task revisions pull a known image.
     * Add the port mappings for Port `80` as follows:
       * **Container port** - `80`
       * **Protocol** - HTTP
@@ -237,7 +237,7 @@ Follow these steps to create and run an ECS service:
 
 ## Install Appsmith Community
 
-To install the Appsmith open source edition (Appsmith Community), replace `appsmith-ee` with `appsmith-ce` in step 4 of the [Create task and container definitions](#create-task-and-container-definitions) section on this page.
+To install the Appsmith open source edition (Appsmith Community), replace `appsmith-ee` with `appsmith-ce` in the **Image/URI** value in step 4 of the [Create task and container definitions](#create-task-and-container-definitions) section on this page, and keep the same `:<version>` suffix.
 
 ## Post-installation configuration
 

--- a/website/docs/getting-started/setup/installation-guides/aws-ecs/aws-ecs-on-ec2.md
+++ b/website/docs/getting-started/setup/installation-guides/aws-ecs/aws-ecs-on-ec2.md
@@ -67,7 +67,7 @@ To deploy Appsmith on the Amazon ECS cluster that has a single node, you need to
     * **Task role** and **Task execution role** as default. For all other fields keep the default settings.
 5. Configure the **Container-1** as shown below:
     * **Name** - Give a meaningful name. For example, `appsmith`
-    * **Image URI** - `index.docker.io/appsmith/appsmith-ee`
+    * **Image URI** - `index.docker.io/appsmith/appsmith-ee:<version>`, replacing `<version>` with a release tag from [Appsmith on GitHub](https://github.com/appsmithorg/appsmith/releases). Use a pinned tag so task revisions pull a known image.
     * Add the port mappings for Port `80` as follows:
       * **Container port** - `80`
       * **Protocol** - HTTP
@@ -135,7 +135,7 @@ To deploy Appsmith on the Amazon ECS cluster that has a single node, you need to
 
 ## Install Appsmith Community
 
-For the Appsmith open source edition (Appsmith Community), substitute `appsmith/appsmith-ee` with `appsmith/appsmith-ce` in the container definition for **Container-1** in the [Create task and container definition](#create-task-and-container-definition) section on this page.
+For the Appsmith open source edition (Appsmith Community), substitute `appsmith/appsmith-ee` with `appsmith/appsmith-ce` in the **Image URI** for **Container-1** in the [Create task and container definition](#create-task-and-container-definition) section on this page, and keep the same `:<version>` suffix.
 
 
 ## Post-installation configuration

--- a/website/docs/getting-started/setup/installation-guides/azure-aci.md
+++ b/website/docs/getting-started/setup/installation-guides/azure-aci.md
@@ -66,13 +66,15 @@ az storage share create --name $fileShareName --account-name $storageAccountName
 
 ## Install Appsmith
 
+- Choose a release tag from [Appsmith on GitHub](https://github.com/appsmithorg/appsmith/releases) and set it in place of `<version>` in the `--image` value below. Pinning the tag keeps upgrades under your control.
+
 - Create an Azure container instance for Appsmith with: 
 
   ```bash
   az container create \
   --resource-group $resourceGroupName \
   	--name $aciName \
-  	--image appsmith/appsmith-ee \
+  	--image appsmith/appsmith-ee:<version> \
   	--ip-address public \
   	--dns-name-label $dnsNameLabel \
   	--ports 80 443 \
@@ -86,7 +88,7 @@ az storage share create --name $fileShareName --account-name $storageAccountName
 
 ## Install Appsmith Community
 
-To install the Appsmith open source edition (Appsmith Community), replace `appsmith-ee` with `appsmith-ce` while creating an Azure container instance file on this page.
+To install the Appsmith open source edition (Appsmith Community), replace `appsmith-ee` with `appsmith-ce` in the `--image` value while creating an Azure container instance on this page, and keep the same `:<version>` suffix.
 
 
 ## Post-installation configuration

--- a/website/docs/getting-started/setup/installation-guides/azure/setup-to-integrate-sso.md
+++ b/website/docs/getting-started/setup/installation-guides/azure/setup-to-integrate-sso.md
@@ -188,6 +188,8 @@ To connect your PostgreSQL database to Appsmith, follow these steps:
 
 Get the `APPSMITH_KEYCLOAK_DB_URL` from the **Connection Strings** section of your Azure PostgreSQL instance. 
 
+Pin the Appsmith image to a release tag from [Appsmith on GitHub](https://github.com/appsmithorg/appsmith/releases) by replacing `<version>` in the example below.
+
 *Example:*
 
 ```yaml
@@ -196,7 +198,7 @@ Get the `APPSMITH_KEYCLOAK_DB_URL` from the **Connection Strings** section of yo
 version: "3"
 services:
   appsmith:
-    image: index.docker.io/appsmith/appsmith-ee
+    image: index.docker.io/appsmith/appsmith-ee:<version>
     container_name: appsmith
     ports:
       - "80:80"

--- a/website/docs/getting-started/setup/installation-guides/docker/README.mdx
+++ b/website/docs/getting-started/setup/installation-guides/docker/README.mdx
@@ -33,7 +33,7 @@ Follow these steps to install Appsmith:
    version: "3"
    services:
       appsmith:
-        image: index.docker.io/appsmith/appsmith-ee
+        image: index.docker.io/appsmith/appsmith-ee:<version>
         container_name: appsmith
         ports:
             - "80:80"
@@ -43,7 +43,11 @@ Follow these steps to install Appsmith:
         restart: unless-stopped
    ```
 
-   The `appsmith-ee` image installs the _Commercial edition_ (recommended), which offers a _free plan_ and the flexibility to upgrade to a paid plan at any point. To install the _Community edition_, replace `appsmith-ee` with `appsmith-ce` in the image attribute within the `docker-compose.yml` file.
+   :::tip Pin the image to a release tag
+   Replace `<version>` with a release tag from [Appsmith on GitHub](https://github.com/appsmithorg/appsmith/releases) (for example, `v1.98`). Pinning the image avoids unexpected upgrades when you recreate the container and is recommended for production. If you omit the tag, Docker uses `latest`, which is acceptable for quick local trials but gives you less control over upgrades.
+   :::
+
+   The `appsmith-ee` image installs the _Commercial edition_ (recommended), which offers a _free plan_ and the flexibility to upgrade to a paid plan at any point. To install the _Community edition_, replace `appsmith-ee` with `appsmith-ce` in the image name and keep the same `:<version>` suffix in the `image` attribute within the `docker-compose.yml` file.
 
 3. Start the Docker container by using the below command. You may need to use `sudo` if you don't have permission to run `docker-compose`:
 

--- a/website/docs/getting-started/setup/installation-guides/docker/migrate.md
+++ b/website/docs/getting-started/setup/installation-guides/docker/migrate.md
@@ -160,6 +160,8 @@ docker-compose up -d
 
 _Please note that you must create a new `docker-compose.yml` in the `"$new_path"` folder, like with the `curl` command. Don't copy it from `"$old_path"`._
 
+After you generate the file, confirm the Appsmith `image` in `docker-compose.yml` uses a pinned release tag if you need a known version; see the [Docker install guide](/getting-started/setup/installation-guides/docker).
+
 ## Import database
 
 After your new deployment comes up (usually takes \~30 seconds), import the data that was exported from the old instance:

--- a/website/docs/getting-started/setup/installation-guides/google-cloud-run.mdx
+++ b/website/docs/getting-started/setup/installation-guides/google-cloud-run.mdx
@@ -80,7 +80,7 @@ Follow these steps to install Appsmith on Google Cloud Run:
 
 3. In the form, select **Deploy one revision from an existing container image**.
 
-   - In the **Container image URL** box, enter `docker.io/appsmith/appsmith-ee`.
+   - In the **Container image URL** box, enter `docker.io/appsmith/appsmith-ee:<version>`, replacing `<version>` with a release tag from [Appsmith on GitHub](https://github.com/appsmithorg/appsmith/releases). Pinning the tag avoids pulling an unexpected image when you deploy new revisions.
 
 4. Enter a desired name in the **Service name** field.
 
@@ -131,7 +131,7 @@ Follow these steps to install Appsmith on Google Cloud Run:
 
 ## Install Appsmith Community
 
-To install the Appsmith open source edition (Appsmith Community), replace `appsmith-ee` with `appsmith-ce` while creating a service in step 3 of the [Install Appsmith](#install-appsmith) section on this page.
+To install the Appsmith open source edition (Appsmith Community), replace `appsmith-ee` with `appsmith-ce` while creating a service in step 3 of the [Install Appsmith](#install-appsmith) section on this page, and keep the same `:<version>` suffix on the image URL.
 
 ## Post-installation configuration
 

--- a/website/docs/getting-started/setup/instance-management/update-appsmith.mdx
+++ b/website/docs/getting-started/setup/instance-management/update-appsmith.mdx
@@ -36,7 +36,20 @@ If your current version is older than v1.9.2. Refer to the [Upgrade to Checkpoin
    ```bash
    docker inspect -f '{{ (index .Mounts 0).Source }}' <APPSMITH_CONTAINER_ID>
    ``` 
-2. Pull the latest Appsmith image and restart the container:  
+2. Retrieve the Appsmith version you want to run.
+
+   Find the release tag on [GitHub](https://github.com/appsmithorg/appsmith/releases).
+
+3. Open `docker-compose.yml` in that directory and set the `image` for the Appsmith service to a pinned tag, for example:
+
+   ```yaml
+   image: index.docker.io/appsmith/appsmith-ee:<version>
+   ```
+
+   If you use the Community edition image, use `appsmith-ce` instead of `appsmith-ee` and the same `:<version>` suffix.
+
+4. Pull the image and restart the container. The running container matches the tag in `docker-compose.yml`.
+
    ```bash
    docker-compose pull && docker-compose rm -fsv appsmith && docker-compose up -d
    ```
@@ -113,7 +126,19 @@ If your current version is older than v1.9.2. Refer to the [Upgrade to Checkpoin
    ```bash
    cd /root/appsmith
    ```  
-2. Pull the latest image and restart the installation:  
+2. Retrieve the Appsmith version you want to run.
+
+   Find the release tag on [GitHub](https://github.com/appsmithorg/appsmith/releases).
+
+3. Open `docker-compose.yml` and set the `image` for the Appsmith service to a pinned tag, for example:
+
+   ```yaml
+   image: index.docker.io/appsmith/appsmith-ee:<version>
+   ```
+
+   If you use the Community edition image, use `appsmith-ce` instead of `appsmith-ee` and the same `:<version>` suffix.
+
+4. Pull the image and restart the installation. The running container matches the tag in `docker-compose.yml`.
 
    ```bash
    docker-compose pull && docker-compose rm -fsv appsmith && docker-compose up -d

--- a/website/docs/getting-started/setup/upgrade-from-community-edition/docker.mdx
+++ b/website/docs/getting-started/setup/upgrade-from-community-edition/docker.mdx
@@ -23,23 +23,24 @@ Follow these steps to upgrade your Appsmith instance:
 
 1. Go to the root directory of Appsmith installation.
 2. Open the `docker-compose.yml` file, and search for the `image:` key.
-3. Update the value of the `image:` key as below:
+3. Choose a release tag for the Commercial edition image from [Appsmith on GitHub](https://github.com/appsmithorg/appsmith/releases).
+4. Update the value of the `image:` key as below. Replace `<version>` with that tag.
 
   ``` yaml
     services:
       appsmith:
       #highlight-next-line
-        image: index.docker.io/appsmith/appsmith-ee
+        image: index.docker.io/appsmith/appsmith-ee:<version>
   ```
-4. Save the file.
+5. Save the file.
 
-5. Recreate the instance with:
+6. Recreate the instance with:
 
   ```bash
   docker-compose up -d --force-recreate
   ```
 
-6. Open [https://localhost](https://localhost) and wait for the server to come up. This can take up to 5 minutes. Once the server is up and running, verify the upgrade with:
+7. Open [https://localhost](https://localhost) and wait for the server to come up. This can take up to 5 minutes. Once the server is up and running, verify the upgrade with:
 
   ```bash
   # verify the image name as (appsmith-ee) in use 
@@ -47,7 +48,7 @@ Follow these steps to upgrade your Appsmith instance:
   ```
 You have successfully upgraded your Docker Appsmith instance. 
 
-7.  Log into your Appsmith account.
+8.  Log into your Appsmith account.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Description 

Provide a concise summary of the changes made in this pull request
- Added instructions to pin the Appsmith image to a specific release tag in various installation guides, including Docker, AWS ECS, Azure, and Google Cloud Run.
- Emphasized the importance of using a pinned version to avoid unexpected upgrades and ensure predictable rollbacks.
- Updated examples to reflect the new format for specifying the image version.

## Pull request type

Check the appropriate box:

- [ ] Review Fixes
- [ ] Documentation Overhaul
- [ ] Feature/Story
    - Link one or more Engineering Tickets
        * 
- [ ] A-Force
- [ ] Error in documentation
- [ ] Maintenance

## Documentation tickets

 Link to one or more documentation tickets:
 - 

## Checklist

From the below options, select the ones that are applicable:

- [ ] Checked for Grammarly suggestions.
- [ ] Adhered to the writing checklist.
- [ ] Adhered to the media checklist.
- [ ] Verified and updated cross-references or added redirect rules.
- [ ] Tested the redirect rules on deploy preview.
- [ ] Validated the modifications made to the content on the deploy preview.
- [ ] Validated the CSS modifications on different screen sizes.
