### PR TITLE
docs: point ECS health checks at /api/v1/health

### DIFF
--- a/website/docs/getting-started/setup/installation-guides/aws-ecs-on-fargate.md
+++ b/website/docs/getting-started/setup/installation-guides/aws-ecs-on-fargate.md
@@ -123,7 +123,7 @@ Follow these steps to create task and container definitions for your cluster:
     * `APPSMITH_DB_URL` - Enter the URI of the external MongoDB (v5.0 or later) instance.
     * `APPSMITH_ENABLE_EMBEDDED_DB` - `0`. This disables embedded mock databases on EFS volume.
 6. Add the below configuration in the **HealthCheck** section:
-    * **Command** - `CMD-SHELL, curl -f http://localhost/ || exit 1`
+    * **Command** - `CMD-SHELL, curl -f http://localhost/api/v1/health || exit 1`
     * **Interval** - 10
     * **Timeout** - 5
     * **Start period** - 160
@@ -184,7 +184,7 @@ Follow these steps to create and run an ECS service:
         * **Target group** - Select **Create new target group**. 
         * **Target group name** - Give a meaningful and unique name.
         * **Health check protocol** - Set it to `HTTP`.
-        * **Health check path** - Set it to `/`.
+        * **Health check path** - Set it to `/api/v1/health`.
     * Port `443` listener- 
         * **Listener** - Select **Create new listener**.
         * **Port** - `443`
@@ -193,7 +193,7 @@ Follow these steps to create and run an ECS service:
         * **Target group** - Select **Create new target group**. 
         * **Target group name** - Give a meaningful and unique name.
         * **Health check protocol** - Set it to `HTTP`.
-        * **Health check path** - Set it to `/`.
+        * **Health check path** - Set it to `/api/v1/health`.
 
 9.  In the **Service auto scaling** section, add the below details: 
     * **Use service auto scaling** - Check this setting.

--- a/website/docs/getting-started/setup/installation-guides/aws-ecs/aws-ecs-on-ec2.md
+++ b/website/docs/getting-started/setup/installation-guides/aws-ecs/aws-ecs-on-ec2.md
@@ -84,9 +84,9 @@ To deploy Appsmith on the Amazon ECS cluster that has a single node, you need to
         * `APPSMITH_DB_URL` : Enter the URI of the external MongoDB (v5.0 or later) instance.
         * `APPSMITH_ENABLE_EMBEDDED_DB` to `0`. This disables embedded mock databases on EFS volume.
 6. Configure the **HealthCheck** section as shown below: 
-    * **HealthCheck Command** - `CMD-SHELL, curl http://localhost/ || exit 1`
+    * **HealthCheck Command** - `CMD-SHELL, curl -f http://localhost/api/v1/health || exit 1`
     * **Interval** - 10
-    * **Timeout** - 2
+    * **Timeout** - 5
     * **Start period** - 160
     * **Retries** - 3
 7. Keep the default settings for other sections, and scroll down to **Storage**. Click **Add volume** button and configure **Volume-1** as shown below:


### PR DESCRIPTION
## Description

The ECS installation guides (Fargate and EC2) configure both the container-level health check and the ALB target-group health checks against `/`. That path is served by Caddy and returns 200 even when the backend has lost database connectivity, so ECS keeps a degraded task in service.

This changes all five health-check references to `/api/v1/health`, which verifies MongoDB and Redis connectivity, so ECS replaces a task whose DB connection has gone stale. It matches what the troubleshooting guide already recommends for load balancer probes.

EC2 guide additionally:
- `curl` → `curl -f`: without `-f`, curl exits 0 on a 5xx response, so the check could never fail on HTTP errors.
- Health check timeout 2s → 5s, matching the Fargate guide, since the endpoint performs real DB pings.

## Context

Pylon issue 2854: an ECS deployment's Mongo driver held a stale replica-set topology (no primary in the client view) and the task stayed in service until manually restarted, because the `/` health check kept returning 200 throughout the outage.

## Behavior notes

- If the external database is down for an extended period, tasks now restart-loop instead of sitting degraded — intended for this failure class.
- The container check now requires the Java backend to be up; the documented start period (160s) plus retries gives ~190s before a booting task is killed, unchanged from before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)