### PR TITLE
chore: enforce HTTP/1.1 for curl commands in vector store workflow

### DIFF
--- a/.github/workflows/generate-file-for-ai.yaml
+++ b/.github/workflows/generate-file-for-ai.yaml
@@ -62,12 +62,12 @@ jobs:
           VECTOR_STORE_ID: ${{ secrets.OPENAI_VECTOR_STORE_ID }}
         run: |
           echo "Validating vector store..."
-          vs_validate=$(curl -fsS "https://api.openai.com/v1/vector_stores/$VECTOR_STORE_ID" \
+          vs_validate=$(curl -fsS --http1.1 "https://api.openai.com/v1/vector_stores/$VECTOR_STORE_ID" \
             -H "Authorization: Bearer $OPENAI_API_KEY")
           echo "$vs_validate" | jq .
 
           echo "Attaching file to vector store..."
-          attach_response=$(curl -sS -X POST \
+          attach_response=$(curl -sS --http1.1 -X POST \
             -H "Authorization: Bearer $OPENAI_API_KEY" \
             -H "Content-Type: application/json" \
             -d "{\"file_id\":\"$FILE_ID\"}" \
@@ -91,7 +91,7 @@ jobs:
         run: |
           echo "Waiting for file $FILE_ID to finish processing in vector store..."
           for i in $(seq 1 60); do
-            file_response=$(curl -sS \
+            file_response=$(curl -sS --http1.1 \
               -H "Authorization: Bearer $OPENAI_API_KEY" \
               "https://api.openai.com/v1/vector_stores/$VECTOR_STORE_ID/files/$FILE_ID")
 


### PR DESCRIPTION
## Description 
- Updated curl commands in the GitHub Actions workflow to explicitly use HTTP/1.1 for improved compatibility during file processing and attachment to the OpenAI vector store.
- Ensured consistent behavior across all curl requests related to vector store operations.

## Pull request type

Check the appropriate box:

- [ ] Review Fixes
- [ ] Documentation Overhaul
- [ ] Feature/Story
    - Link one or more Engineering Tickets
        * 
- [ ] A-Force
- [ ] Error in documentation
- [ ] Maintenance

## Documentation tickets

 Link to one or more documentation tickets:
 - 

## Checklist

From the below options, select the ones that are applicable:

- [ ] Checked for Grammarly suggestions.
- [ ] Adhered to the writing checklist.
- [ ] Adhered to the media checklist.
- [ ] Verified and updated cross-references or added redirect rules.
- [ ] Tested the redirect rules on deploy preview.
- [ ] Validated the modifications made to the content on the deploy preview.
- [ ] Validated the CSS modifications on different screen sizes.
