### PR TITLE
docs: fix MultiSelect setSelectedOptions setter reference

### DIFF
--- a/website/docs/reference/widgets/multiselect.md
+++ b/website/docs/reference/widgets/multiselect.md
@@ -461,16 +461,37 @@ MultiSelect1.setRequired(true)
 </dd>
 
 
-#### setSelectedOptions (param: object): Promise
+#### setSelectedOptions (param: array): Promise
 
 <dd>
 
-Sets the selected option of the MultiSelect widget.
+Sets the selected option(s) of the MultiSelect widget. Updates the widget's default selected values, reflected in `selectedOptionValues`.
+
+*Parameter type*: `Array<string | number>` or `Array<{ label: string, value: string | number }>`
+
+*Notes*:
+- Pass option **values** from your source data (the field bound to the **Value key** / `optionValue` property), not display labels.
+- Values in the array must be unique.
+- Pass an empty array `[]` to clear all selections.
+- `undefined` is not allowed and will throw.
 
 *Example*:
 
 ```js
-MultiSelect1.setSelectedOption({ label: 'Option 2', value: 'option2' })
+// Recommended — array of option values
+MultiSelect1.setSelectedOptions(["GREEN", "RED"])
+
+// Array of label/value objects
+MultiSelect1.setSelectedOptions([
+  { label: "Green", value: "GREEN" },
+  { label: "Red", value: "RED" }
+])
+
+// Single selection (coerced to one-element array)
+MultiSelect1.setSelectedOptions("GREEN")
+
+// Clear selection
+MultiSelect1.setSelectedOptions([])
 ```
 
 </dd>


### PR DESCRIPTION
## Description

Fixes the `setSelectedOptions` setter reference for the MultiSelect widget. The previous entry was incorrect on four counts:
- The example used the singular `setSelectedOption` — MultiSelect exposes `setSelectedOptions` (plural).
- The parameter was typed as `object` — it takes an **array** (or a value coerced to one).
- The description implied a single selection — MultiSelect supports multiple selections.
- The example passed a single `{ label, value }` object — callers should pass an array.

Corrected to document the array parameter type, multiple-selection behavior, and array-based examples (option values, label/value objects, single-value coercion, and clearing with `[]`). Verified against the Appsmith codebase: the setter maps to `defaultOptionValue` (type `array`, accessor `selectedOptionValues`).

The singular `setSelectedOption` in `select.md` (single Select widget) is correct and left unchanged.

## Pull request type

- [x] Error in documentation

## Checklist

- [x] Adhered to the writing checklist.
- [x] Validated the modifications made to the content on the deploy preview.
