### PR TITLE
fix: replace stale managed vector store files

### DIFF
--- a/.github/scripts/cleanup-openai-vector-store.sh
+++ b/.github/scripts/cleanup-openai-vector-store.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${OPENAI_API_KEY:?OPENAI_API_KEY is required}"
+: "${VECTOR_STORE_ID:?VECTOR_STORE_ID is required}"
+: "${FILE_ID:?FILE_ID is required}"
+
+readonly OPENAI_API_BASE_URL="${OPENAI_API_BASE_URL:-https://api.openai.com/v1}"
+readonly MANAGED_BY_VALUE="generate-file-for-ai"
+readonly MAX_LIST_PAGES="${VECTOR_STORE_MAX_LIST_PAGES:-1000}"
+readonly VERIFY_MAX_ATTEMPTS="${VECTOR_STORE_VERIFY_MAX_ATTEMPTS:-6}"
+readonly VERIFY_RETRY_DELAY_SECONDS="${VECTOR_STORE_VERIFY_RETRY_DELAY_SECONDS:-5}"
+readonly CURL_CONNECT_TIMEOUT_SECONDS="${OPENAI_CURL_CONNECT_TIMEOUT_SECONDS:-10}"
+readonly CURL_MAX_TIME_SECONDS="${OPENAI_CURL_MAX_TIME_SECONDS:-60}"
+
+if ! [[ "$MAX_LIST_PAGES" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ERROR: VECTOR_STORE_MAX_LIST_PAGES must be a positive integer"
+  exit 1
+fi
+
+if ! [[ "$VERIFY_MAX_ATTEMPTS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ERROR: VECTOR_STORE_VERIFY_MAX_ATTEMPTS must be a positive integer"
+  exit 1
+fi
+
+if ! [[ "$VERIFY_RETRY_DELAY_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: VECTOR_STORE_VERIFY_RETRY_DELAY_SECONDS must be a non-negative integer"
+  exit 1
+fi
+
+readonly -a CURL_ARGS=(
+  --fail
+  --silent
+  --show-error
+  --http1.1
+  --connect-timeout "$CURL_CONNECT_TIMEOUT_SECONDS"
+  --max-time "$CURL_MAX_TIME_SECONDS"
+)
+
+declare -a stale_file_ids=()
+
+array_contains() {
+  local needle="$1"
+  local item
+  shift
+
+  for item in "$@"; do
+    if [ "$item" = "$needle" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+api_get() {
+  curl "${CURL_ARGS[@]}" \
+    -H "Authorization: Bearer $OPENAI_API_KEY" \
+    "$1"
+}
+
+api_delete() {
+  curl "${CURL_ARGS[@]}" -X DELETE \
+    -H "Authorization: Bearer $OPENAI_API_KEY" \
+    "$1"
+}
+
+validate_list_response() {
+  local response="$1"
+  local context="$2"
+
+  if ! jq -e '
+    .object == "list" and
+    (.data | type == "array") and
+    (.data | all(
+      .[];
+      (.id | type == "string") and
+      (.id | length > 0) and
+      ((.attributes == null) or (.attributes | type == "object")) and
+      ((.attributes.managed_by == null) or (.attributes.managed_by | type == "string"))
+    )) and
+    (.has_more | type == "boolean") and
+    ((.has_more == false) or ((.last_id | type == "string") and (.last_id | length > 0)))
+  ' > /dev/null <<< "$response"; then
+    echo "ERROR: Invalid vector store $context response"
+    echo "$response"
+    exit 1
+  fi
+}
+
+list_vector_store_pages() {
+  local callback="$1"
+  local context="$2"
+  local after=""
+  local encoded_after
+  local has_more
+  local list_response
+  local list_url
+  local next_after
+  local page_count=0
+  local -a seen_cursors=()
+
+  while true; do
+    page_count=$((page_count + 1))
+    if [ "$page_count" -gt "$MAX_LIST_PAGES" ]; then
+      echo "ERROR: Vector store $context exceeded $MAX_LIST_PAGES pages"
+      exit 1
+    fi
+
+    list_url="$OPENAI_API_BASE_URL/vector_stores/$VECTOR_STORE_ID/files?limit=100"
+    if [ -n "$after" ]; then
+      encoded_after=$(jq -rn --arg value "$after" '$value | @uri')
+      list_url="$list_url&after=$encoded_after"
+    fi
+
+    if ! list_response=$(api_get "$list_url"); then
+      echo "ERROR: Failed to list vector store files during $context"
+      exit 1
+    fi
+    validate_list_response "$list_response" "$context"
+    "$callback" "$list_response"
+
+    has_more=$(jq -r '.has_more' <<< "$list_response")
+    if [ "$has_more" = "false" ]; then
+      return
+    fi
+
+    next_after=$(jq -r '.last_id' <<< "$list_response")
+    if array_contains "$next_after" ${seen_cursors[@]+"${seen_cursors[@]}"}; then
+      echo "ERROR: Vector store $context repeated pagination cursor $next_after"
+      exit 1
+    fi
+
+    seen_cursors+=("$next_after")
+    after="$next_after"
+  done
+}
+
+managed_by_for_file() {
+  local response="$1"
+  local file_id="$2"
+
+  jq -r --arg file_id "$file_id" '
+    .data[] | select(.id == $file_id) | .attributes.managed_by // empty
+  ' <<< "$response"
+}
+
+add_stale_file() {
+  local file_id="$1"
+
+  if array_contains "$file_id" ${stale_file_ids[@]+"${stale_file_ids[@]}"}; then
+    return
+  fi
+
+  stale_file_ids+=("$file_id")
+}
+
+classify_stale_files() {
+  local list_response="$1"
+  local file_id
+  local managed_by
+
+  while IFS= read -r file_id; do
+    if [ "$file_id" = "$FILE_ID" ]; then
+      continue
+    fi
+
+    managed_by=$(managed_by_for_file "$list_response" "$file_id")
+    if [ "$managed_by" = "$MANAGED_BY_VALUE" ]; then
+      echo "Found workflow-managed stale file: $file_id"
+      add_stale_file "$file_id"
+    elif [ -n "$managed_by" ]; then
+      echo "Preserving file $file_id managed by $managed_by"
+    else
+      echo "Preserving unmanaged file $file_id"
+    fi
+  done < <(jq -r '.data[].id' <<< "$list_response")
+}
+
+echo "Finding stale workflow-managed files..."
+list_vector_store_pages classify_stale_files "file discovery"
+
+if [ "${#stale_file_ids[@]}" -eq 0 ]; then
+  echo "No stale workflow-managed files found"
+fi
+
+for stale_file_id in ${stale_file_ids[@]+"${stale_file_ids[@]}"}; do
+  echo "Deleting stale file $stale_file_id..."
+  if ! delete_response=$(api_delete "$OPENAI_API_BASE_URL/files/$stale_file_id"); then
+    echo "ERROR: Request to delete stale file $stale_file_id failed"
+    exit 1
+  fi
+
+  if ! jq -e --arg file_id "$stale_file_id" '
+    .id == $file_id and .deleted == true
+  ' > /dev/null <<< "$delete_response"; then
+    echo "ERROR: Failed to delete stale file $stale_file_id"
+    echo "$delete_response"
+    exit 1
+  fi
+
+  echo "Deleted stale file $stale_file_id"
+done
+
+declare -a unexpected_file_ids=()
+current_file_found=false
+
+verify_vector_store_page() {
+  local list_response="$1"
+  local file_id
+  local managed_by
+
+  while IFS= read -r file_id; do
+    managed_by=$(managed_by_for_file "$list_response" "$file_id")
+
+    if [ "$file_id" = "$FILE_ID" ]; then
+      if [ "$managed_by" != "$MANAGED_BY_VALUE" ]; then
+        echo "ERROR: Current file $FILE_ID is missing its ownership attribute"
+        exit 1
+      fi
+      current_file_found=true
+      continue
+    fi
+
+    if array_contains "$file_id" ${stale_file_ids[@]+"${stale_file_ids[@]}"}; then
+      unexpected_file_ids+=("$file_id")
+      continue
+    fi
+
+    if [ "$managed_by" = "$MANAGED_BY_VALUE" ]; then
+      unexpected_file_ids+=("$file_id")
+    fi
+  done < <(jq -r '.data[].id' <<< "$list_response")
+}
+
+echo "Verifying vector store contents..."
+for ((attempt = 1; attempt <= VERIFY_MAX_ATTEMPTS; attempt++)); do
+  unexpected_file_ids=()
+  current_file_found=false
+
+  list_vector_store_pages verify_vector_store_page "verification"
+
+  if [ "$current_file_found" = "true" ] && [ "${#unexpected_file_ids[@]}" -eq 0 ]; then
+    echo "Vector store contains only the current workflow-managed file and preserved non-workflow files"
+    exit 0
+  fi
+
+  echo "Verification attempt $attempt: current_file_found=$current_file_found, stale_files=${unexpected_file_ids[*]:-none}"
+  if [ "$attempt" -lt "$VERIFY_MAX_ATTEMPTS" ]; then
+    sleep "$VERIFY_RETRY_DELAY_SECONDS"
+  fi
+done
+
+echo "ERROR: Vector store still contains stale workflow-managed files"
+exit 1

--- a/.github/scripts/tests/cleanup-openai-vector-store.test.sh
+++ b/.github/scripts/tests/cleanup-openai-vector-store.test.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly CLEANUP_SCRIPT="$TEST_DIR/../cleanup-openai-vector-store.sh"
+readonly MOCK_BIN_DIR="$TEST_DIR/fixtures"
+readonly TEST_ROOT="$(mktemp -d)"
+
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+run_cleanup() {
+  local scenario="$1"
+  local state_dir="$TEST_ROOT/$scenario"
+  local max_list_pages="1000"
+
+  if [ "$scenario" = "page-limit" ]; then
+    max_list_pages="2"
+  fi
+
+  mkdir -p "$state_dir"
+  env \
+    PATH="$MOCK_BIN_DIR:$PATH" \
+    MOCK_SCENARIO="$scenario" \
+    MOCK_STATE_DIR="$state_dir" \
+    OPENAI_API_KEY="test-key" \
+    VECTOR_STORE_ID="test-vector-store" \
+    FILE_ID="file-current" \
+    VECTOR_STORE_MAX_LIST_PAGES="$max_list_pages" \
+    VECTOR_STORE_VERIFY_RETRY_DELAY_SECONDS="0" \
+    bash "$CLEANUP_SCRIPT"
+}
+
+assert_contains() {
+  local output="$1"
+  local expected="$2"
+
+  if [[ "$output" != *"$expected"* ]]; then
+    echo "Expected output to contain: $expected" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+}
+
+assert_file_exists() {
+  local path="$1"
+
+  if [ ! -f "$path" ]; then
+    echo "Expected file to exist: $path" >&2
+    exit 1
+  fi
+}
+
+assert_file_missing() {
+  local path="$1"
+
+  if [ -e "$path" ]; then
+    echo "Expected file to be absent: $path" >&2
+    exit 1
+  fi
+}
+
+expect_success() {
+  local scenario="$1"
+  local output
+
+  if ! output=$(run_cleanup "$scenario" 2>&1); then
+    echo "Expected scenario '$scenario' to succeed" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+  printf '%s' "$output"
+}
+
+expect_failure() {
+  local scenario="$1"
+  local expected="$2"
+  local output
+
+  if output=$(run_cleanup "$scenario" 2>&1); then
+    echo "Expected scenario '$scenario' to fail" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+  assert_contains "$output" "$expected"
+}
+
+success_output=$(expect_success success)
+assert_contains "$success_output" "Verification attempt 1"
+assert_contains "$success_output" "Vector store contains only the current workflow-managed file and preserved non-workflow files"
+assert_file_exists "$TEST_ROOT/success/deleted-file-tagged-old"
+assert_file_exists "$TEST_ROOT/success/deleted-file-renamed-old"
+assert_file_missing "$TEST_ROOT/success/deleted-file-untagged-appsmith-docs"
+assert_file_missing "$TEST_ROOT/success/deleted-file-unrelated"
+echo "PASS: paginated cleanup preserves unmanaged files and tolerates delayed removal"
+
+no_stale_output=$(expect_success no-stale)
+assert_contains "$no_stale_output" "No stale workflow-managed files found"
+echo "PASS: no-op cleanup"
+
+expect_failure delete-failure "Failed to delete stale file file-tagged-old"
+echo "PASS: unsuccessful deletion is rejected"
+
+expect_failure repeated-cursor "repeated pagination cursor repeated-cursor"
+echo "PASS: repeated pagination cursor is rejected"
+
+expect_failure page-limit "exceeded 2 pages"
+echo "PASS: pagination page limit is enforced"
+
+expect_failure invalid-list "Invalid vector store file discovery response"
+echo "PASS: malformed list response is rejected"
+
+echo "6 cleanup tests passed"

--- a/.github/scripts/tests/fixtures/curl
+++ b/.github/scripts/tests/fixtures/curl
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${MOCK_SCENARIO:?MOCK_SCENARIO is required}"
+: "${MOCK_STATE_DIR:?MOCK_STATE_DIR is required}"
+
+url="${!#}"
+method="GET"
+connect_timeout_seen=false
+max_time_seen=false
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --connect-timeout)
+      shift
+      [ "${1:-}" = "10" ] || { echo "Unexpected connect timeout" >&2; exit 2; }
+      connect_timeout_seen=true
+      ;;
+    --max-time)
+      shift
+      [ "${1:-}" = "60" ] || { echo "Unexpected maximum time" >&2; exit 2; }
+      max_time_seen=true
+      ;;
+    -X)
+      shift
+      method="${1:-}"
+      ;;
+  esac
+  shift
+done
+
+[ "$connect_timeout_seen" = "true" ] || { echo "Missing connect timeout" >&2; exit 2; }
+[ "$max_time_seen" = "true" ] || { echo "Missing maximum time" >&2; exit 2; }
+
+all_stale_files_deleted() {
+  [ -f "$MOCK_STATE_DIR/deleted-file-tagged-old" ] &&
+    [ -f "$MOCK_STATE_DIR/deleted-file-renamed-old" ]
+}
+
+success_list_response() {
+  if all_stale_files_deleted; then
+    if [ ! -f "$MOCK_STATE_DIR/first-verification-returned" ]; then
+      touch "$MOCK_STATE_DIR/first-verification-returned"
+      jq -n '{
+        object: "list",
+        data: [
+          {id: "file-current", attributes: {managed_by: "generate-file-for-ai"}},
+          {id: "file-tagged-old", attributes: {managed_by: "generate-file-for-ai"}},
+          {id: "file-untagged-appsmith-docs", attributes: null},
+          {id: "file-unrelated", attributes: {}}
+        ],
+        has_more: false,
+        last_id: "file-unrelated"
+      }'
+    else
+      jq -n '{
+        object: "list",
+        data: [
+          {id: "file-current", attributes: {managed_by: "generate-file-for-ai"}},
+          {id: "file-untagged-appsmith-docs", attributes: null},
+          {id: "file-unrelated", attributes: {}},
+          {id: "file-other-owner", attributes: {managed_by: "manual-upload"}},
+          {id: "file-unrelated-two", attributes: null}
+        ],
+        has_more: false,
+        last_id: "file-unrelated-two"
+      }'
+    fi
+  elif [[ "$url" == *"after=cursor-page-1"* ]]; then
+    jq -n '{
+      object: "list",
+      data: [
+        {id: "file-renamed-old", attributes: {managed_by: "generate-file-for-ai"}},
+        {id: "file-unrelated-two", attributes: null}
+      ],
+      has_more: false,
+      last_id: "file-unrelated-two"
+    }'
+  else
+    jq -n '
+      [range(0; 96) as $index |
+        {id: ("file-manual-" + ($index | tostring)), attributes: {managed_by: "manual-upload"}}
+      ] as $manual_files |
+      {
+        object: "list",
+        data: ([
+          {id: "file-current", attributes: {managed_by: "generate-file-for-ai"}},
+          {id: "file-tagged-old", attributes: {managed_by: "generate-file-for-ai"}},
+          {id: "file-untagged-appsmith-docs", attributes: null},
+          {id: "file-unrelated", attributes: {}}
+        ] + $manual_files),
+        has_more: true,
+        last_id: "cursor-page-1"
+      }
+    '
+  fi
+}
+
+if [[ "$url" == *"/vector_stores/test-vector-store/files?"* ]]; then
+  case "$MOCK_SCENARIO" in
+    success)
+      success_list_response
+      ;;
+    no-stale)
+      jq -n '{
+        object: "list",
+        data: [
+          {id: "file-current", attributes: {managed_by: "generate-file-for-ai"}},
+          {id: "file-unrelated", attributes: null}
+        ],
+        has_more: false,
+        last_id: "file-unrelated"
+      }'
+      ;;
+    delete-failure)
+      jq -n '{
+        object: "list",
+        data: [
+          {id: "file-current", attributes: {managed_by: "generate-file-for-ai"}},
+          {id: "file-tagged-old", attributes: {managed_by: "generate-file-for-ai"}}
+        ],
+        has_more: false,
+        last_id: "file-tagged-old"
+      }'
+      ;;
+    repeated-cursor)
+      jq -n '{
+        object: "list",
+        data: [{id: "file-current", attributes: {managed_by: "generate-file-for-ai"}}],
+        has_more: true,
+        last_id: "repeated-cursor"
+      }'
+      ;;
+    page-limit)
+      if [[ "$url" == *"after=page-1"* ]]; then
+        next_cursor="page-2"
+      else
+        next_cursor="page-1"
+      fi
+      jq -n --arg cursor "$next_cursor" '{
+        object: "list",
+        data: [{id: "file-current", attributes: {managed_by: "generate-file-for-ai"}}],
+        has_more: true,
+        last_id: $cursor
+      }'
+      ;;
+    invalid-list)
+      jq -n '{object: "list", data: "invalid", has_more: false}'
+      ;;
+    *)
+      echo "Unknown mock scenario: $MOCK_SCENARIO" >&2
+      exit 2
+      ;;
+  esac
+elif [ "$method" = "GET" ] && [[ "$url" == *"/files/"* ]]; then
+  echo "Unexpected metadata request: ${url##*/}" >&2
+  exit 2
+elif [ "$method" = "DELETE" ] && [[ "$url" == *"/files/"* ]]; then
+  file_id="${url##*/}"
+  case "$file_id" in
+    file-tagged-old|file-renamed-old)
+      if [ "$MOCK_SCENARIO" = "delete-failure" ] && [ "$file_id" = "file-tagged-old" ]; then
+        jq -n --arg id "$file_id" '{id: $id, deleted: false}'
+      else
+        touch "$MOCK_STATE_DIR/deleted-$file_id"
+        jq -n --arg id "$file_id" '{id: $id, deleted: true}'
+      fi
+      ;;
+    *)
+      echo "Unexpected deletion: $file_id" >&2
+      exit 2
+      ;;
+  esac
+else
+  echo "Unexpected request: $method $url" >&2
+  exit 2
+fi

