### PR TITLE
docs: replace Appsmith AI reference with migration guide (deprecated Sept 30, 2026)

### DIFF
--- a/website/docs/connect-data/reference/appsmith-ai.md
+++ b/website/docs/connect-data/reference/appsmith-ai.md
@@ -5,7 +5,7 @@ description: Appsmith AI is deprecated. This page shows how to migrate your Apps
 # Migrate from Appsmith AI
 
 :::caution Deprecated
-Appsmith AI is deprecated and stops working on **September 30, 2026**. Creating new Appsmith AI datasources is no longer possible. Existing datasources and queries continue to work until that date; files uploaded for context are not available afterwards.
+Appsmith AI is deprecated and stops working on **September 30, 2026**. Creating new Appsmith AI datasources, or new queries on existing ones, is no longer possible. Existing queries continue to work until that date; files uploaded for context are not available afterwards.
 :::
 
 This page shows how to move your existing Appsmith AI queries to the [OpenAI](/connect-data/reference/open-ai), [Anthropic](/connect-data/reference/anthropic), or [Google AI](/connect-data/reference/google-ai) datasources using your own API key.

--- a/website/docs/connect-data/reference/appsmith-ai.md
+++ b/website/docs/connect-data/reference/appsmith-ai.md
@@ -1,359 +1,85 @@
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+---
+description: Appsmith AI is deprecated. This page shows how to migrate your Appsmith AI queries to the OpenAI, Anthropic, or Google AI datasources using your own API key.
+---
 
-# Appsmith AI
+# Migrate from Appsmith AI
 
-This page provides information on creating queries with Appsmith AI, which allows you to configure applications with advanced AI features such as text generation, image classification, and sentiment analysis without the need for any API keys or datasource authentication.
-
-:::note Data, Privacy and Security
-Appsmith is committed to providing safe and responsible access to AI capabilities. Your prompts, outputs, embeddings, and data are not shared with other users and are never utilized to fine-tune models. 
+:::caution Deprecated
+Appsmith AI is deprecated and stops working on **September 30, 2026**. Creating new Appsmith AI datasources is no longer possible. Existing datasources and queries continue to work until that date; files uploaded for context are not available afterwards.
 :::
 
+This page shows how to move your existing Appsmith AI queries to the [OpenAI](/connect-data/reference/open-ai), [Anthropic](/connect-data/reference/anthropic), or [Google AI](/connect-data/reference/google-ai) datasources using your own API key.
 
-## Connect Appsmith AI
+## Prerequisites
 
