### PR TITLE
docs: add Easypanel deployment guide

### DIFF
--- a/website/docs/getting-started/setup/README.md
+++ b/website/docs/getting-started/setup/README.md
@@ -23,6 +23,7 @@ You can follow one of the below guides to deploy Appsmith on the platform you pr
 - [Kubernetes](/getting-started/setup/installation-guides/kubernetes) (_High Availability and Scalability_)
 - [AWS AMI](/getting-started/setup/installation-guides/aws-ami)
 - [DigitalOcean](/getting-started/setup/installation-guides/digitalocean)
+- [Easypanel](/getting-started/setup/installation-guides/easypanel)
 
 While Appsmith is a dockerized application that works on other platforms, official support is limited to these configurations. For other environments, support is provided on a case-by-case basis. For more information about installation platforms, see all [installation guides](/getting-started/setup/installation-guides).
 

--- a/website/docs/getting-started/setup/installation-guides/README.md
+++ b/website/docs/getting-started/setup/installation-guides/README.md
@@ -139,4 +139,16 @@ Choose from the following guides to deploy Appsmith according to your business n
          Automate the deployment of Appsmith with Ansible, enabling consistent configurations across your infrastructure.
       </div>
    </a>
+
+   <a className="containerAnchor containerColumnSampleApp columnGrid column-two" href="/getting-started/setup/installation-guides/easypanel">
+      <div className="containerHead">
+         <div className="containerHeading">
+            <b>Easypanel</b>
+         </div>
+      </div>
+      <hr className="gradient-hr" />
+      <div className="containerDescription">
+         Deploy Appsmith with one click using Easypanel's official template, a server control panel that runs the Docker image for you.
+      </div>
+   </a>
 </div>

--- a/website/docs/getting-started/setup/installation-guides/easypanel.md
+++ b/website/docs/getting-started/setup/installation-guides/easypanel.md
@@ -1,0 +1,18 @@
+---
+description: Deploy Appsmith with one click using Easypanel's official template.
+---
+
+# Easypanel
+
+[Easypanel](https://easypanel.io/) is a server control panel that can deploy Appsmith with one click using its official template, without needing to manually run Docker commands.
+
+## Steps
+
+1. Open your Easypanel dashboard and create (or open) a project
+2. Click **+ Add Service** and choose **Templates**
+3. Search for **Appsmith** and select it
+4. Click **Create** to deploy the service
+
+Easypanel runs the official Appsmith Docker image (`appsmith/appsmith-ce`) for you and mounts a persistent volume for `/appsmith-stacks`.
+
+See the [official Appsmith template on Easypanel](https://easypanel.io/templates/appsmith) for more details.


### PR DESCRIPTION
Adds an Easypanel installation guide alongside the existing Docker/Kubernetes/AWS/DigitalOcean guides. Appsmith has an official one-click template on Easypanel (https://easypanel.io/templates/appsmith).