--- a/.github/workflows/generate-file-for-ai.yaml
+++ b/.github/workflows/generate-file-for-ai.yaml
@@ -21,6 +21,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Test vector store cleanup logic
+        timeout-minutes: 2
+        run: bash .github/scripts/tests/cleanup-openai-vector-store.test.sh
+
       - name: Merge markdown files
         run: |
           find website/docs \( -name '*.md' -o -name '*.mdx' \) -exec cat {} + > appsmith-docs.md
@@ -70,7 +74,8 @@ jobs:
           attach_response=$(curl -sS --http1.1 -X POST \
             -H "Authorization: Bearer $OPENAI_API_KEY" \
             -H "Content-Type: application/json" \
-            -d "{\"file_id\":\"$FILE_ID\"}" \
+            -d "$(jq -n --arg file_id "$FILE_ID" \
+              '{file_id: $file_id, attributes: {managed_by: "generate-file-for-ai"}}')" \
             "https://api.openai.com/v1/vector_stores/$VECTOR_STORE_ID/files")
 
           echo "$attach_response"
@@ -112,3 +117,9 @@ jobs:
           echo "ERROR: Timed out waiting for file ingestion"
           exit 1
 
+      - name: Remove stale workflow-managed files
+        timeout-minutes: 15
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          VECTOR_STORE_ID: ${{ secrets.OPENAI_VECTOR_STORE_ID }}
+        run: bash .github/scripts/cleanup-openai-vector-store.sh


### PR DESCRIPTION
## Description

- tag newly attached documentation files with a workflow ownership attribute
- delete older files only when they carry the same workflow ownership attribute
- preserve all unmanaged files and files managed by another source
- wait for successful ingestion before cleanup and verify the resulting store contents
- bound API requests, pagination, verification retries, and cleanup runtime
- add mocked regression coverage that runs before OpenAI mutations

## Test plan

- [x] Validate workflow YAML and step structure
- [x] Validate Bash syntax
- [x] Run six mocked cleanup scenarios covering pagination, delayed removal, unmanaged-file preservation, deletion failure, repeated cursors, page limits, and malformed responses

Result: 6 cleanup tests passed.