-<ZoomImage
-  src="/img/-appsmith-ai-home.png" 
-  alt="Appsmith AI"
-  caption="Appsmith AI query"
-/>
+- An API key from the provider you want to use:
+  - [OpenAI API keys](https://platform.openai.com/api-keys)
+  - [Anthropic API keys](https://console.anthropic.com/settings/keys)
+  - [Google AI Studio API keys](https://aistudio.google.com/apikey)
+- A list of the queries in your app that use an Appsmith AI datasource. Each query uses one of the seven commands covered below.
 
+:::note
+With your own API key, the provider bills you directly for token usage. Appsmith does not proxy or pay for these requests.
+:::
 
+## Create the new datasource
 
-### Connection parameters
+1. Click the (**+**) sign in the **Datasources** pane.
+2. Under **AI Integrations**, select **OpenAI**, **Anthropic**, or **Google AI**.
+3. Enter your API key and save the datasource.
 
-The following section is a reference guide that provides a complete description of all the parameters to connect to the datasource.
+## Recreate each query
 
+Every Appsmith AI command maps to a command on the new datasource. The Appsmith AI commands were purpose-built prompts over a large language model, so migrating a query mostly means moving your input into a prompt.
 
-#### Files
+| Appsmith AI command | OpenAI | Anthropic | Google AI |
+|---|---|---|---|
+| Generate text | Chat | Chat | Generate Content |
+| Summarise text | Chat | Chat | Generate Content |
+| Classify text | Chat | Chat | Generate Content |
+| Extract entities from text | Chat | Chat | Generate Content |
+| Describe Image | Vision | Vision | Generate Content |
+| Classify Image | Vision | Vision | Generate Content |
+| Extract entities from image | Vision | Vision | Generate Content |
 
-<dd>
+### Generate text
 
+Move your **Prompt** into the message of the new Chat or Generate Content query. If you used standing instructions (tone, role, output format), put them in a system message.
 
-You have the option to enhance [text generation](#generate-text) by uploading specific files for context. The maximum allowable file size is 20 MB; compress your file if the size exceeds 20 MB.
+### Summarise, classify, and extract entities from text
 
-Submission of files is not mandatory, and you can use Appsmith AI without uploading any files.
+These commands wrapped your input in a task-specific prompt. Recreate the task as an explicit instruction in a Chat or Generate Content query:
 
+- **Summarise text:** `Summarise the following text in about 5 sentences: {{Input1.text}}`
+- **Classify text:** `Classify the following text into exactly one of these labels: Urgent, High priority, Low priority. Respond with only the label. Text: {{Input1.text}}`
+- **Extract entities from text:** `Extract the following entities from the text: Name, Email, Address. Respond as JSON with one key per entity. If an entity is not found, use "Not found". Text: {{Input1.text}}`
 
-For example, if you are working on a loan approval application and want to upload an SOP for insights into user preferences and financial details, the system uses the provided information to generate tailored recommendations and guidance.
+Anything you had in **Additional Instructions** can be appended to the prompt. For classification and extraction, instructing the model to respond with only the label or only JSON keeps widget bindings simple.
 
+### Image commands
 
-</dd>
+Use the **Vision** command (OpenAI, Anthropic) or **Generate Content** with an image (Google AI). Pass the image as a URL or base64 string, the same formats Appsmith AI accepted, together with an instruction:
 
+- **Describe Image:** `Describe this image.`
+- **Classify Image:** `Classify this image into exactly one of: Jacket, Shirt, Pant, T-Shirt. Respond with only the label.`
+- **Extract entities from image:** `Extract the following from this image: name, date of birth, license number. Respond as JSON.`
 
-## Query Appsmith AI
+## Update widget bindings
 
+The response structure differs between providers and from Appsmith AI. After recreating a query, run it once and re-bind your widgets to the new response structure. See the response details in the [OpenAI](/connect-data/reference/open-ai), [Anthropic](/connect-data/reference/anthropic), and [Google AI](/connect-data/reference/google-ai) references.
 
-The following section is a reference guide that provides a description of the available commands with their parameters to create Appsmith AI queries.
+## Migrate file context
 
+Appsmith AI's **Generate text** command could answer questions using files uploaded to the datasource (file context). Uploaded files and their indexes are not migrated and are **not available after September 30, 2026**. There is no drop-in replacement; choose the option that fits your data size:
 
-### Generate text 
+- **Small documents:** include the document text directly in the prompt of a Chat or Generate Content query.
+- **Larger document sets:** build a retrieval flow. For example, generate embeddings with the OpenAI datasource's **Embeddings** command, store them in a vector-capable database such as [PostgreSQL](/connect-data/reference/querying-postgres) with pgvector, and pass the retrieved passages into your prompt.
+- **Provider-hosted retrieval:** upload documents to your provider's own file or retrieval tooling and call it with the [REST API datasource](/connect-data/reference/authenticated-api).
 
+:::caution
+If you rely on file context, download your original files and migrate before the shutdown date while they are still accessible.
+:::
 
+## Clean up
 
-The Generate Text action allows you to generate text based on specific prompts.
-
-<ZoomImage
-  src="/img/appsmith-ai-loan-example.png" 
-  alt="Appsmith AI"
-  caption="Generate text query"
-/>
-
-
-
-
-<dd>
-
-#### Prompt
-
-
-This field allows you to input prompts for text generation. You can also add data from queries or JSObjects using mustache bindings `{{}}`, like `{{user_Input.text}}`.
-
-
-*Example*:
-
-<Tabs>
-  <TabItem value="apple" label="With file as context" default>
-    
-    ```
-  You are helpful assistant who can help loan agents with loan approval or rejection recommendations. Analyse the loan details and generate a recommendation based on the SOP document that you have access to. 
-
-  Loan details: 
-  Credit score: `{{tbl_users.selectedRow.creditscore}}`
-  DTI Ratio: `{{tbl_users.selectedRow.dtiratio}}`
-
-  Your response should contain a recommendation followed by a list of all reasons. The format should be: 
-  Recommendation: `<your recommendation. Possible values: (Approve/Conditional Approve/Reject)>`
-  Reasons: `<your reasons>`
-    ```
-
-  </TabItem>
-  <TabItem value="orange" label="Without File">
-    ```
-    Write a creative product description for an electric car named RevaX, with the keywords- fast charging, 200 miles per single charge, compact, eco-friendly, economical. This is targeted towards a climate concious tech/EV enthusiast who enjoys driving. Also describe the benefits of this product in less than 80 words.
-    ```
-  </TabItem>
-</Tabs>
-
-
-
-
-
-</dd>
-
-<dd>
-
-#### Use context from files
-
-Enhance the quality of AI responses by selecting relevant files that provide context. 
-
-Upload your files through the [datasource](#files) to enable the system to better understand and generate more accurate and context-aware responses.
-
-</dd>
-
-### Classify text
-
-
-
-This action allows you to analyze and categorize text based on its content. You can gain insights into the nature of the provided text, making it a valuable for text classification tasks in your applications.
-
-
-
-<dd>
-
-#### Input
-
-
-
-This field enables you to input prompts for text classification. You can provide either a simple text or an array of text, such as chat details, for classification. Additionally, you can add data from queries or JSObjects using mustache bindings `{{}}`.
-
-For example, you can input a user's product review, like:
-
-"Received my laptop stand from Macazon after a significant delay in delivery, which was a bit disappointing. Upon unboxing, I noticed the build seemed sturdy, but unfortunately, the stand doesn't function as expected. It's supposed to be adjustable, but the mechanism is quite stiff, making it challenging to change angles or heights."
-
-</dd>
-
-<dd>
-
-#### Labels
-
-
-
-Labels refer to predefined categories or classes assigned to the analyzed text. These labels are essential for organizing and identifying the nature of the text content. 
-
-For example, if you are classifying product reviews, labels could include categories such as "Urgent," "High priority," or "Low."
-
-</dd>
-
-<dd>
-
-#### Additional Instructions
-
-
-This property allows you to provide additional instructions to fine-tune the text classification process. You can use this field to offer specific guidance or adjustments to the AI.
-
-For example, you can use the following label descriptions:
-
-* Urgent: Issues that prevent a customer from using the product.
-* High priority: Issues that are impactful but still allow the product to be usable.
-* Low priority: Issues that, while present, can be lived with.
-
-
-
-
-</dd>
-
-
-### Summarise text
-
-
-
-This action condenses and distills lengthy pieces of text into concise summaries, providing a quick overview of the main points or key information. This feature is particularly useful for extracting essential details from large bodies of text, making it easier to comprehend and work with voluminous content.
-
-
-<dd>
-
-#### Input
-
-
-
-This field allows you to provide input for text summarization.  For instance, you can input text from a support conversation or any other lengthy content that you want to condense into a concise summary. 
-
-</dd>
-
-<dd>
-
-#### Additional Instructions
-
-
-
-This property allows you to provide additional instructions to fine-tune the text summarization process. You can use this field to offer specific guidance or adjustments to the AI.
-
-
-For example, if the summary appears either too brief or detailed, customize the summarization length with the instruction: "Summarize the content in approximately 5 sentences."
-
-
-
-</dd>
-
-
-### Extract entities from text
-
-
-This action allows you to identify and extract specific pieces of information, such as names, addresses, and other entities, from a given text. 
-
-
-<dd>
-
-#### Input
-
-
-
-This field allows you to provide text from which you want to extract entities. For example, you can pass a user's email content to extract information such as name, email, address, and other relevant details.
-
-</dd>
-
-
-
-<dd>
-
-#### Entities
-
-
-
-Entities are specific pieces of information that you want to extract from the provided input text. In this field, you should provide a comma-separated list of the entities you want to extract. 
-
-For example, if you are extracting information, your list might include entities like "Name," "Email," and "Address". 
-
-</dd>
-
-<dd>
-
-#### Additional Instructions
-
-
-
-This property allows you to provide additional instructions to fine-tune the entity extraction process. You can use this field to offer specific guidance or adjustments to the AI.
-
-For example, you can instruct the model that "If you’re unable to extract an entity, respond with "Not found".
-
-</dd>
-
-
-### Classify Image
-
-
- 
-This action is designed to analyze and categorize the content of an image, automatically assigning labels or categories to images.
-
-
-
-<dd>
-
-#### Input
-
-
-
-This field allows you to provide the image, either in the form of an image URL or as a base64 encoded image. If you want to upload an image from a Filepicker, you can use `{{upload_FilePicker.files[0]}}`.
-
-
-
-
-</dd>
-
-<dd>
-
-#### Labels
-
-
-
-In this field, provide a comma-separated list of labels to classify the input image. These labels serve as the identified categories or characteristics that the AI system uses to categorize and classify the content of the provided image.
-
-For example, you can add product categories such as Jacket, Shirt, Pant, T-Shirt, Shorts, Dress, Skirt in this field. 
-</dd>
-
-<dd>
-
-#### Additional Instructions
-
-
-
-This property allows you to provide additional instructions to fine-tune the classification process. You can use this field to offer specific guidance or adjustments to the AI.
-
-For example, you can instruct the model to "Identify the category of clothing. Apply only one category.".
-
-</dd>
-
-### Describe Image
-
-
- 
-This action generates textual information about an image, producing a descriptive summary of the visual content captured within the image.
-
-
-
-<dd>
-
-#### Input
-
-
-
-This field allows you to provide the image, either in the form of an image URL or as a base64 encoded image. If you want to upload an image from a Filepicker, you can use `{{upload_FilePicker.files[0]}}`.
-
-
-
-
-</dd>
-
-<dd>
-
-#### Additional Instructions
-
-
-
-This property allows you to provide additional instructions to fine-tune the caption. You can use this field to offer specific guidance or adjustments to the AI.
-
-For example, you can instruct the model to "Write a 200 word product description".
-
-</dd>
-
-### Extract entities from image
-
-
- 
-This action involves the identification and extraction of specific pieces of information or entities from an image. This feature uses advanced image processing techniques to recognize and retrieve relevant data points, such as text, objects, or other elements, from the visual content captured in the image. 
-
-
-<dd>
-
-#### Input
-
- 
-This field allows you to provide the image, either in the form of an image URL or as a base64 encoded image. If you want to upload an image from a Filepicker, you can use `{{upload_FilePicker.files[0]}}`.
-
-</dd>
-
-<dd>
-
-#### Entities
-
-
-
-Entities are specific pieces of information or features within the visual content of the image that you want to identify and retrieve. Entities could include text, objects, landmarks, or any other distinct elements present in the image.
-
-For example, if you want to extract details from an ID card, you can specify entities such as name, date of birth, gender, license number, and height.
-
-</dd>
-
-<dd>
-
-#### Additional Instructions
-
-
-
-This property allows you to provide additional instructions to fine-tune the entity extraction. You can use this field to offer specific guidance or adjustments to the AI.
-
-For example, you can instruct the model that "The date should be in dd/mm/yyyy format".
-
-
-</dd>
+Once all queries in an app are migrated and verified, delete the old Appsmith AI queries and datasource.


### PR DESCRIPTION
## Description

Provide a concise summary of the changes made in this pull request
- Replace the Appsmith AI reference page (`/connect-data/reference/appsmith-ai`) with a **Migrate from Appsmith AI** guide at the same URL. Appsmith AI is deprecated and stops working on **September 30, 2026**; new datasource creation is blocked by appsmithorg/appsmith#42015, and the in-product deprecation banner links to this URL.
- The guide covers: a deprecation notice with the shutdown date, command-by-command mapping of all seven Appsmith AI commands to the OpenAI / Anthropic / Google AI datasources (BYOK), prompt examples for the wrapped commands (summarise/classify/extract), re-binding widgets to new response shapes, and alternatives for file context, which has no drop-in replacement after shutdown.
- Keeping the same URL means no redirect rules are needed and the shipped in-product link resolves to migration guidance.

## Pull request type

Check the appropriate box:

- [ ] Review Fixes
- [ ] Documentation Overhaul
- [x] Feature/Story
    - Link one or more Engineering Tickets
        * appsmithorg/appsmith#9316
        * appsmithorg/appsmith#42015
- [ ] A-Force
- [ ] Error in documentation
- [ ] Maintenance

## Documentation tickets

 Link to one or more documentation tickets:
 - N/A (docs follow-up tracked in appsmithorg/appsmith#42015)

## Checklist

From the below options, select the ones that are applicable:

- [ ] Checked for Grammarly suggestions.
- [ ] Adhered to the writing checklist.
- [ ] Adhered to the media checklist.
- [x] Verified and updated cross-references or added redirect rules.
- [ ] Tested the redirect rules on deploy preview.
- [ ] Validated the modifications made to the content on the deploy preview.
- [ ] Validated the CSS modifications on different screen sizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfztenqynzJcU2DZJD6nR5
