### PR TITLE
docs: drop t3a.large from minimum instance recommendations

### DIFF
--- a/website/docs/getting-started/setup/best-practices.md
+++ b/website/docs/getting-started/setup/best-practices.md
@@ -20,7 +20,7 @@ Selecting the right platform and deployment method is crucial for the scalabilit
   - If using serverless platforms such as **AWS ECS**, external instances of MongoDB and Redis must be provisioned, with **MongoDB Atlas** and **Elasticache** recommended. For more information, see [AWS ECS Installation](/getting-started/setup/installation-guides/aws-ecs/aws-ecs-on-ec2) guide.
 
 - **Infrastructure and capacity planning**:
-  - **Baseline**: Start with **2 vCPU** and **8 GB of memory** for standard deployments. On AWS, the [AWS AMI](/getting-started/setup/installation-guides/aws-ami) guide lists **`t3.large`** or **`t3a.large`** as the minimum instance size. These are entry-level baselines for testing, evaluation, or low-traffic workloads—not fixed production capacity for a given user count.
+  - **Baseline**: Start with **2 vCPU** and **8 GB of memory** for standard deployments. On AWS, the [AWS AMI](/getting-started/setup/installation-guides/aws-ami) guide lists **`t3.large`** as the minimum instance size. These are entry-level baselines for testing, evaluation, or low-traffic workloads—not fixed production capacity for a given user count.
   - **Production sizing**: Capacity depends on application workload, concurrency, and whether MongoDB, Redis, and PostgreSQL run locally or as external services. For the full planning workflow, see [Infrastructure and capacity planning](/getting-started/setup/infrastructure-sizing).
   - **Free disk space**: Always ensure at least `10-15GB` of free space.
   - **Node separation**: For better data safety, keep separate node groups for **MongoDB**, **Redis**, **Postgres**, and the **Appsmith pod** in Kubernetes.

--- a/website/docs/getting-started/setup/infrastructure-sizing.md
+++ b/website/docs/getting-started/setup/infrastructure-sizing.md
@@ -37,7 +37,7 @@ For production environments where scalability and availability are important, **
 
 ## Baseline starting points
 
-Appsmith’s current self-hosting guidance recommends **2 vCPU** and **8 GB of memory** as a starting point for standard deployments. The [AWS AMI](/getting-started/setup/installation-guides/aws-ami) guide lists **`t3.large`** or **`t3a.large`** as the minimum instance size (2 vCPU, 8 GB memory).
+Appsmith’s current self-hosting guidance recommends **2 vCPU** and **8 GB of memory** as a starting point for standard deployments. The [AWS AMI](/getting-started/setup/installation-guides/aws-ami) guide lists **`t3.large`** as the minimum instance size (2 vCPU, 8 GB memory).
 
 These recommendations should generally be viewed as **entry-level baselines** suitable for:
 

--- a/website/docs/getting-started/setup/installation-guides/aws-ami.md
+++ b/website/docs/getting-started/setup/installation-guides/aws-ami.md
@@ -39,7 +39,7 @@ a. Configure the instance as below:
 | Attribute         | Value                                                                           |
 | ----------------- | ------------------------------------------------------------------------------- |
 | **Name**          | Give a desired name.                                                            |
-| **Instance type** | Minimum `t3.large` or `t3a.large` (2 vCPU, 8 GB memory) for evaluation and low-traffic workloads. For production sizing guidance, see [Infrastructure and capacity planning](/getting-started/setup/infrastructure-sizing). |
+| **Instance type** | Minimum `t3.large` (2 vCPU, 8 GB memory) for evaluation and low-traffic workloads. For production sizing guidance, see [Infrastructure and capacity planning](/getting-started/setup/infrastructure-sizing). |
 | **Key pair**      | Select the Key pair you created in the [Prerequisites](#prerequisites) section. |
 
 b. Scroll down to the **Networking** section, and configure as below:

--- a/website/docs/getting-started/setup/installation-guides/aws-ecs/aws-ecs-on-ec2.md
+++ b/website/docs/getting-started/setup/installation-guides/aws-ecs/aws-ecs-on-ec2.md
@@ -43,7 +43,7 @@ To deploy Appsmith on the Amazon ECS cluster that has a single node, you need to
     * **Provisioning Model**: Choose **On-demand**
     * **Auto Scaling Group**: Keep default selection
     * **Operating system/Architecture**: Amazon Linux 2
-    * **EC2 instance type**: Select at least a `t3.large` or a `t3a.large` instance type (2 vCPU, 8 GB of memory) as an entry-level baseline for evaluation and low-traffic workloads. For production sizing guidance, see [Infrastructure and capacity planning](/getting-started/setup/infrastructure-sizing).
+    * **EC2 instance type**: Select at least a `t3.large` instance type (2 vCPU, 8 GB of memory) as an entry-level baseline for evaluation and low-traffic workloads. For production sizing guidance, see [Infrastructure and capacity planning](/getting-started/setup/infrastructure-sizing).
     * **Desired Capacity**: Give **Minimum** as 1 and **Maximum** as 2
     * **SSH Key pair**: Use the key pair created in the [Prerequisites](#prerequisites) section
     Keep default settings for other attributes.


### PR DESCRIPTION
## Summary

- t3a class instances aren't strong enough for real-world Appsmith workloads, so the minimum-instance guidance now lists only `t3.large`.
- Updates four pages that previously suggested `t3.large` or `t3a.large`: AWS AMI, AWS ECS on EC2, Best practices, and Infrastructure sizing.

## Test plan

- [ ] Verify each affected page renders without the `t3a.large` reference