### PR TITLE
docs: add admin email recovery troubleshooting guide

### DIFF
--- a/website/docs/help-and-support/troubleshooting-guide/deployment-error-guides/unknown-admin-email-recovery.mdx
+++ b/website/docs/help-and-support/troubleshooting-guide/deployment-error-guides/unknown-admin-email-recovery.mdx
@@ -1,0 +1,111 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Recover admin access when you don't know the admin email
+
+## Symptom
+
+<Message
+  messageContainerClassName="error"
+  messageContent="You cannot access Admin Settings and do not know which email has Instance Administrator privileges."
+/>
+
+## Cause
+
+Instance administrator email addresses are managed in **Admin Settings**, which only instance administrators can access. If you cannot reach Admin Settings, you cannot see or change the current admin list from the UI. This commonly happens when the previous administrator left the organization, you inherited an existing deployment, or you forgot which account was configured as the instance administrator.
+
+## Solution
+
+1. Choose the email address for the new instance administrator.
+2. Set [`APPSMITH_ADMIN_EMAILS`](/getting-started/setup/environment-variables#appsmith_admin_emails) using the platform-specific steps below.
+3. Restart the instance for the change to take effect.
+4. Sign up with a new email or sign in with an existing account using that email address. The user receives the [Instance Administrator](/advanced-concepts/granular-access-control/reference/default-roles#instance-administrator-role) role on startup.
+5. Open **Admin Settings** to verify access and manage other administrators.
+
+:::info
+If signup is disabled, ensure [`APPSMITH_SIGNUP_DISABLED`](/getting-started/setup/environment-variables#appsmith_signup_disabled) allows the new administrator to register, or use an email address that already has an account on the instance.
+:::
+
+:::info
+If the instance uses SSO-only login, re-enable form login before signing up. See [Locked out after misconfiguring or disconnecting SSO](/help-and-support/troubleshooting-guide/sso-authentication-errors#locked-out-after-misconfiguring-or-disconnecting-sso).
+:::
+
+<Tabs groupId="appsmithplatforms" queryString="current-platform">
+
+<TabItem label="Docker" value="docker">
+
+1. Navigate to your installation folder.
+2. Open the `stacks/configuration/docker.env` file.
+3. Add or update the environment variable:
+
+    ```bash
+    APPSMITH_ADMIN_EMAILS=your-admin@example.com
+    ```
+
+    To assign more than one instance administrator, separate email addresses with commas.
+
+4. Restart the Docker containers for the changes to take effect:
+
+    ```bash
+    docker-compose restart appsmith
+    ```
+
+</TabItem>
+
+<TabItem label="Helm" value="helm">
+
+1. Open a shell on your Kubernetes client.
+2. Retrieve the current values from your installation and store them in a file:
+
+    ```bash
+    helm get values appsmith -n appsmith -o yaml > values.yaml
+    ```
+
+3. Modify parameters under the `applicationConfig` section in the `values.yaml` file:
+
+    ```yaml
+    applicationConfig:
+      APPSMITH_ADMIN_EMAILS: "your-admin@example.com"
+    ```
+
+    To assign more than one instance administrator, separate email addresses with commas.
+
+4. Apply the updated values:
+
+    ```bash
+    helm upgrade appsmith appsmith-ee/appsmith -f values.yaml -n appsmith
+    ```
+
+</TabItem>
+
+<TabItem label="AWS ECS" value="aws-ecs">
+
+1. Open the AWS ECS console.
+2. Select **Task Definitions** and choose the relevant task definition.
+3. Click **Create new revision**.
+4. In the **Task Definition config** page, edit the Appsmith container.
+5. Under **Environment**, add or update the environment variable:
+
+    - Key: `APPSMITH_ADMIN_EMAILS`
+    - Value: `your-admin@example.com` (comma-separated for multiple administrators)
+
+    <ZoomImage src="/img/ecs-task-env_(1).png" alt="ECS environment configuration example" />
+
+6. Click **Update**, then **Create** to generate a new task definition.
+7. In the ECS console, navigate to your cluster and select the service.
+8. Update the service to use the latest task definition revision.
+9. Review and confirm the update.
+
+    <ZoomImage src="/img/instance-configuration-ecs-service-restart.png" alt="ECS service restart example" />
+
+The new ECS task should be running within a minute.
+
+</TabItem>
+
+</Tabs>
+
+## See also
+
+* [Configure Environment Variables](/getting-started/setup/instance-configuration/configure-using-environment-variables)
+* [Environment Variables — APPSMITH_ADMIN_EMAILS](/getting-started/setup/environment-variables#appsmith_admin_emails)
+* [Instance Administrator role](/advanced-concepts/granular-access-control/reference/default-roles#instance-administrator-role)

--- a/website/docs/help-and-support/troubleshooting-guide/deployment-errors.mdx
+++ b/website/docs/help-and-support/troubleshooting-guide/deployment-errors.mdx
@@ -157,6 +157,7 @@ Once you have the logs from your container, you can verify whether the error you
 - [MongoDb Startup Error](/help-and-support/troubleshooting-guide/deployment-error-guides/mongodb-startup-error-postv5)
 - [MongoDb Schema Error](/help-and-support/troubleshooting-guide/deployment-error-guides/schema-mismatch-error)
 - [K8s Helm 3.0.4 Error](/help-and-support/troubleshooting-guide/deployment-error-guides/k8s-helm3.0.4-upgrade-error)
+- [Unknown Admin Email Recovery](/help-and-support/troubleshooting-guide/deployment-error-guides/unknown-admin-email-recovery)
 
 ## Getting help
 

--- a/website/docs/help-and-support/troubleshooting-guide/license-and-activation-errors.md
+++ b/website/docs/help-and-support/troubleshooting-guide/license-and-activation-errors.md
@@ -39,7 +39,7 @@ The license and other admin settings are only visible to users with instance adm
 
 #### Solution
 
-- Add your email to the [`APPSMITH_ADMIN_EMAILS`](/getting-started/setup/environment-variables#appsmith_admin_emails) environment variable and restart Appsmith for the change to take effect.
+- Follow [Recover admin access when you don't know the admin email](/help-and-support/troubleshooting-guide/deployment-error-guides/unknown-admin-email-recovery) to grant yourself instance administrator access.
 - Sign in with that admin user, then go to **Admin Settings** → **License & Plans** to enter or update the license key.
 - Alternatively, an existing instance admin can grant you admin rights by adding your email to the Admin users list in **Admin Settings**.
 
@@ -57,7 +57,7 @@ After a renewal, payment, or backend fix, the updated license status can take ti
 
 - After a confirmed renewal/payment, restart your instance and confirm whether the issue clears.
 - The notification can take up to a couple of hours to disappear on its own. To apply it immediately, go to **Admin Settings** → **License & Plans** and click the **Refresh** button next to the license key.
-- If the instance has no admin user with form login, add one via [`APPSMITH_ADMIN_EMAILS`](/getting-started/setup/environment-variables#appsmith_admin_emails) and restart, then sign up with that user and refresh the license from the **License & Plans** tab.
+- If the instance has no admin user with form login, follow [Recover admin access when you don't know the admin email](/help-and-support/troubleshooting-guide/deployment-error-guides/unknown-admin-email-recovery), then refresh the license from the **License & Plans** tab.
 - If the status still does not update after these steps, contact support. The renewal may need a backend correction on the customer portal before it can be refreshed on your instance.
 
 ### Payment overdue notification while the license is still valid

--- a/website/docs/help-and-support/troubleshooting-guide/sso-authentication-errors.md
+++ b/website/docs/help-and-support/troubleshooting-guide/sso-authentication-errors.md
@@ -14,8 +14,7 @@ To regain admin access, re-enable form login and sign up with a new admin accoun
 
 - Re-enable form login on the running instance with `appsmithctl enable-form-login`, or toggle **Form Login** under **Admin Settings → User Management** if you still have admin access. See [User Management](/getting-started/setup/instance-configuration/user-management#authentication).
 - Ensure signup is not restricted (check [`APPSMITH_SIGNUP_DISABLED`](/getting-started/setup/environment-variables#appsmith_signup_disabled)).
-- Add a new email to the [`APPSMITH_ADMIN_EMAILS`](/getting-started/setup/environment-variables#appsmith_admin_emails) line of your `docker.env` file (or `values.yaml` for Kubernetes).
-- Restart the server and sign up with the new email.
+- Follow [Recover admin access when you don't know the admin email](/help-and-support/troubleshooting-guide/deployment-error-guides/unknown-admin-email-recovery) to add a new instance administrator.
 - Once logged in, open **Admin Settings** to reconfigure SSO or update the provider's client secret.
 
 ### Users locked out after disconnecting OIDC SSO
@@ -99,7 +98,7 @@ The SSO login button can disappear if the SSO configuration was lost (see the re
 
 #### Solution
 
-- Regain access by adding a new email to [`APPSMITH_ADMIN_EMAILS`](/getting-started/setup/environment-variables#appsmith_admin_emails), restarting the server, and signing up with that email.
+- Regain access by following [Recover admin access when you don't know the admin email](/help-and-support/troubleshooting-guide/deployment-error-guides/unknown-admin-email-recovery).
 - In **Admin Settings**, if SSO shows unavailable, click the **Refresh** button next to your license key.
 - Confirm you are running the Enterprise Edition image (`appsmith/appsmith-ee`), since SSO (OIDC and SAML) is an Enterprise feature.
 

--- a/website/docs/help-and-support/troubleshooting-guide/user-management-errors.md
+++ b/website/docs/help-and-support/troubleshooting-guide/user-management-errors.md
@@ -116,5 +116,4 @@ When the only user with instance-admin access leaves, no one can reach Admin Set
 
 #### Solution
 
-- Add the new administrator's email to the [`APPSMITH_ADMIN_EMAILS`](/getting-started/setup/environment-variables#appsmith_admin_emails) environment variable in your `docker.env` (Docker) or `values.yaml` (Kubernetes) file.
-- Restart the instance. The new admin can then log in and access Admin Settings.
+- Follow [Recover admin access when you don't know the admin email](/help-and-support/troubleshooting-guide/deployment-error-guides/unknown-admin-email-recovery).

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -908,6 +908,7 @@ const sidebars = {
             "help-and-support/troubleshooting-guide/deployment-error-guides/mongodb-startup-error-postv5",
             "help-and-support/troubleshooting-guide/deployment-error-guides/schema-mismatch-error",
             "help-and-support/troubleshooting-guide/deployment-error-guides/k8s-helm3.0.4-upgrade-error",
+            "help-and-support/troubleshooting-guide/deployment-error-guides/unknown-admin-email-recovery",
             "help-and-support/troubleshooting-guide/backup-restore-errors",
             "help-and-support/troubleshooting-guide/license-and-activation-errors",
             "help-and-support/troubleshooting-guide/sso-authentication-errors",


### PR DESCRIPTION
## Description 

Provide a concise summary of the changes made in this pull request
- Add a deployment error guide for recovering instance administrator access when the admin email is unknown, with Docker, Helm, and AWS ECS steps for `APPSMITH_ADMIN_EMAILS`.
- Register the page in the sidebar and link to it from deployment-errors and related troubleshooting pages.

## Pull request type

Check the appropriate box:

- [ ] Review Fixes
- [ ] Documentation Overhaul
- [ ] Feature/Story
    - Link one or more Engineering Tickets
        * 
- [ ] A-Force
- [x] Error in documentation
- [ ] Maintenance

## Documentation tickets

 Link to one or more documentation tickets:
 - 

## Checklist

From the below options, select the ones that are applicable:

- [ ] Checked for Grammarly suggestions.
- [ ] Adhered to the writing checklist.
- [ ] Adhered to the media checklist.
- [x] Verified and updated cross-references or added redirect rules.
- [ ] Tested the redirect rules on deploy preview.
- [ ] Validated the modifications made to the content on the deploy preview.
- [ ] Validated the CSS modifications on different screen sizes.

Made with [Cursor](https://cursor.com)