### PR TITLE
docs: update environment variable documentation for form login behavior

### DIFF
--- a/website/docs/getting-started/setup/environment-variables.md
+++ b/website/docs/getting-started/setup/environment-variables.md
@@ -124,7 +124,9 @@ With Appsmith, you can manage user access and authentication methods in your ins
 
 <dd>
 
-Set to `true` to turn off the default username and password login. Useful for administrators who want to enforce Single Sign-On (SSO) or limit authentication methods for added security and control.
+Set to `true` to turn off the default username and password login when the instance is first configured. Useful for administrators who want to enforce Single Sign-On (SSO) or limit authentication methods for added security and control.
+
+Changing this variable after that initial setup does **not** update form login behavior in a running instance. To change form login afterward, use [`appsmithctl enable-form-login`](/getting-started/setup/instance-management/appsmithctl#enable-form-login) (alias `appsmithctl efl`) or toggle **Form Login** under **Admin Settings → User Management**, as described in [User Management](/getting-started/setup/instance-configuration/user-management#authentication).
 </dd>
 
 ### Security

--- a/website/docs/getting-started/setup/instance-management/appsmithctl.mdx
+++ b/website/docs/getting-started/setup/instance-management/appsmithctl.mdx
@@ -111,3 +111,21 @@ For more information about restoring an Appsmith instance, see [Restore Instance
 
 For more information about restoring the Appsmith database, see [Restore Database](/getting-started/setup/instance-management/backup-and-restore/restore-database) guide.
 </dd>
+
+#### `enable-form-login`
+
+<dd>
+Use this when you need to turn **form login** (email and password sign-in) back on for your Appsmith instance.
+
+  ```bash
+  appsmithctl enable-form-login
+  ```
+
+You can also use the short alias:
+
+  ```bash
+  appsmithctl efl
+  ```
+
+To change form login from the Admin Settings UI instead, see [User Management](/getting-started/setup/instance-configuration/user-management#authentication).
+</dd>


### PR DESCRIPTION
## Description 

- Clarified that setting the variable to `true` disables default username and password login only during initial configuration.
- Added instructions for re-enabling form login post-setup using the `appsmithctl enable-form-login` command or through Admin Settings.

## Pull request type

Check the appropriate box:

- [ ] Review Fixes
- [ ] Documentation Overhaul
- [ ] Feature/Story
    - Link one or more Engineering Tickets
        * 
- [ ] A-Force
- [ ] Error in documentation
- [x] Maintenance

## Documentation tickets

 Link to one or more documentation tickets:
 - 

## Checklist

From the below options, select the ones that are applicable:

- [ ] Checked for Grammarly suggestions.
- [ ] Adhered to the writing checklist.
- [ ] Adhered to the media checklist.
- [ ] Verified and updated cross-references or added redirect rules.
- [ ] Tested the redirect rules on deploy preview.
- [ ] Validated the modifications made to the content on the deploy preview.
- [ ] Validated the CSS modifications on different screen sizes.
