### PR TITLE
docs: sync Button widget properties and add related cross-links

### DIFF
--- a/website/docs/reference/widgets/button/README.md
+++ b/website/docs/reference/widgets/button/README.md
@@ -96,7 +96,7 @@ Sets the Google reCAPTCHA version to use for the button, either v2 or v3.
 
 Buttons can have some special behaviors when they're located within the boundaries of a [Form widget](/reference/widgets/form). Its form-specific behavior is controlled by two of the button's properties:
 
-#### Disabled invalid forms 
+#### Disable when form is invalid
 
 <dd>
 
@@ -174,6 +174,32 @@ This property can be dynamically set using JavaScript by providing a string valu
 
 </dd>
 
+### Label styles
+
+#### Font color `string`
+
+<dd>
+
+Sets the text color of the button label. Additionally, you can programmatically modify the text color using JavaScript functions.
+
+</dd>
+
+#### Font size `string`
+
+<dd>
+
+Controls the font size of the button label. Additionally, you can programmatically modify the text size using JavaScript functions.
+
+</dd>
+
+#### Emphasis `string`
+
+<dd>
+
+Allows you to choose a font style for the button label, such as bold or italic. Additionally, you can programmatically modify the font style using JavaScript functions.
+
+</dd>
+
 ### Color
 
 #### Button color `string`
@@ -204,11 +230,9 @@ This property adds a drop shadow effect to the frame of the widget. If JavaScrip
 
 </dd>
 
+## Reference properties
 
-
-### Reference properties
-
-Reference properties enable you to access the widget's data and state using the dot operator in other widgets or JavaScript functions. They provide additional information or allow interaction with the widget programmatically. For instance, to retrieve the visibility status of a  button widget, you can use `Button1.isVisible`.
+Reference properties enable you to access the widget's data and state using the dot operator in other widgets or JavaScript functions. They provide additional information or allow interaction with the widget programmatically. For instance, to retrieve the visibility status of a button widget, you can use `Button1.isVisible`.
 
 #### text `string`
 
@@ -248,7 +272,6 @@ It reflects the state of the widget's **Disabled** setting. It is represented by
 
 </dd>
 
-
 ## Methods
 
 Widget property setters enable you to modify the values of widget properties at runtime, eliminating the need to manually update properties in the editor.
@@ -265,7 +288,7 @@ Sets the visibility of the widget.
 *Example*:
 
 ```js
-Button1..setVisibility(true)
+Button1.setVisibility(true)
 
 ```
 

--- a/website/docs/reference/widgets/button/google-recaptcha.md
+++ b/website/docs/reference/widgets/button/google-recaptcha.md
@@ -28,7 +28,7 @@ description: >-
 The exact steps depend on your backend - see [Google's reference](https://developers.google.com/recaptcha/docs/verify) for detailed instructions.
 :::
 
-The user's reCAPTCHA response can be obtained in the API Pane with the `recaptchaToken` key.
+The user's reCAPTCHA response can be obtained in the API Pane with the `recaptchaToken` key. See the Button widget [Validation](/reference/widgets/button#validation) properties for configuring Google reCAPTCHA on a button.
 
 Make a `POST` request to `https://www.google.com/recaptcha/api/siteverify` with the `secret` (secret key) and `response` (user response) parameters to retrieve the score in a JSON format:
 

--- a/website/docs/reference/widgets/form.md
+++ b/website/docs/reference/widgets/form.md
@@ -2,7 +2,7 @@
 
 This page provides information on how to use the Form widget to collect, validate, and submit user input. It acts as a container for grouping related inputs and comes with a default Text widget for the title, as well as Submit and Reset buttons for form interaction. 
 
-The Reset button allows for one-click clearing of form fields to default values. Similarly, the Success button allows you to set actions to be performed when the submit button is clicked. 
+The Reset button allows for one-click clearing of form fields to default values. Similarly, the Success button allows you to set actions to be performed when the submit button is clicked. These behaviors are controlled by the Button widget's [Form settings](/reference/widgets/button#form-settings), including **Disable when form is invalid** and **Reset form on success**. 
 
 <VideoEmbed host="youtube" videoId="UgpQ0ZOnzdg" title="How to use Form Widget" caption="How to use Form Widget"/>
 


### PR DESCRIPTION
## Description 

- Sync the Button widget reference with the product: add missing **Label styles** (Font color, Font size, Emphasis), rename **Disabled invalid forms** to **Disable when form is invalid**, and fix the Reference properties section heading plus a `setVisibility` typo.
- Add cross-links from the Form widget to Button Form settings, and from the Google reCAPTCHA guide to Button Validation properties.

## Pull request type

- [ ] Review Fixes
- [ ] Documentation Overhaul
- [x] Feature/Story
    - https://github.com/appsmithorg/appsmith/pull/41998 (fixes https://github.com/appsmithorg/appsmith/issues/15065)
- [ ] A-Force
- [ ] Error in documentation
- [ ] Maintenance

## Documentation tickets

## Checklist

- [ ] Checked for Grammarly suggestions.
- [ ] Adhered to the writing checklist.
- [ ] Adhered to the media checklist.
- [x] Verified and updated cross-references or added redirect rules.
- [x] Tested the redirect rules on deploy preview.
- [x] Validated the modifications made to the content on the deploy preview.
- [ ] Validated the CSS modifications on different screen sizes.
