### PR TITLE
docs: route security vulnerability reports to GitHub

### DIFF
--- a/website/docs/getting-started/faq.md
+++ b/website/docs/getting-started/faq.md
@@ -17,7 +17,7 @@ Appsmith is open source, which means developers can easily adopt, extend and use
 
 Appsmith applications are secure by default. See [Security](/product/security) for more information. For Appsmith cloud users, data is stored and processed on servers in the US. If you want to have complete control over how your data is stored and transmitted, or need to ensure HIPAA compliance, you can [self-host Appsmith](/getting-started/setup) to ensure none of your data leaves your VPC.
 
-We appreciate any information that can help improve the security of our systems and protect users' data. If you believe you have discovered a security vulnerability, please email our security team at [security@appsmith.com](mailto:security@appsmith.com) with a description of the issue and any relevant details. After reviewing the report, appropriate action is taken to address the issue. Please note that Appsmith does not typically offer monetary rewards for security reports.
+We appreciate any information that can help improve the security of our systems and protect users' data. If you believe you have discovered a security vulnerability, please reach out to us through [GitHub's private vulnerability reporting](https://github.com/appsmithorg/appsmith/security/advisories/new) with a description of the issue and any relevant details. After reviewing the report, appropriate action is taken to address the issue. Please note that Appsmith does not typically offer monetary rewards for security reports.
 
 ## Does Appsmith support multi-user editing?
 

--- a/website/docs/product/security.md
+++ b/website/docs/product/security.md
@@ -82,5 +82,5 @@ This method allows for a good balance between security, and convenience. Having 
 These security implementations demonstrate Appsmith's commitment to maintaining a secure environment for developers and users alike. By following the guidelines provided, you can contribute to creating secure applications on the Appsmith platform.
 
 :::info
-Appsmith maintains an open communication channel with security researchers to report security vulnerabilities responsibly. If you notice a security vulnerability, please email `security@appsmith.com`. Please note that Appsmith does not typically offer monetary rewards for security reports.
+Appsmith maintains an open communication channel with security researchers to report security vulnerabilities responsibly. If you believe you have discovered a security vulnerability, please reach out to us through [GitHub's private vulnerability reporting](https://github.com/appsmithorg/appsmith/security/advisories/new) with a description of the issue and any relevant details. After reviewing the report, appropriate action is taken to address the issue. Please note that Appsmith does not typically offer monetary rewards for security reports.
 :::


### PR DESCRIPTION
## Description 

Provide a concise summary of the changes made in this pull request
- Replace `security@appsmith.com` with GitHub private vulnerability reporting on the FAQ and security pages.

## Pull request type

Check the appropriate box:

- [ ] Review Fixes
- [ ] Documentation Overhaul
- [ ] Feature/Story
    - Link one or more Engineering Tickets
        * 
- [ ] A-Force
- [ ] Error in documentation
- [x] Maintenance

## Documentation tickets

 Link to one or more documentation tickets:
 - 

## Checklist

From the below options, select the ones that are applicable:

- [ ] Checked for Grammarly suggestions.
- [ ] Adhered to the writing checklist.
- [ ] Adhered to the media checklist.
- [ ] Verified and updated cross-references or added redirect rules.
- [ ] Tested the redirect rules on deploy preview.
- [ ] Validated the modifications made to the content on the deploy preview.
- [ ] Validated the CSS modifications on different screen sizes.

Made with [Cursor](https://cursor.com)