### PR TITLE
docs: remove Appsmith Community AMI section

### DIFF
--- a/website/docs/getting-started/setup/installation-guides/aws-ami.md
+++ b/website/docs/getting-started/setup/installation-guides/aws-ami.md
@@ -89,11 +89,6 @@ The application password is **only** available in system logs for the initial 24
 
 3. Once you've created an account, you can either start with the free plan or activate your instance with a license key. If you want to generate a license key, sign up on [customer.appsmith.com](https://customer.appsmith.com) to create one, and then proceed to activate your instance using the newly generated license key.
 
-## Install Appsmith Community
-
-To install the open source edition of Appsmith (Appsmith Community), choose the [Appsmith Community Edition](https://aws.amazon.com/marketplace/pp/prodview-mclslaty46ah4) in step 7 of the [Install Appsmith](#install-appsmith) section on this page.
-
-
 ## Post-installation configuration
 
 Once you have completed the installation process, consider performing the tasks below to configure and manage your Appsmith instance, enhancing its security and performance, specifically if it's intended for production use.


### PR DESCRIPTION
## Summary

- Remove the **Install Appsmith Community** section from the AWS AMI install guide. The Appsmith Community Edition AMI is no longer published on AWS Marketplace, so the link was broken and customers can no longer subscribe to that image.

## Test plan

- [ ] Verify the AWS AMI install page renders without the removed section
- [ ] Confirm no other pages link to the `#install-appsmith-community` anchor