### PR TITLE
docs: bump minimum self-hosting instance size to t3.large

### DIFF
--- a/website/docs/getting-started/setup/best-practices.md
+++ b/website/docs/getting-started/setup/best-practices.md
@@ -20,8 +20,8 @@ Selecting the right platform and deployment method is crucial for the scalabilit
   - If using serverless platforms such as **AWS ECS**, external instances of MongoDB and Redis must be provisioned, with **MongoDB Atlas** and **Elasticache** recommended. For more information, see [AWS ECS Installation](/getting-started/setup/installation-guides/aws-ecs/aws-ecs-on-ec2) guide.
 
 - **Instance recommendations**:
-  - **Minimum instance size**: `t3.medium` or equivalent. This should scale well for hundreds of users.
-  - **For 500 concurrent users**, we recommend `t3.large` or larger instances.
+  - **Minimum instance size**: `t3.large` or equivalent (2 vCPU, 8 GB of memory). This should scale well for hundreds of users.
+  - **For 500 concurrent users**, we recommend `t3.xlarge` or larger instances.
   - **Free disk space**: Always ensure at least `10-15GB` of free space.
   - **Node separation**: For better data safety, keep separate node groups for **MongoDB**, **Redis**, **Postgres**, and the **Appsmith pod** in Kubernetes.
   

--- a/website/docs/getting-started/setup/installation-guides/aws-ecs/aws-ecs-on-ec2.md
+++ b/website/docs/getting-started/setup/installation-guides/aws-ecs/aws-ecs-on-ec2.md
@@ -43,7 +43,7 @@ To deploy Appsmith on the Amazon ECS cluster that has a single node, you need to
     * **Provisioning Model**: Choose **On-demand**
     * **Auto Scaling Group**: Keep default selection
     * **Operating system/Architecture**: Amazon Linux 2
-    * **EC2 instance type**: Select at least a `t3.medium` or a `t3a.medium` instance type.
+    * **EC2 instance type**: Select at least a `t3.large` or a `t3a.large` instance type (2 vCPU, 8 GB of memory).
     * **Desired Capacity**: Give **Minimum** as 1 and **Maximum** as 2
     * **SSH Key pair**: Use the key pair created in the [Prerequisites](#prerequisites) section
     Keep default settings for other attributes.


### PR DESCRIPTION
## Summary

- Align the [Self-hosting Best Practices](https://docs.appsmith.com/getting-started/setup/best-practices) instance sizing with the 8 GB / 2 vCPU baseline already documented on the Self Hosting overview, AWS AMI, and Kubernetes guides. Minimum is now `t3.large` (was `t3.medium` / 4 GB), and the 500-concurrent-user tier steps up from `t3.large` to `t3.xlarge` so the two bullets don't collapse onto the same size.
- Fix the same drift in the AWS ECS-on-EC2 install guide, which still specced `t3.medium` / `t3a.medium`.

The Fargate, Cloud Run, and Azure ACI install guides also undershoot the 8 GB baseline (4 GB each), but bumping those changes customer cost on managed/serverless platforms — left for a deliberate follow-up alongside the broader best-practices revamp.

## Test plan

- [ ] Pages render correctly on the docs site preview
- [ ] No broken links introduced