### PR TITLE
fix: detach stale files from vector store before deleting them

### DIFF
--- a/.github/scripts/cleanup-openai-vector-store.sh
+++ b/.github/scripts/cleanup-openai-vector-store.sh
@@ -184,9 +184,24 @@ if [ "${#stale_file_ids[@]}" -eq 0 ]; then
 fi
 
 for stale_file_id in ${stale_file_ids[@]+"${stale_file_ids[@]}"}; do
+  echo "Detaching stale file $stale_file_id from vector store..."
+  if ! detach_response=$(api_delete "$OPENAI_API_BASE_URL/vector_stores/$VECTOR_STORE_ID/files/$stale_file_id"); then
+    echo "ERROR: Request to detach stale file $stale_file_id failed"
+    exit 1
+  fi
+
+  if ! jq -e --arg file_id "$stale_file_id" '
+    .id == $file_id and .deleted == true
+  ' > /dev/null <<< "$detach_response"; then
+    echo "ERROR: Failed to detach stale file $stale_file_id"
+    echo "$detach_response"
+    exit 1
+  fi
+
   echo "Deleting stale file $stale_file_id..."
   if ! delete_response=$(api_delete "$OPENAI_API_BASE_URL/files/$stale_file_id"); then
     echo "ERROR: Request to delete stale file $stale_file_id failed"
+    echo "ORPHANED FILE $stale_file_id: detached from the vector store but not deleted; delete it manually"
     exit 1
   fi
 
@@ -194,6 +209,7 @@ for stale_file_id in ${stale_file_ids[@]+"${stale_file_ids[@]}"}; do
     .id == $file_id and .deleted == true
   ' > /dev/null <<< "$delete_response"; then
     echo "ERROR: Failed to delete stale file $stale_file_id"
+    echo "ORPHANED FILE $stale_file_id: detached from the vector store but not deleted; delete it manually"
     echo "$delete_response"
     exit 1
   fi

--- a/.github/scripts/tests/cleanup-openai-vector-store.test.sh
+++ b/.github/scripts/tests/cleanup-openai-vector-store.test.sh
@@ -87,6 +87,8 @@ expect_failure() {
 success_output=$(expect_success success)
 assert_contains "$success_output" "Verification attempt 1"
 assert_contains "$success_output" "Vector store contains only the current workflow-managed file and preserved non-workflow files"
+assert_file_exists "$TEST_ROOT/success/detached-file-tagged-old"
+assert_file_exists "$TEST_ROOT/success/detached-file-renamed-old"
 assert_file_exists "$TEST_ROOT/success/deleted-file-tagged-old"
 assert_file_exists "$TEST_ROOT/success/deleted-file-renamed-old"
 assert_file_missing "$TEST_ROOT/success/deleted-file-untagged-appsmith-docs"
@@ -100,6 +102,10 @@ echo "PASS: no-op cleanup"
 expect_failure delete-failure "Failed to delete stale file file-tagged-old"
 echo "PASS: unsuccessful deletion is rejected"
 
+expect_failure detach-failure "Failed to detach stale file file-tagged-old"
+assert_file_missing "$TEST_ROOT/detach-failure/deleted-file-tagged-old"
+echo "PASS: unsuccessful detach stops before file deletion"
+
 expect_failure repeated-cursor "repeated pagination cursor repeated-cursor"
 echo "PASS: repeated pagination cursor is rejected"
 
@@ -109,4 +115,4 @@ echo "PASS: pagination page limit is enforced"
 expect_failure invalid-list "Invalid vector store file discovery response"
 echo "PASS: malformed list response is rejected"
 
-echo "6 cleanup tests passed"
+echo "7 cleanup tests passed"

--- a/.github/scripts/tests/fixtures/curl
+++ b/.github/scripts/tests/fixtures/curl
@@ -112,7 +112,7 @@ if [[ "$url" == *"/vector_stores/test-vector-store/files?"* ]]; then
         last_id: "file-unrelated"
       }'
       ;;
-    delete-failure)
+    delete-failure|detach-failure)
       jq -n '{
         object: "list",
         data: [
@@ -155,10 +155,30 @@ if [[ "$url" == *"/vector_stores/test-vector-store/files?"* ]]; then
 elif [ "$method" = "GET" ] && [[ "$url" == *"/files/"* ]]; then
   echo "Unexpected metadata request: ${url##*/}" >&2
   exit 2
+elif [ "$method" = "DELETE" ] && [[ "$url" == *"/vector_stores/test-vector-store/files/"* ]]; then
+  file_id="${url##*/}"
+  case "$file_id" in
+    file-tagged-old|file-renamed-old)
+      if [ "$MOCK_SCENARIO" = "detach-failure" ]; then
+        jq -n --arg id "$file_id" '{id: $id, object: "vector_store.file.deleted", deleted: false}'
+      else
+        touch "$MOCK_STATE_DIR/detached-$file_id"
+        jq -n --arg id "$file_id" '{id: $id, object: "vector_store.file.deleted", deleted: true}'
+      fi
+      ;;
+    *)
+      echo "Unexpected detach: $file_id" >&2
+      exit 2
+      ;;
+  esac
 elif [ "$method" = "DELETE" ] && [[ "$url" == *"/files/"* ]]; then
   file_id="${url##*/}"
   case "$file_id" in
     file-tagged-old|file-renamed-old)
+      if [ ! -f "$MOCK_STATE_DIR/detached-$file_id" ]; then
+        echo "File $file_id deleted before being detached from the vector store" >&2
+        exit 2
+      fi
       if [ "$MOCK_SCENARIO" = "delete-failure" ] && [ "$file_id" = "file-tagged-old" ]; then
         jq -n --arg id "$file_id" '{id: $id, deleted: false}'
       else


### PR DESCRIPTION
## Summary

Fixes the "Upload Docs to OpenAI Vector Store" workflow failing in the "Remove stale workflow-managed files" step ([failed run](https://github.com/appsmithorg/appsmith-docs/actions/runs/33529572639/job/99928974488)).

The cleanup script deleted stale files through the Files API only (`DELETE /v1/files/{id}`). The vector store kept listing the deleted entry, so the verification loop exhausted all six attempts and the job exited 1.

## Changes

- `cleanup-openai-vector-store.sh`: detach each stale file from the vector store (`DELETE /v1/vector_stores/{vs}/files/{id}`) before deleting the file object. Log an explicit `ORPHANED FILE` warning if the file delete fails after a successful detach, since later runs cannot rediscover a file that is no longer attached.
- Test mock (`fixtures/curl`): add the detach route, an ordering guard that fails if a file is deleted before being detached, and a `detach-failure` scenario.
- Test suite: assert detach markers in the success scenario and add a detach-failure case that confirms the script stops before deleting the file object.

## Testing

```
bash .github/scripts/tests/cleanup-openai-vector-store.test.sh
7 cleanup tests passed
```

Shellcheck was not run locally (not installed).

## Known risk

If a run is killed between the detach and the file delete, the file object is orphaned in OpenAI storage and no later run will find it. Low severity, now surfaced in the log. A periodic sweep of `GET /v1/files` would be a follow-up if this ever matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
